### PR TITLE
setup.py : missing fvcore

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,6 @@ also installs detectron2 with a few simple commands.
 - [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
 	You can install them together at [pytorch.org](https://pytorch.org) to make sure of this.
 - OpenCV, needed by demo and visualization
-- [fvcore](https://github.com/facebookresearch/fvcore/): `pip install 'git+https://github.com/facebookresearch/fvcore'`
 - pycocotools: `pip install cython; pip install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'`
 - GCC >= 4.9
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "matplotlib",
         "tqdm>4.29.0",
         "tensorboard",
+        "fvcore @ git+https://github.com/facebookresearch/fvcore.git"
     ],
     extras_require={"all": ["shapely", "psutil"]},
     ext_modules=get_extensions(),


### PR DESCRIPTION
I was missing fvcore (provided by FAIR)  when pip installing detectron2.
