### PR TITLE
Add a check for args.input in demo/demo.py

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -75,6 +75,7 @@ if __name__ == "__main__":
     if args.input:
         if len(args.input) == 1:
             args.input = glob.glob(os.path.expanduser(args.input[0]))
+            assert args.input, "The input path(s) was not found"
         for path in tqdm.tqdm(args.input, disable=not args.output):
             # use PIL, to be consistent with evaluation
             img = read_image(path, format="BGR")


### PR DESCRIPTION
Because if the path can't be found/resolved and it's only one, `glob.glob` fails silently and the script also fails silently.