### PR TITLE
Fix area calculation error in convert_to_coco_dict

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -331,7 +331,8 @@ def convert_to_coco_dict(dataset_name):
                 area = polygons.area()[0].item()
             else:
                 # Computing areas using bounding boxes
-                area = Boxes([bbox]).area()[0].item()
+                bbox_xy = BoxMode.convert(bbox, bbox_mode, BoxMode.XYXY_ABS)
+                area = Boxes([bbox_xy]).area()[0].item()
 
             if "keypoints" in annotation:
                 keypoints = annotation["keypoints"]  # list[int]

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -331,7 +331,7 @@ def convert_to_coco_dict(dataset_name):
                 area = polygons.area()[0].item()
             else:
                 # Computing areas using bounding boxes
-                bbox_xy = BoxMode.convert(bbox, bbox_mode, BoxMode.XYXY_ABS)
+                bbox_xy = BoxMode.convert(bbox, BoxMode.XYWH_ABS, BoxMode.XYXY_ABS)
                 area = Boxes([bbox_xy]).area()[0].item()
 
             if "keypoints" in annotation:


### PR DESCRIPTION
Fixes: #349  

The constructor of `Boxes`  needs the bbox in `BoxMode.XYXY_ABS` mode.
This error will cause incorrect area calculation in `convert_to_coco_dict`.   
I added a line converting the original bbox to XYXY_ABS before constructing `Boxes`.  
