### PR TITLE
Updated git clone line in install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ also installs detectron2 with a few simple commands.
 
 After having the above dependencies, run:
 ```
-git clone git@github.com:facebookresearch/detectron2.git
+git clone https://github.com/facebookresearch/detectron2.git
 cd detectron2
 python setup.py build develop
 


### PR DESCRIPTION
Get the following when I run `git clone git@github.com:facebookresearch/detectron2.git`. Replaced line with `git clone https://github.com/facebookresearch/detectron2.git`.

```bash
git clone git@github.com:facebookresearch/detectron2.git
Cloning into 'detectron2'...
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.253.113' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```