### PR TITLE
Fix a bug not ignoring the IGNORE_VALUE label when visualizing semantic annotation dataset

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -35,7 +35,7 @@ Install panopticapi by:
 ```
 pip install git+https://github.com/cocodataset/panopticapi.git
 ```
-Then, run `./prepare_panoptic_fpn.py`, to extract semantic annotations from panoptic annotations.
+Then, run `python prepare_panoptic_fpn.py`, to extract semantic annotations from panoptic annotations.
 
 ## Expected dataset structure for LVIS instance segmentation:
 ```

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -463,14 +463,12 @@ class Visualizer:
 
         return self.output
 
-    def draw_dataset_dict(self, dic, ignore_label=255):
+    def draw_dataset_dict(self, dic):
         """
         Draw semantic segmentation predictions/labels.
 
         Args:
             dic (dict): Metadata of one image, in Detectron2 Dataset format.
-            ignore_label (int): value in semantic segmentation ground truth. The corresponding
-                pixels are not drawn.
 
         Returns:
             output (VisImage): image object with visualizations.
@@ -503,7 +501,6 @@ class Visualizer:
         if sem_seg is None and "sem_seg_file_name" in dic:
             sem_seg = cv2.imread(dic["sem_seg_file_name"], cv2.IMREAD_GRAYSCALE)
         if sem_seg is not None:
-            sem_seg[sem_seg == ignore_label] = len(self.metadata.stuff_classes)
             self.draw_sem_seg(sem_seg, area_threshold=0, alpha=0.5)
         return self.output
 

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -465,10 +465,10 @@ class Visualizer:
 
     def draw_dataset_dict(self, dic):
         """
-        Draw semantic segmentation predictions/labels.
+        Draw annotations/segmentaions in Detectron2 Dataset format.
 
         Args:
-            dic (dict): Metadata of one image, in Detectron2 Dataset format.
+            dic (dict): annotation/segmentation data of one image, in Detectron2 Dataset format.
 
         Returns:
             output (VisImage): image object with visualizations.

--- a/tools/visualize_data.py
+++ b/tools/visualize_data.py
@@ -92,6 +92,5 @@ if __name__ == "__main__":
         for dic in dicts:
             img = utils.read_image(dic["file_name"], "RGB")
             visualizer = Visualizer(img, metadata=metadata, scale=scale)
-            vis = visualizer.draw_dataset_dict(
-                dic, ignore_label=cfg.MODEL.SEM_SEG_HEAD.IGNORE_VALUE)
+            vis = visualizer.draw_dataset_dict(dic)
             output(vis, os.path.basename(dic["file_name"]))

--- a/tools/visualize_data.py
+++ b/tools/visualize_data.py
@@ -92,5 +92,6 @@ if __name__ == "__main__":
         for dic in dicts:
             img = utils.read_image(dic["file_name"], "RGB")
             visualizer = Visualizer(img, metadata=metadata, scale=scale)
-            vis = visualizer.draw_dataset_dict(dic)
+            vis = visualizer.draw_dataset_dict(
+                dic, ignore_label=cfg.MODEL.SEM_SEG_HEAD.IGNORE_VALUE)
             output(vis, os.path.basename(dic["file_name"]))


### PR DESCRIPTION
An IndexError occurred when visualizing the semantic annotations (stuffs) via:
`python tools/visualize_data.py --source annotation --config-file configs/Misc/semantic_R_50_FPN_1x.yaml --show`

It is due to a bug not respecting `cfg.MODEL.SEM_SEG_HEAD.IGNORE_VALUE` in draw_dataset_dict.