### PR TITLE
Fixed bug where predictions.pred_masks has no attribute numpy

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -337,7 +337,7 @@ class Visualizer:
         keypoints = predictions.pred_keypoints if predictions.has("pred_keypoints") else None
 
         if predictions.has("pred_masks"):
-            masks = predictions.pred_masks.numpy()
+            masks = np.asarray(predictions.pred_masks)
             masks = [GenericMask(x, self.output.height, self.output.width) for x in masks]
         else:
             masks = None


### PR DESCRIPTION
When testing the default `tools/visualise_json_results.py` code an AttributeError was raised on an Instances object. This was in the visualiser.py code where `.numpy()` was not an attribute of `predictions.pred_masks` since it was a list. 

This PR wraps the list in the `numpy.asarray` function.