### PR TITLE
catch and ignore potential exif transpose bug

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -45,8 +45,12 @@ def read_image(file_name, format=None):
     """
     with PathManager.open(file_name, "rb") as f:
         image = Image.open(f)
-
-        image = ImageOps.exif_transpose(image)
+        
+        # capture and ignore this bug: https://github.com/python-pillow/Pillow/issues/3973
+        try:
+            image = ImageOps.exif_transpose(image)
+        except:
+            pass
 
         if format is not None:
             # PIL only supports RGB, so convert to RGB and flip channels over below


### PR DESCRIPTION
There is a bug in Pillow not yet fixed when exif-transposing images: 

https://github.com/python-pillow/Pillow/issues/3973

and this can crash the whole training, this PR is to catch the bug and ignore and use the image as is

I believe that if the exif data was valuable for the user, he will check before hand that they are correct, so this PR should not impact anything meaniningfull 

error to be fixed: 

```
Original Traceback (most recent call last):
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/torch/utils/data/_utils/worker.py", line 178, in _worker_loop
    data = fetcher.fetch(index)
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/detectron2/data/common.py", line 39, in __getitem__
    data = self._map_func(self._dataset[cur_idx])
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/detectron2/data/dataset_mapper.py", line 74, in __call__
    image = utils.read_image(dataset_dict["file_name"], format=self.img_format)
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/detectron2/data/detection_utils.py", line 49, in read_image
    image = ImageOps.exif_transpose(image)
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/PIL/ImageOps.py", line 549, in exif_transpose
    transposed_image.info["exif"] = exif.tobytes()
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/PIL/Image.py", line 3213, in tobytes
    return b"Exif\x00\x00" + head + ifd.tobytes(offset)
  File "/miniconda/envs/sterblue/lib/python3.7/site-packages/PIL/TiffImagePlugin.py", line 837, in tobytes
    count = len(data)
TypeError: object of type 'int' has no len()
```
