### PR TITLE
Save the planet by not reading images for size

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -6,6 +6,7 @@ import os
 import datetime
 import json
 import numpy as np
+import imagesize
 
 from PIL import Image
 
@@ -262,12 +263,10 @@ def load_sem_seg(gt_root, image_root, gt_ext="png", image_ext="jpg"):
 
     dataset_dicts = []
     for (img_path, gt_path) in zip(input_files, gt_files):
+        w, h = imagesize.get(gt_path)
         record = {}
         record["file_name"] = img_path
         record["sem_seg_file_name"] = gt_path
-        with PathManager.open(gt_path, "rb") as f:
-            img = Image.open(f)
-            w, h = img.size
         record["height"] = h
         record["width"] = w
         dataset_dicts.append(record)

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -263,7 +263,8 @@ def load_sem_seg(gt_root, image_root, gt_ext="png", image_ext="jpg"):
 
     dataset_dicts = []
     for (img_path, gt_path) in zip(input_files, gt_files):
-        w, h = imagesize.get(gt_path)
+        local_path = PathManager.get_local_path(gt_path)
+        w, h = imagesize.get(local_path)
         record = {}
         record["file_name"] = img_path
         record["sem_seg_file_name"] = gt_path

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "matplotlib",
         "tqdm>4.29.0",
         "tensorboard",
+        "imagesize",
     ],
     extras_require={"all": ["shapely", "psutil"]},
     ext_modules=get_extensions(),


### PR DESCRIPTION
```
In [7]: %timeit Image.open("datasets/coco/train2017/000000000009.jpg").size                           
34.9 µs ± 59.6 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [8]: %timeit imagesize.get("datasets/coco/train2017/000000000009.jpg")                             
9.43 µs ± 64.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

https://images.app.goo.gl/Msptv7xcCVsXJ5zh8
