### PR TITLE
Clarify building on Windows 10 is not supported

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,8 @@ also installs detectron2 with a few simple commands.
 - pycocotools: `pip install cython; pip install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'`
 - GCC >= 4.9
 
+Please note that building on Windows 10 is not supported.
+
 
 ### Build detectron2
 


### PR DESCRIPTION
After spending the past 6 hours trying to get detectron2 to run on Windows 10 with zero success, including repeated (re-)installs of CUDA, Visual Studio 2019, Pytorch and Torchvision, etc, only to find that Windows 10 is not supported, I am proposing amending INSTALL.md to explicitly clarify this.

I have followed various Github pull requests and community suggestions, only to encounter errors upon more errors. Some of these instructions include hand modifications of pytorch libraries, which I have performed without fixing the error. In addition, after this hand modification, my copy of Anaconda is now corrupt and basic `conda` operations are now throwing errors.

As someone more familiar with tensorflow who has not had any issues with Windows, the past 6 hours wasn't very productive. I appreciate that you are sharing your code for free with the community, however, a heads up that this is not supported and does not build on Windows 10 would very appreciated.