### PR TITLE
setup.py missing pycocotools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
         "matplotlib",
         "tqdm>4.29.0",
         "tensorboard",
-        "pycocotools"
+        "cython",
+        "pycocotools @ git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
     ],
     extras_require={"all": ["shapely", "psutil"]},
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "matplotlib",
         "tqdm>4.29.0",
         "tensorboard",
+        "pycocotools"
     ],
     extras_require={"all": ["shapely", "psutil"]},
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,9 @@ setup(
     "platform for object detection and segmentation.",
     packages=find_packages(exclude=("configs", "tests")),
     python_requires=">=3.6",
+    setup_requires=[
+        "cython"
+    ],
     install_requires=[
         "termcolor>=1.1",
         "Pillow",


### PR DESCRIPTION
When testing the demo script with : 

> python3 demo/demo.py --config-file configs/COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml  --input sample.jpg --opts MODEL.WEIGHTS detectron2://COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x/137849600/model_final_f10217.pkl

it was complaining pycocotools was missing. 

I propose to add to the setup.py script