### PR TITLE
Add Generic Dataset to COCO converter

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -408,7 +408,7 @@ def convert_to_coco_json(dataset_name, output_folder="", allow_cached=True):
     # TODO: The dataset or the conversion script *may* change,
     # a checksum would be useful for validating the cached data
     cache_path = os.path.join(output_folder, f"{dataset_name}_coco_format.json")
-    os.makedirs(output_folder, exist_ok=True)
+    PathManager.mkdirs(output_folder)
     if os.path.exists(cache_path) and allow_cached:
         logger.info(f"Reading cached annotations in COCO format from:{cache_path} ...")
     else:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -352,7 +352,6 @@ def convert_to_coco_dict(dataset_name):
                         # For COCO format consistency we substract 0.5
                         # https://github.com/facebookresearch/detectron2/pull/175#issuecomment-551202163
                         keypoints[idx] = v - 0.5
-                obj["keypoints"] = keypts
                 if "num_keypoints" in annotation:
                     num_keypoints = annotation["num_keypoints"]
                 else:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -381,6 +381,17 @@ def convert_to_coco_dict(dataset_name):
 
 
 def convert_to_coco_json(dataset_name, output_folder="", allow_cached=True):
+    """
+    Converts dataset into COCO format and saves it to a json file.
+
+    Args:
+        dataset_name: reference from the config file to the catalogs
+        output_folde: where json file will be saved and loaded from
+        allow_cached: if json file is already present then skip conversion
+    Returns:
+        cache_path: path to the COCO-format json file
+    """
+
     # TODO: The dataset or the conversion script *may* change,
     # a checksum would be useful for validating the cached data
     cache_path = os.path.join(output, f"{dataset_name}_coco_format.json")

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -292,7 +292,7 @@ def convert_to_coco_dict(dataset_name):
     Convert a generic dataset into COCO json format
 
     Generic dataset description can be found here:
-    https://github.com/facebookresearch/detectron2/blob/master/docs/tutorials/datasets.md#register-a-dataset
+    https://detectron2.readthedocs.io/tutorials/datasets.html#register-a-dataset
 
     COCO data format description can be found here:
     http://cocodataset.org/#format-data

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -344,7 +344,15 @@ def convert_to_coco_dict(dataset_name):
                 area = Boxes([bbox]).area()[0].item()
 
             if "keypoints" in annotation:
-                keypoints = annotation["keypoints"]
+                keypoints = annotation["keypoints"] # list[int]
+                for idx, v in enumerate(keypoints):
+                    if idx % 3 != 2:
+                        # COCO's segmentation coordinates are floating points in [0, H or W],
+                        # but keypoint coordinates are integers in [0, H-1 or W-1]
+                        # For COCO format consistency we substract 0.5
+                        # https://github.com/facebookresearch/detectron2/pull/175#issuecomment-551202163
+                        keypoints[idx] = v - 0.5
+                obj["keypoints"] = keypts
                 if "num_keypoints" in annotation:
                     num_keypoints = annotation["num_keypoints"]
                 else:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -365,7 +365,7 @@ def convert_to_coco_dict(dataset_name):
             # Add optional fields
             if "keypoints" in annotation:
                 coco_annotation["keypoints"] = keypoints
-                coco_annotation["num_keypoints"] = keypoints
+                coco_annotation["num_keypoints"] = num_keypoints
 
             if "segmentation" in annotation:
                 coco_annotation["segmentation"] = annotation["segmentation"]

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -8,7 +8,6 @@ import json
 import numpy as np
 
 from PIL import Image
-from copy import deepcopy
 
 from fvcore.common.timer import Timer
 from detectron2.structures import BoxMode, PolygonMasks, Boxes
@@ -433,7 +432,6 @@ if __name__ == "__main__":
         "dataset_name" can be "coco_2014_minival_100", or other
         pre-registered ones
     """
-    import numpy as np
     from detectron2.utils.logger import setup_logger
     from detectron2.utils.visualizer import Visualizer
     import detectron2.data.datasets  # noqa # add pre-defined metadata

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -334,11 +334,13 @@ def convert_to_coco_dict(dataset_name):
             annotation["id"] = len(annotations) + 1
             annotation["image_id"] = image_dict["image_id"]
 
-            # TODO: make BBOX_MODE serializable, otherwise remove it
+            # COCO requirement: XYWH box format
             bbox = annotation["bbox"]
             bbox_mode = annotation["bbox_mode"]
             bbox = BoxMode.convert(bbox, bbox_mode, BoxMode.XYWH_ABS)
             del annotation["bbox_mode"]
+            # TODO: make BBOX_MODE serializable, otherwise remove it
+            annotation["bbox"] = bbox
 
             # COCO requirement: instance area
             if "segmentation" in annotation:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -355,6 +355,8 @@ def convert_to_coco_dict(dataset_name):
             # Add optional fields
             if "keypoints" in annotation:
                 coco_annotation["keypoints"] = annotation["keypoints"]
+            if "num_keypoints" in annotation:
+                coco_annotation["num_keypoints"] = annotation["num_keypoints"]
             if "segmentation" in annotation:
                 coco_annotation["segmentation"] = annotation["segmentation"]
 

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from PIL import Image
 from copy import deepcopy
-from collections import Counter
 
 from fvcore.common.timer import Timer
 from detectron2.structures import BoxMode, PolygonMasks, Boxes
@@ -313,8 +312,6 @@ def convert_to_coco_dict(dataset_name):
     coco_images = []
     coco_annotations = []
 
-    # just for logging purposes
-    _annotation_keys = Counter()
     for image_dict in dataset_dicts:
         coco_image = {
             "id": image_dict["image_id"],

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -380,10 +380,10 @@ def convert_to_coco_dict(dataset_name):
     return coco_dict
 
 
-def convert_to_coco_json(dataset_name, allow_cached=True):
+def convert_to_coco_json(dataset_name, output_folder="", allow_cached=True):
     # TODO: The dataset or the conversion script *may* change,
     # a checksum would be useful for validating the cached data
-    cache_path = f"/tmp/{dataset_name}_coco_format.json"
+    cache_path = os.path.join(output, f"{dataset_name}_coco_format.json")
     if os.path.exists(cache_path) and allow_cached:
         logger.warning(f"Reading cached annotations in COCO format from:{cache_path}")
     else:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -345,7 +345,6 @@ def convert_to_coco_dict(dataset_name):
                 area = Boxes([bbox]).area()[0].item()
 
             if "keypoints" in annotation:
-                import pdb; pdb.set_trace()
                 keypoints = annotation["keypoints"]
                 if "num_keypoints" in annotation:
                     num_keypoints = annotation["num_keypoints"]

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -18,6 +18,7 @@ from tabulate import tabulate
 
 import detectron2.utils.comm as comm
 from detectron2.data import MetadataCatalog
+from detectron2.data.datasets.coco import convert_to_coco_json
 from detectron2.structures import Boxes, BoxMode, pairwise_iou
 from detectron2.utils.logger import create_small_table
 
@@ -49,6 +50,12 @@ class COCOEvaluator(DatasetEvaluator):
         self._logger = logging.getLogger(__name__)
 
         self._metadata = MetadataCatalog.get(dataset_name)
+        if not hasattr(self._metadata, "json_file"):
+            self._logger.warning(f"json_file was not found in MetaDataCatalog for [{dataset_name}]")
+
+            cache_path = convert_to_coco_json(dataset_name)
+            self._metadata.json_file = cache_path
+
         json_file = PathManager.get_local_path(self._metadata.json_file)
         with contextlib.redirect_stdout(io.StringIO()):
             self._coco_api = COCO(json_file)

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -55,7 +55,7 @@ class COCOEvaluator(DatasetEvaluator):
 
         PathManager.mkdirs(output_dir)
         if not hasattr(self._metadata, "json_file"):
-            self._logger.warning(f"json_file was not found in MetaDataCatalog for [{dataset_name}]")
+            self._logger.warning(f"json_file was not found in MetaDataCatalog for '{dataset_name}'")
 
             cache_path = convert_to_coco_json(dataset_name, output_dir)
             self._metadata.json_file = cache_path

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -52,8 +52,6 @@ class COCOEvaluator(DatasetEvaluator):
         self._logger = logging.getLogger(__name__)
 
         self._metadata = MetadataCatalog.get(dataset_name)
-
-        PathManager.mkdirs(output_dir)
         if not hasattr(self._metadata, "json_file"):
             self._logger.warning(f"json_file was not found in MetaDataCatalog for '{dataset_name}'")
 

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -35,8 +35,10 @@ class COCOEvaluator(DatasetEvaluator):
         """
         Args:
             dataset_name (str): name of the dataset to be evaluated.
-                It must have the following corresponding metadata:
+                It must have either the following corresponding metadata:
                     "json_file": the path to the COCO format annotation
+                Or it must be in detectron2's standard dataset format
+                    so it can be converted to COCO format automatically.
             cfg (CfgNode): config instance
             distributed (True): if True, will collect results from all ranks for evaluation.
                 Otherwise, will evaluate the results in the current process.
@@ -58,6 +60,7 @@ class COCOEvaluator(DatasetEvaluator):
             cache_path = convert_to_coco_json(dataset_name, output_dir)
             self._metadata.json_file = cache_path
 
+        # TODO: json_file should be renamed to json_path
         json_file = PathManager.get_local_path(self._metadata.json_file)
         with contextlib.redirect_stdout(io.StringIO()):
             self._coco_api = COCO(json_file)

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -53,7 +53,7 @@ class COCOEvaluator(DatasetEvaluator):
         if not hasattr(self._metadata, "json_file"):
             self._logger.warning(f"json_file was not found in MetaDataCatalog for [{dataset_name}]")
 
-            cache_path = convert_to_coco_json(dataset_name)
+            cache_path = convert_to_coco_json(dataset_name, output_dir)
             self._metadata.json_file = cache_path
 
         json_file = PathManager.get_local_path(self._metadata.json_file)

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -60,7 +60,6 @@ class COCOEvaluator(DatasetEvaluator):
             cache_path = convert_to_coco_json(dataset_name, output_dir)
             self._metadata.json_file = cache_path
 
-        # TODO: json_file should be renamed to json_path
         json_file = PathManager.get_local_path(self._metadata.json_file)
         with contextlib.redirect_stdout(io.StringIO()):
             self._coco_api = COCO(json_file)

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -50,6 +50,8 @@ class COCOEvaluator(DatasetEvaluator):
         self._logger = logging.getLogger(__name__)
 
         self._metadata = MetadataCatalog.get(dataset_name)
+
+        PathManager.mkdirs(output_dir)
         if not hasattr(self._metadata, "json_file"):
             self._logger.warning(f"json_file was not found in MetaDataCatalog for [{dataset_name}]")
 

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -351,6 +351,12 @@ class PolygonMasks:
         return torch.stack(results, dim=0).to(device=device)
 
     def area(self):
+        """
+        Computes area of the mask.
+        Only works with Polygons, using the shoelace formula:
+        # https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
+        """
+
         area = []
         for polygons_per_instance in self.polygons:
             area_per_instance = 0

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -10,6 +10,12 @@ from detectron2.layers.roi_align import ROIAlign
 from .boxes import Boxes
 
 
+def polygon_area(x, y):
+    # Using the shoelace formula
+    # https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
+    return 0.5 * np.abs(np.dot(x, np.roll(y, 1)) - np.dot(y, np.roll(x, 1)))
+
+
 def polygons_to_bitmask(polygons: List[np.ndarray], height: int, width: int) -> np.ndarray:
     """
     Args:
@@ -343,3 +349,12 @@ class PolygonMasks:
         if len(results) == 0:
             return torch.empty(0, mask_size, mask_size, dtype=torch.bool, device=device)
         return torch.stack(results, dim=0).to(device=device)
+
+    def area(self):
+        area = []
+        for polygons_per_instance in self.polygons:
+            area_per_instance = 0
+            for p in polygons_per_instance:
+                area_per_instance += polygon_area(p[0::2], p[1::2])
+            area.append(area_per_instance)
+        return area

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -354,7 +354,7 @@ class PolygonMasks:
         """
         Computes area of the mask.
         Only works with Polygons, using the shoelace formula:
-        # https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
+        https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
 
         Returns:
             Tensor: a vector, area for each instance

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -363,4 +363,7 @@ class PolygonMasks:
             for p in polygons_per_instance:
                 area_per_instance += polygon_area(p[0::2], p[1::2])
             area.append(area_per_instance)
-        return area
+
+        # TODO: rewrite the helper function in torch when the PolygonMasks are
+        # rewritten to use torch
+        return torch.tensor(area)

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -355,6 +355,9 @@ class PolygonMasks:
         Computes area of the mask.
         Only works with Polygons, using the shoelace formula:
         # https://stackoverflow.com/questions/24467972/calculate-area-of-polygon-given-x-y-coordinates
+
+        Returns:
+            Tensor: a vector, area for each instance
         """
 
         area = []

--- a/detectron2/structures/masks.py
+++ b/detectron2/structures/masks.py
@@ -367,6 +367,4 @@ class PolygonMasks:
                 area_per_instance += polygon_area(p[0::2], p[1::2])
             area.append(area_per_instance)
 
-        # TODO: rewrite the helper function in torch when the PolygonMasks are
-        # rewritten to use torch
         return torch.tensor(area)

--- a/tests/test_mask_ops.py
+++ b/tests/test_mask_ops.py
@@ -136,6 +136,21 @@ class TestMaskCropPaste(unittest.TestCase):
                 table.append((rasterize_method, paste_method, iou))
         return table
 
+    def test_polygon_area(self):
+        # Draw polygon boxes
+        for d in [5.0, 10.0, 1000.0]:
+            polygon = PolygonMasks([[[0, 0, 0, d, d, d, d, 0]]])
+            area = polygon.area()[0]
+            target = d ** 2
+            self.assertEqual(area, target)
+
+        # Draw polygon triangles
+        for d in [5.0, 10.0, 1000.0]:
+            polygon = PolygonMasks([[[0, 0, 0, d, d, d]]])
+            area = polygon.area()[0]
+            target = d ** 2 / 2
+            self.assertEqual(area, target)
+
 
 def benchmark_paste():
     S = 800


### PR DESCRIPTION
# Add Generic Dataset to COCO converter

Related issue #99, solution based on @ppwwyyxx's comment [here](https://github.com/facebookresearch/detectron2/issues/99#issuecomment-542950935).

Main purpose is to allow COCO evaluation for custom datasets by providing a converter tool that formats the target annotations into [COCO-format](http://cocodataset.org/#format-data).
### Notes:
- The dataset needs to be registered in the `MetadataCatalog` and `DatasetCatalog`
- The instances must have `bbox` and `bbox_mode` fields (COCO uses XYWH)
- If annotations have `segmentation` field, they must be in polygon format. The segmentation mask will be used for computing the area.
- If annotations do not have `segmentation` field, the bbox will be used for area.

#### Results:
Evaluated the [pretrained cityscapes model](https://dl.fbaipublicfiles.com/detectron2/Cityscapes/mask_rcnn_R_50_FPN/142423278/model_final_af9cf5.pkl) from the MODEL_ZOO.md using the provided [config file](https://github.com/facebookresearch/detectron2/blob/master/configs/Cityscapes/mask_rcnn_R_50_FPN.yaml) by modifying the [`tools/train_net.py`](https://github.com/facebookresearch/detectron2/blob/master/tools/train_net.py#L79) script to use `COCOEvaluator` instead of `CityscapesEvaluator`.

Take a look at class specific mAP scores, the differences can be substantial.

CityScapes validation set using <b>CityScapes evaluation = 36.4809 mAP</b>
```
[10/26 11:16:39 d2.evaluation.evaluator]: Start inference on 500 images
[10/26 11:16:39 d2.evaluation.cityscapes_evaluation]: Writing cityscapes results to temporary directory /tmp/cityscapes_eval_oaexjo1z ...
[10/26 11:16:51 d2.evaluation.evaluator]: Inference done 50/500. 0.2316 s / img. ETA=0:01:44
[10/26 11:17:13 d2.evaluation.evaluator]: Inference done 100/500. 0.3355 s / img. ETA=0:02:14
[10/26 11:17:36 d2.evaluation.evaluator]: Inference done 150/500. 0.3794 s / img. ETA=0:02:12
[10/26 11:18:00 d2.evaluation.evaluator]: Inference done 200/500. 0.4070 s / img. ETA=0:02:02
[10/26 11:18:25 d2.evaluation.evaluator]: Inference done 250/500. 0.4238 s / img. ETA=0:01:45
[10/26 11:18:49 d2.evaluation.evaluator]: Inference done 300/500. 0.4338 s / img. ETA=0:01:26
[10/26 11:19:13 d2.evaluation.evaluator]: Inference done 350/500. 0.4404 s / img. ETA=0:01:06
[10/26 11:19:39 d2.evaluation.evaluator]: Inference done 400/500. 0.4517 s / img. ETA=0:00:45
[10/26 11:20:04 d2.evaluation.evaluator]: Inference done 450/500. 0.4566 s / img. ETA=0:00:22
[10/26 11:20:28 d2.evaluation.evaluator]: Inference done 500/500. 0.4593 s / img. ETA=0:00:00
[10/26 11:20:28 d2.evaluation.evaluator]: Total inference time: 0:03:47 (0.458586 s / img per device, on 1 devices)
[10/26 11:20:28 d2.evaluation.evaluator]: Total inference pure compute time: 0:01:10 (0.142812 s / img per device, on 1 devices)
[10/26 11:20:28 d2.evaluation.cityscapes_evaluation]: Evaluating results under /tmp/cityscapes_eval_oaexjo1z ...
Creating ground truth instances from png files.
Processing 500 images...
Images Processed: 500 
Matching 500 pairs of images...
Images Processed: 500 

##################################################
what           :             AP         AP_50%
##################################################
person         :          0.350          0.677
rider          :          0.288          0.697
car            :          0.530          0.779
truck          :          0.343          0.472
bus            :          0.570          0.753
train          :          0.375          0.569
motorcycle     :          0.223          0.461
bicycle        :          0.238          0.570
--------------------------------------------------
average        :          0.365          0.622

[10/26 11:25:23 d2.engine.defaults]: Evaluation results for cityscapes_fine_instance_seg_val in csv format:
[10/26 11:25:23 d2.evaluation.testing]: copypaste: Task: segm
[10/26 11:25:23 d2.evaluation.testing]: copypaste: AP,AP50
[10/26 11:25:23 d2.evaluation.testing]: copypaste: 36.4809,62.2190
```


#### CityScapes validation set using <b>COCO evaluation = 36.2857 mAP</b>
```
WARNING [10/26 11:03:05 d2.evaluation.coco_evaluation]: json_file was not found in MetaDataCatalog for [cityscapes_fine_instance_seg_val]
[10/26 11:03:05 d2.data.datasets.coco]: Fetching dataset annotations
[10/26 11:03:05 d2.data.datasets.coco]: Converting dataset dicts into COCO format
[10/26 11:03:07 d2.data.datasets.coco]: Conversion finished, num images: 500, num annotations: 10655
[10/26 11:03:07 d2.data.datasets.coco]: Annotation fields: Counter({'iscrowd': 10655, 'category_id': 10655, 'segmentation': 10655, 'bbox': 10655, 'id': 10655, 'image_id': 10655, 'area': 10655})
[10/26 11:03:07 d2.data.datasets.coco]: Caching annotations in COCO format: /tmp/cityscapes_fine_instance_seg_val_coco_format.json
[10/26 11:03:08 d2.evaluation.evaluator]: Start inference on 500 images
[10/26 11:03:20 d2.evaluation.evaluator]: Inference done 50/500. 0.2094 s / img. ETA=0:01:34
[10/26 11:03:38 d2.evaluation.evaluator]: Inference done 100/500. 0.2906 s / img. ETA=0:01:56
[10/26 11:03:57 d2.evaluation.evaluator]: Inference done 150/500. 0.3252 s / img. ETA=0:01:53
[10/26 11:04:18 d2.evaluation.evaluator]: Inference done 200/500. 0.3470 s / img. ETA=0:01:44
[10/26 11:04:38 d2.evaluation.evaluator]: Inference done 250/500. 0.3599 s / img. ETA=0:01:29
[10/26 11:04:58 d2.evaluation.evaluator]: Inference done 300/500. 0.3668 s / img. ETA=0:01:13
[10/26 11:05:18 d2.evaluation.evaluator]: Inference done 350/500. 0.3712 s / img. ETA=0:00:55
[10/26 11:05:40 d2.evaluation.evaluator]: Inference done 400/500. 0.3793 s / img. ETA=0:00:37
[10/26 11:06:00 d2.evaluation.evaluator]: Inference done 450/500. 0.3828 s / img. ETA=0:00:19
[10/26 11:06:20 d2.evaluation.evaluator]: Inference done 500/500. 0.3843 s / img. ETA=0:00:00
[10/26 11:06:20 d2.evaluation.evaluator]: Total inference time: 0:03:10 (0.383838 s / img per device, on 1 devices)
[10/26 11:06:20 d2.evaluation.evaluator]: Total inference pure compute time: 0:01:11 (0.144153 s / img per device, on 1 devices)
[10/26 11:06:21 d2.evaluation.coco_evaluation]: Preparing results for COCO format ...
[10/26 11:06:21 d2.evaluation.coco_evaluation]: Saving results to runs/cityscapes-pretrained-COCO-eval/inference/coco_instances_results.json
[10/26 11:06:21 d2.evaluation.coco_evaluation]: Evaluating predictions ...
Loading and preparing results...
DONE (t=0.01s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *bbox*
DONE (t=3.93s).
Accumulating evaluation results...
DONE (t=0.22s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.414
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.654
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.434
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.176
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.409
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.617
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.268
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.457
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.484
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.216
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.483
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.714
[10/26 11:06:25 d2.evaluation.coco_evaluation]: Evaluation results for bbox: 
|   AP   |  AP50  |  AP75  |  APs   |  APm   |  APl   |
|:------:|:------:|:------:|:------:|:------:|:------:|
| 41.354 | 65.448 | 43.383 | 17.634 | 40.881 | 61.721 |
[10/26 11:06:25 d2.evaluation.coco_evaluation]: Per-category bbox AP: 
| category   | AP     | category   | AP     | category   | AP     |
|:-----------|:-------|:-----------|:-------|:-----------|:-------|
| person     | 41.451 | rider      | 43.958 | car        | 58.137 |
| truck      | 34.661 | bus        | 60.029 | train      | 28.731 |
| motorcycle | 28.660 | bicycle    | 35.208 |            |        |
Loading and preparing results...
DONE (t=0.10s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *segm*
DONE (t=4.46s).
Accumulating evaluation results...
DONE (t=0.22s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.363
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.611
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.367
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.095
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.327
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.595
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.251
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.406
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.426
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.154
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.406
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.662
[10/26 11:06:30 d2.evaluation.coco_evaluation]: Evaluation results for segm: 
|   AP   |  AP50  |  AP75  |  APs  |  APm   |  APl   |
|:------:|:------:|:------:|:-----:|:------:|:------:|
| 36.286 | 61.128 | 36.737 | 9.542 | 32.674 | 59.500 |
[10/26 11:06:30 d2.evaluation.coco_evaluation]: Per-category segm AP: 
| category   | AP     | category   | AP     | category   | AP     |
|:-----------|:-------|:-----------|:-------|:-----------|:-------|
| person     | 33.715 | rider      | 28.496 | car        | 51.762 |
| truck      | 34.899 | bus        | 57.147 | train      | 38.189 |
| motorcycle | 22.842 | bicycle    | 23.236 |            |        |
[10/26 11:06:30 d2.engine.defaults]: Evaluation results for cityscapes_fine_instance_seg_val in csv format:
[10/26 11:06:30 d2.evaluation.testing]: copypaste: Task: bbox
[10/26 11:06:30 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[10/26 11:06:30 d2.evaluation.testing]: copypaste: 41.3545,65.4483,43.3829,17.6341,40.8814,61.7215
[10/26 11:06:30 d2.evaluation.testing]: copypaste: Task: segm
[10/26 11:06:30 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[10/26 11:06:30 d2.evaluation.testing]: copypaste: 36.2857,61.1284,36.7366,9.5421,32.6742,59.4999
```