### PR TITLE
Fix transparency parameter and window size

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -13,6 +13,9 @@ from detectron2.utils.logger import setup_logger
 
 from predictor import VisualizationDemo
 
+# constants
+WINDOW_NAME = "COCO detections"
+
 
 def setup_cfg(args):
     # load config from file and command-line arguments
@@ -92,16 +95,16 @@ if __name__ == "__main__":
                     out_filename = args.output
                 visualized_output.save(out_filename)
             else:
-                cv2.namedWindow("COCO detections", cv2.WINDOW_NORMAL)
-                cv2.imshow("COCO detections", visualized_output.get_image()[:, :, ::-1])
+                cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
+                cv2.imshow(WINDOW_NAME, visualized_output.get_image()[:, :, ::-1])
                 if cv2.waitKey(0) == 27:
                     break  # esc to quit
     elif args.webcam:
         assert args.input is None, "Cannot have both --input and --webcam!"
         cam = cv2.VideoCapture(0)
         for vis in tqdm.tqdm(demo.run_on_video(cam)):
-            cv2.namedWindow("COCO detections", cv2.WINDOW_NORMAL)
-            cv2.imshow("COCO detections", vis)
+            cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
+            cv2.imshow(WINDOW_NAME, vis)
             if cv2.waitKey(1) == 27:
                 break  # esc to quit
         cv2.destroyAllWindows()

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -92,6 +92,7 @@ if __name__ == "__main__":
                     out_filename = args.output
                 visualized_output.save(out_filename)
             else:
+                cv2.namedWindow("COCO detections", cv2.WINDOW_NORMAL)
                 cv2.imshow("COCO detections", visualized_output.get_image()[:, :, ::-1])
                 if cv2.waitKey(0) == 27:
                     break  # esc to quit
@@ -99,6 +100,7 @@ if __name__ == "__main__":
         assert args.input is None, "Cannot have both --input and --webcam!"
         cam = cv2.VideoCapture(0)
         for vis in tqdm.tqdm(demo.run_on_video(cam)):
+            cv2.namedWindow("COCO detections", cv2.WINDOW_NORMAL)
             cv2.imshow("COCO detections", vis)
             if cv2.waitKey(1) == 27:
                 break  # esc to quit
@@ -132,6 +134,7 @@ if __name__ == "__main__":
             if args.output:
                 output_file.write(vis_frame)
             else:
+                cv2.namedWindow(basename, cv2.WINDOW_NORMAL)
                 cv2.imshow(basename, vis_frame)
                 if cv2.waitKey(1) == 27:
                     break  # esc to quit

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -447,7 +447,7 @@ class Visualizer:
             colors = [random_color(rgb=True, maximum=1) for k in category_ids]
         except AttributeError:
             colors = None
-        self.overlay_instances(masks=masks, labels=labels, assigned_colors=colors)
+        self.overlay_instances(masks=masks, labels=labels, assigned_colors=colors, alpha=alpha)
 
         return self.output
 


### PR DESCRIPTION
* Fixed missing alpha in instance masks of panoptic segmentation output
*(When changing alpha in demo/demo.py, the instance masks' alpha doesn't change otherwise)*
* Add namedWindow to handle the overlage window size