### PR TITLE
hotfix-file saving for uppercase image formats, i.e. JPG and PNG.

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -252,7 +252,7 @@ class VisImage:
             filepath (str): a string that contains the absolute path, including the file name, where
                 the visualized image will be saved.
         """
-        if filepath.endswith(".jpg") or filepath.endswith(".png"):
+        if filepath.lower().endswith(".jpg") or filepath.lower().endswith(".png"):
             # faster than matplotlib's imshow
             cv2.imwrite(filepath, self.get_image()[:, :, ::-1])
         else:


### PR DESCRIPTION
Thank you for your code. This PR is a minor fix to the upper letter format issue.

Saving the visualized files with '**JPG**' format (upper letters) will result in:

> Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers).

although the image range is between [0-255] and in uint8 format. 

The current code uses cv2 to save for '**_png_**' and '**_jpg_**' format but it won't check for any uppercase file formats. For example, if it is '**JPG**' it will not consider it 'jpg' and won't use cv2. A small fix using lower() function will fix this issue.

I'm not sure if there are any other hardcoded formats inside of the code in other parts, but if there is a comparison, we should consider upper and lower strings. 
