### PR TITLE
Cross dataset category-id wrapper

### DIFF
--- a/configs/Misc/wrapper-test/cityscapes-on-coco.yaml
+++ b/configs/Misc/wrapper-test/cityscapes-on-coco.yaml
@@ -1,0 +1,5 @@
+_BASE_: "../../Cityscapes/mask_rcnn_R_50_FPN.yaml"
+MODEL:
+  WEIGHTS: "detectron2://Cityscapes/mask_rcnn_R_50_FPN/142423278/model_final_af9cf5.pkl"
+DATASETS:
+  TEST: ("coco_2014_minival_100@cityscapes_fine_instance_seg_val",)

--- a/configs/Misc/wrapper-test/coco-on-cityscapes.yaml
+++ b/configs/Misc/wrapper-test/coco-on-cityscapes.yaml
@@ -1,0 +1,5 @@
+_BASE_: "../../COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"
+MODEL:
+  WEIGHTS: "detectron2://COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x/137849600/model_final_f10217.pkl"
+DATASETS:
+  TEST: ("cityscapes_fine_instance_seg_val@coco_2014_minival_100",)

--- a/detectron2/data/catalog.py
+++ b/detectron2/data/catalog.py
@@ -54,6 +54,11 @@ class DatasetCatalog(object):
         try:
             f = DatasetCatalog._REGISTERED[name]
         except KeyError:
+            if "@" in name:
+                from detectron2.data.datasets.wrap import register_wrapper
+                source_dataset_name, target_dataset_name = name.split("@")
+                register_wrapper(source_dataset_name, target_dataset_name)
+                return DatasetCatalog._REGISTERED[name]()
             raise KeyError(
                 "Dataset '{}' is not registered! Available datasets are: {}".format(
                     name, ", ".join(DatasetCatalog._REGISTERED.keys())

--- a/detectron2/data/catalog.py
+++ b/detectron2/data/catalog.py
@@ -56,6 +56,7 @@ class DatasetCatalog(object):
         except KeyError:
             if "@" in name:
                 from detectron2.data.datasets.wrap import register_wrapper
+
                 source_dataset_name, target_dataset_name = name.split("@")
                 register_wrapper(source_dataset_name, target_dataset_name)
                 return DatasetCatalog._REGISTERED[name]()

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -343,7 +343,7 @@ def convert_to_coco_dict(dataset_name):
                     # BinaryMask
                     raise RuntimeError(
                         "segmentation could not be interpreted as RLE or Polygon ",
-                        "BinaryMask in dataset dicts are deprecated."
+                        "BinaryMask in dataset dicts are deprecated.",
                     )
             else:
                 # Computing areas using bounding boxes

--- a/detectron2/data/datasets/wrap.py
+++ b/detectron2/data/datasets/wrap.py
@@ -33,24 +33,28 @@ def wrap_dataset_dicts(dataset_dicts, idS_to_idT, drop_empty=True):
             # mappings will have None values as category ids and have to be
             # handled by the User.
             wrapped_category_id = idS_to_idT.get(obj["category_id"], None)
+            obj["category_id"] = wrapped_category_id
             if wrapped_category_id is not None or not drop_empty:
-                wrapped_objects.append(wrapped_category_id)
+                wrapped_objects.append(obj)
 
         d["annotations"] = wrapped_objects
 
 
-def register_wrapper(source_dataset_name, target_dataset_name, default="unlabeled"):
+def register_wrapper(source_dataset_name, target_dataset_name):
     wrap_name = f"{source_dataset_name}@{target_dataset_name}"
-    DatasetCatalog.register(
-        wrap_name,
-        lambda: load_wrapped_dataset(source_dataset_name, target_dataset_name)
-    )
 
-    # Copy all metadata from source
-    source_metadata_dict = MetadataCatalog.get(source_dataset_name).as_dict()
-    source_metadata_dict.pop("name", None)
-    source_metadata_dict.pop("thing_classes", None)
-    MetadataCatalog.get(wrap_name).set(**source_metadata_dict)
+    # Copy metadata from source
+    wrapped_metadata_dict = MetadataCatalog.get(source_dataset_name).as_dict()
+    wrapped_metadata_dict.pop("name", None)
+    wrapped_metadata_dict.pop("thing_classes", None)
+
+    # Prevent using own evaluator so a new generic->coco json can be generated
+    wrapped_metadata_dict["evaluator_type"] = "coco"
+    # even if source dataset is COCO, numbers of classes may have changed
+    wrapped_metadata_dict.pop("json_file", None)
+
+    # Register wrapped dataset metadata
+    MetadataCatalog.get(wrap_name).set(**wrapped_metadata_dict)
 
     # Load metadata for mapping categories
     source_metadata = MetadataCatalog.get(source_dataset_name)
@@ -70,10 +74,15 @@ def register_wrapper(source_dataset_name, target_dataset_name, default="unlabele
             # present in the target class set
 
             # 1) Decorate unmatched target classes
-            # class_name += " (unmatched)"
+            class_name = f"[x] {class_name}"
 
             # 2) Use a default value
-            class_name = default
-
+            # class_name = None
         wrapped_class_names.append(class_name)
     MetadataCatalog.get(wrap_name).thing_classes = wrapped_class_names
+
+    # Register wrapped dataset loader
+    DatasetCatalog.register(
+        wrap_name,
+        lambda: load_wrapped_dataset(source_dataset_name, target_dataset_name)
+    )

--- a/detectron2/data/datasets/wrap.py
+++ b/detectron2/data/datasets/wrap.py
@@ -1,5 +1,6 @@
 from .. import DatasetCatalog, MetadataCatalog
 
+
 def load_wrapped_dataset(source_dataset_name, target_dataset_name):
     # load the source dataset dicts
     dataset_dicts = DatasetCatalog.get(source_dataset_name)
@@ -17,8 +18,7 @@ def get_id_mapping(source_class_names, target_class_names):
     assert len(common_classes) > 0
 
     idS_to_idT = {
-        source_class_names.index(name): target_class_names.index(name)
-        for name in common_classes
+        source_class_names.index(name): target_class_names.index(name) for name in common_classes
     }
 
     return idS_to_idT
@@ -83,6 +83,5 @@ def register_wrapper(source_dataset_name, target_dataset_name):
 
     # Register wrapped dataset loader
     DatasetCatalog.register(
-        wrap_name,
-        lambda: load_wrapped_dataset(source_dataset_name, target_dataset_name)
+        wrap_name, lambda: load_wrapped_dataset(source_dataset_name, target_dataset_name)
     )

--- a/detectron2/data/datasets/wrap.py
+++ b/detectron2/data/datasets/wrap.py
@@ -1,0 +1,79 @@
+from .. import DatasetCatalog, MetadataCatalog
+
+def load_wrapped_dataset(source_dataset_name, target_dataset_name):
+    # load the source dataset dicts
+    dataset_dicts = DatasetCatalog.get(source_dataset_name)
+
+    # load category id mapping
+    wrap_name = f"{source_dataset_name}@{target_dataset_name}"
+    idS_to_idT = MetadataCatalog.get(wrap_name).idS_to_idT
+
+    wrap_dataset_dicts(dataset_dicts, idS_to_idT)
+    return dataset_dicts
+
+
+def get_id_mapping(source_class_names, target_class_names):
+    common_classes = set(source_class_names) & set(target_class_names)
+    assert len(common_classes) > 0
+
+    idS_to_idT = {
+        source_class_names.index(name): target_class_names.index(name)
+        for name in common_classes
+    }
+
+    return idS_to_idT
+
+
+def wrap_dataset_dicts(dataset_dicts, idS_to_idT, drop_empty=True):
+    for d in dataset_dicts:
+        objects = d["annotations"]
+        wrapped_objects = []
+        for obj in objects:
+            # if drop_empty is False, categories that has no corresponding
+            # mappings will have None values as category ids and have to be
+            # handled by the User.
+            wrapped_category_id = idS_to_idT.get(obj["category_id"], None)
+            if wrapped_category_id is not None or not drop_empty:
+                wrapped_objects.append(wrapped_category_id)
+
+        d["annotations"] = wrapped_objects
+
+
+def register_wrapper(source_dataset_name, target_dataset_name, default="unlabeled"):
+    wrap_name = f"{source_dataset_name}@{target_dataset_name}"
+    DatasetCatalog.register(
+        wrap_name,
+        lambda: load_wrapped_dataset(source_dataset_name, target_dataset_name)
+    )
+
+    # Copy all metadata from source
+    source_metadata_dict = MetadataCatalog.get(source_dataset_name).as_dict()
+    source_metadata_dict.pop("name", None)
+    source_metadata_dict.pop("thing_classes", None)
+    MetadataCatalog.get(wrap_name).set(**source_metadata_dict)
+
+    # Load metadata for mapping categories
+    source_metadata = MetadataCatalog.get(source_dataset_name)
+    target_metadata = MetadataCatalog.get(target_dataset_name)
+
+    # Add source -> target category_id mapping to metadata
+    source_class_names = source_metadata.thing_classes
+    target_class_names = target_metadata.thing_classes
+    idS_to_idT = get_id_mapping(source_class_names, target_class_names)
+    MetadataCatalog.get(wrap_name).idS_to_idT = idS_to_idT
+
+    # Add target thing_classes to metadata
+    wrapped_class_names = []
+    for category_id, class_name in enumerate(target_class_names):
+        if category_id not in idS_to_idT.values():
+            # Different ways to handle source classes that are not
+            # present in the target class set
+
+            # 1) Decorate unmatched target classes
+            # class_name += " (unmatched)"
+
+            # 2) Use a default value
+            class_name = default
+
+        wrapped_class_names.append(class_name)
+    MetadataCatalog.get(wrap_name).thing_classes = wrapped_class_names


### PR DESCRIPTION
# Dataset wrapper
Create a mapping between two datasets to make cross-dataset evaluation more convenient.

The wrapper matches `category_id`s based on the registered list at `MetadataCatalog.<dataset>.thing_classes`. In this implementation the **source** dataset provides the content and the **target** dataset provides the ordered label set. To ensure a convenient usage a new syntax was added to the `DatasetCatalog`, which is the following: `<source dataset>@<target dataset>`. 

## Example usage
In practice if we have trained a model on `dataset-A`, and we want to evaluate on `dataset-B` that has a different class label set. Formally we would like a mapping where the source is `dataset-B` and the target is `dataset-A`.
Instead of creating a new dataset, we could simply just use the config file as follows: 
```
TEST: "dataset-B@dataset-A"
```
and the rest would be taken care of automatically.

## Real examples
In the examples below the goal was to:
1. Evaluate the reference Cityscapes Mask-RCNN model on COCO minival_100 set.
1. Evaluate the reference COCO Mask-RCNN model on Cityscapes validation set


#### `python tools/train_net.py --conf configs/Misc/wrapper-test/cityscapes-on-coco.yaml --eval-only`
```
[11/23 08:09:09 d2.data.datasets.coco]: Loaded 100 images in COCO format from datasets/coco/annotations/instances_minival2014_100.json
[11/23 08:09:09 d2.data.build]: Distribution of training instances among all 8 categories:
|  category  | #instances   |  category  | #instances   |  category  | #instances   |
|:----------:|:-------------|:----------:|:-------------|:----------:|:-------------|
|   person   | 341          | [x] rider  | 0            |    car     | 51           |
|   truck    | 4            |    bus     | 10           |   train    | 2            |
| motorcycle | 23           |  bicycle   | 10           |            |              |
|   total    | 441          |            |              |            |              |
WARNING [11/23 08:09:09 d2.evaluation.coco_evaluation]: json_file was not found in MetaDataCatalog for 'coco_2014_minival_100@cityscapes_fine_instance_seg_val'
[11/23 08:09:09 d2.data.datasets.coco]: Converting dataset annotations in 'coco_2014_minival_100@cityscapes_fine_instance_seg_val' to COCO format ...)
[11/23 08:09:09 d2.data.datasets.coco]: Loaded 100 images in COCO format from datasets/coco/annotations/instances_minival2014_100.json
[11/23 08:09:09 d2.data.datasets.coco]: Converting dataset dicts into COCO format
[11/23 08:09:09 d2.data.datasets.coco]: Conversion finished, num images: 100, num annotations: 452
[11/23 08:09:09 d2.data.datasets.coco]: Caching annotations in COCO format: ./output/inference/coco_2014_minival_100@cityscapes_fine_instance_seg_val_coco_format.json
[11/23 08:09:09 d2.evaluation.evaluator]: Start inference on 100 images
[11/23 08:09:14 d2.evaluation.evaluator]: Inference done 50/100. 0.1027 s / img. ETA=0:00:05
[11/23 08:09:20 d2.evaluation.evaluator]: Inference done 100/100. 0.1035 s / img. ETA=0:00:00
[11/23 08:09:20 d2.evaluation.evaluator]: Total inference time: 0:00:09 (0.094737 s / img per device, on 1 devices)
[11/23 08:09:20 d2.evaluation.evaluator]: Total inference pure compute time: 0:00:09 (0.097896 s / img per device, on 1 devices)
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Preparing results for COCO format ...
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Saving results to ./output/inference/coco_instances_results.json
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Evaluating predictions ...
Loading and preparing results...
DONE (t=0.00s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *bbox*
DONE (t=0.04s).
Accumulating evaluation results...
DONE (t=0.03s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.015
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.017
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.016
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.043
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.031
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.031
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.031
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.113
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.000
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Evaluation results for bbox: 
|  AP   |  AP50  |  AP75  |  APs  |  APm  |  APl  |
|:-----:|:------:|:------:|:-----:|:-----:|:-----:|
| 1.453 | 1.661  | 1.556  | 0.000 | 4.309 | 0.000 |
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Per-category bbox AP: 
| category   | AP    | category   | AP    | category   | AP    |
|:-----------|:------|:-----------|:------|:-----------|:------|
| person     | 0.000 | [x] rider  | nan   | car        | 0.000 |
| truck      | 0.368 | bus        | 9.802 | train      | 0.000 |
| motorcycle | 0.000 | bicycle    | 0.000 |            |       |
Loading and preparing results...
DONE (t=0.01s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *segm*
DONE (t=0.09s).
Accumulating evaluation results...
DONE (t=0.02s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.011
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.017
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.016
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.028
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.014
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.014
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.014
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.000
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.040
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.000
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Evaluation results for segm: 
|  AP   |  AP50  |  AP75  |  APs  |  APm  |  APl  |
|:-----:|:------:|:------:|:-----:|:-----:|:-----:|
| 1.100 | 1.661  | 1.556  | 0.000 | 2.759 | 0.000 |
[11/23 08:09:20 d2.evaluation.coco_evaluation]: Per-category segm AP: 
| category   | AP    | category   | AP    | category   | AP    |
|:-----------|:------|:-----------|:------|:-----------|:------|
| person     | 0.000 | [x] rider  | nan   | car        | 0.000 |
| truck      | 0.074 | bus        | 7.624 | train      | 0.000 |
| motorcycle | 0.000 | bicycle    | 0.000 |            |       |
[11/23 08:09:20 d2.engine.defaults]: Evaluation results for coco_2014_minival_100@cityscapes_fine_instance_seg_val in csv format:
[11/23 08:09:20 d2.evaluation.testing]: copypaste: Task: bbox
[11/23 08:09:20 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[11/23 08:09:20 d2.evaluation.testing]: copypaste: 1.4528,1.6609,1.5559,0.0000,4.3093,0.0000
[11/23 08:09:20 d2.evaluation.testing]: copypaste: Task: segm
[11/23 08:09:20 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[11/23 08:09:20 d2.evaluation.testing]: copypaste: 1.0996,1.6609,1.5559,0.0000,2.7591,0.0000
```

#### `python tools/train_net.py --conf configs/Misc/wrapper-test/coco-on-cityscapes.yaml --eval-only`
```
[11/23 08:10:02 d2.data.datasets.cityscapes]: Preprocessing cityscapes annotations ...
[11/23 08:10:13 d2.data.datasets.cityscapes]: Loaded 500 images from datasets/cityscapes/leftImg8bit/val
[11/23 08:10:13 d2.data.build]: Distribution of training instances among all 80 categories:
|   category    | #instances   |   category    | #instances   |   category    | #instances   |
|:-------------:|:-------------|:-------------:|:-------------|:-------------:|:-------------|
|    person     | 3399         |    bicycle    | 1169         |      car      | 4656         |
|  motorcycle   | 149          | [x] airplane  | 0            |      bus      | 98           |
|     train     | 23           |     truck     | 93           |   [x] boat    | 0            |
| [x] traffic.. | 0            | [x] fire hy.. | 0            | [x] stop sign | 0            |
| [x] parking.. | 0            |   [x] bench   | 0            |   [x] bird    | 0            |
|    [x] cat    | 0            |    [x] dog    | 0            |   [x] horse   | 0            |
|   [x] sheep   | 0            |    [x] cow    | 0            | [x] elephant  | 0            |
|   [x] bear    | 0            |   [x] zebra   | 0            |  [x] giraffe  | 0            |
| [x] backpack  | 0            | [x] umbrella  | 0            |  [x] handbag  | 0            |
|    [x] tie    | 0            | [x] suitcase  | 0            |  [x] frisbee  | 0            |
|   [x] skis    | 0            | [x] snowboard | 0            | [x] sports .. | 0            |
|   [x] kite    | 0            | [x] basebal.. | 0            | [x] basebal.. | 0            |
| [x] skatebo.. | 0            | [x] surfboard | 0            | [x] tennis .. | 0            |
|  [x] bottle   | 0            | [x] wine gl.. | 0            |    [x] cup    | 0            |
|   [x] fork    | 0            |   [x] knife   | 0            |   [x] spoon   | 0            |
|   [x] bowl    | 0            |  [x] banana   | 0            |   [x] apple   | 0            |
| [x] sandwich  | 0            |  [x] orange   | 0            | [x] broccoli  | 0            |
|  [x] carrot   | 0            |  [x] hot dog  | 0            |   [x] pizza   | 0            |
|   [x] donut   | 0            |   [x] cake    | 0            |   [x] chair   | 0            |
|   [x] couch   | 0            | [x] potted .. | 0            |    [x] bed    | 0            |
| [x] dining .. | 0            |  [x] toilet   | 0            |    [x] tv     | 0            |
|  [x] laptop   | 0            |   [x] mouse   | 0            |  [x] remote   | 0            |
| [x] keyboard  | 0            | [x] cell ph.. | 0            | [x] microwave | 0            |
|   [x] oven    | 0            |  [x] toaster  | 0            |   [x] sink    | 0            |
| [x] refrige.. | 0            |   [x] book    | 0            |   [x] clock   | 0            |
|   [x] vase    | 0            | [x] scissors  | 0            | [x] teddy b.. | 0            |
| [x] hair dr.. | 0            | [x] toothbr.. | 0            |               |              |
|     total     | 9587         |               |              |               |              |
WARNING [11/23 08:10:13 d2.evaluation.coco_evaluation]: json_file was not found in MetaDataCatalog for 'cityscapes_fine_instance_seg_val@coco_2014_minival_100'
[11/23 08:10:13 d2.data.datasets.coco]: Converting dataset annotations in 'cityscapes_fine_instance_seg_val@coco_2014_minival_100' to COCO format ...)
[11/23 08:10:13 d2.data.datasets.cityscapes]: Preprocessing cityscapes annotations ...
[11/23 08:10:23 d2.data.datasets.cityscapes]: Loaded 500 images from datasets/cityscapes/leftImg8bit/val
[11/23 08:10:23 d2.data.datasets.coco]: Converting dataset dicts into COCO format
[11/23 08:10:24 d2.data.datasets.coco]: Conversion finished, num images: 500, num annotations: 10109
[11/23 08:10:24 d2.data.datasets.coco]: Caching annotations in COCO format: ./output/inference/cityscapes_fine_instance_seg_val@coco_2014_minival_100_coco_format.json
[11/23 08:10:26 d2.evaluation.evaluator]: Start inference on 500 images
[11/23 08:10:40 d2.evaluation.evaluator]: Inference done 50/500. 0.2592 s / img. ETA=0:01:56
[11/23 08:11:06 d2.evaluation.evaluator]: Inference done 100/500. 0.3921 s / img. ETA=0:02:36
[11/23 08:11:31 d2.evaluation.evaluator]: Inference done 150/500. 0.4323 s / img. ETA=0:02:31
[11/23 08:11:57 d2.evaluation.evaluator]: Inference done 200/500. 0.4553 s / img. ETA=0:02:16
[11/23 08:12:23 d2.evaluation.evaluator]: Inference done 250/500. 0.4669 s / img. ETA=0:01:56
[11/23 08:12:50 d2.evaluation.evaluator]: Inference done 300/500. 0.4805 s / img. ETA=0:01:36
[11/23 08:13:17 d2.evaluation.evaluator]: Inference done 350/500. 0.4884 s / img. ETA=0:01:13
[11/23 08:13:45 d2.evaluation.evaluator]: Inference done 400/500. 0.4963 s / img. ETA=0:00:49
[11/23 08:14:13 d2.evaluation.evaluator]: Inference done 450/500. 0.5045 s / img. ETA=0:00:25
[11/23 08:14:41 d2.evaluation.evaluator]: Inference done 500/500. 0.5093 s / img. ETA=0:00:00
[11/23 08:14:41 d2.evaluation.evaluator]: Total inference time: 0:04:12 (0.509091 s / img per device, on 1 devices)
[11/23 08:14:41 d2.evaluation.evaluator]: Total inference pure compute time: 0:00:45 (0.092237 s / img per device, on 1 devices)
[11/23 08:14:41 d2.evaluation.coco_evaluation]: Preparing results for COCO format ...
[11/23 08:14:41 d2.evaluation.coco_evaluation]: Saving results to ./output/inference/coco_instances_results.json
[11/23 08:14:41 d2.evaluation.coco_evaluation]: Evaluating predictions ...
Loading and preparing results...
DONE (t=0.01s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *bbox*
DONE (t=5.11s).
Accumulating evaluation results...
DONE (t=0.37s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.274
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.450
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.280
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.085
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.271
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.499
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.208
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.363
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.390
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.107
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.367
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.658
[11/23 08:14:47 d2.evaluation.coco_evaluation]: Evaluation results for bbox: 
|   AP   |  AP50  |  AP75  |  APs  |  APm   |  APl   |
|:------:|:------:|:------:|:-----:|:------:|:------:|
| 27.391 | 45.042 | 27.990 | 8.468 | 27.076 | 49.926 |
[11/23 08:14:47 d2.evaluation.coco_evaluation]: Per-category bbox AP: 
| category          | AP     | category         | AP     | category           | AP     |
|:------------------|:-------|:-----------------|:-------|:-------------------|:-------|
| person            | 26.101 | bicycle          | 24.427 | car                | 45.420 |
| motorcycle        | 18.910 | [x] airplane     | nan    | bus                | 44.222 |
| train             | 6.526  | truck            | 26.133 | [x] boat           | nan    |
| [x] traffic light | nan    | [x] fire hydrant | nan    | [x] stop sign      | nan    |
| [x] parking meter | nan    | [x] bench        | nan    | [x] bird           | nan    |
| [x] cat           | nan    | [x] dog          | nan    | [x] horse          | nan    |
| [x] sheep         | nan    | [x] cow          | nan    | [x] elephant       | nan    |
| [x] bear          | nan    | [x] zebra        | nan    | [x] giraffe        | nan    |
| [x] backpack      | nan    | [x] umbrella     | nan    | [x] handbag        | nan    |
| [x] tie           | nan    | [x] suitcase     | nan    | [x] frisbee        | nan    |
| [x] skis          | nan    | [x] snowboard    | nan    | [x] sports ball    | nan    |
| [x] kite          | nan    | [x] baseball bat | nan    | [x] baseball glove | nan    |
| [x] skateboard    | nan    | [x] surfboard    | nan    | [x] tennis racket  | nan    |
| [x] bottle        | nan    | [x] wine glass   | nan    | [x] cup            | nan    |
| [x] fork          | nan    | [x] knife        | nan    | [x] spoon          | nan    |
| [x] bowl          | nan    | [x] banana       | nan    | [x] apple          | nan    |
| [x] sandwich      | nan    | [x] orange       | nan    | [x] broccoli       | nan    |
| [x] carrot        | nan    | [x] hot dog      | nan    | [x] pizza          | nan    |
| [x] donut         | nan    | [x] cake         | nan    | [x] chair          | nan    |
| [x] couch         | nan    | [x] potted plant | nan    | [x] bed            | nan    |
| [x] dining table  | nan    | [x] toilet       | nan    | [x] tv             | nan    |
| [x] laptop        | nan    | [x] mouse        | nan    | [x] remote         | nan    |
| [x] keyboard      | nan    | [x] cell phone   | nan    | [x] microwave      | nan    |
| [x] oven          | nan    | [x] toaster      | nan    | [x] sink           | nan    |
| [x] refrigerator  | nan    | [x] book         | nan    | [x] clock          | nan    |
| [x] vase          | nan    | [x] scissors     | nan    | [x] teddy bear     | nan    |
| [x] hair drier    | nan    | [x] toothbrush   | nan    |                    |        |
Loading and preparing results...
DONE (t=0.20s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *segm*
DONE (t=5.91s).
Accumulating evaluation results...
DONE (t=0.37s).
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.228
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.401
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.226
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.039
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.189
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.462
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.192
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.314
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.330
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.068
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.280
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.600
[11/23 08:14:54 d2.evaluation.coco_evaluation]: Evaluation results for segm: 
|   AP   |  AP50  |  AP75  |  APs  |  APm   |  APl   |
|:------:|:------:|:------:|:-----:|:------:|:------:|
| 22.802 | 40.055 | 22.568 | 3.931 | 18.854 | 46.187 |
[11/23 08:14:54 d2.evaluation.coco_evaluation]: Per-category segm AP: 
| category          | AP     | category         | AP     | category           | AP     |
|:------------------|:-------|:-----------------|:-------|:-------------------|:-------|
| person            | 20.054 | bicycle          | 12.211 | car                | 37.586 |
| motorcycle        | 12.677 | [x] airplane     | nan    | bus                | 43.833 |
| train             | 7.411  | truck            | 25.842 | [x] boat           | nan    |
| [x] traffic light | nan    | [x] fire hydrant | nan    | [x] stop sign      | nan    |
| [x] parking meter | nan    | [x] bench        | nan    | [x] bird           | nan    |
| [x] cat           | nan    | [x] dog          | nan    | [x] horse          | nan    |
| [x] sheep         | nan    | [x] cow          | nan    | [x] elephant       | nan    |
| [x] bear          | nan    | [x] zebra        | nan    | [x] giraffe        | nan    |
| [x] backpack      | nan    | [x] umbrella     | nan    | [x] handbag        | nan    |
| [x] tie           | nan    | [x] suitcase     | nan    | [x] frisbee        | nan    |
| [x] skis          | nan    | [x] snowboard    | nan    | [x] sports ball    | nan    |
| [x] kite          | nan    | [x] baseball bat | nan    | [x] baseball glove | nan    |
| [x] skateboard    | nan    | [x] surfboard    | nan    | [x] tennis racket  | nan    |
| [x] bottle        | nan    | [x] wine glass   | nan    | [x] cup            | nan    |
| [x] fork          | nan    | [x] knife        | nan    | [x] spoon          | nan    |
| [x] bowl          | nan    | [x] banana       | nan    | [x] apple          | nan    |
| [x] sandwich      | nan    | [x] orange       | nan    | [x] broccoli       | nan    |
| [x] carrot        | nan    | [x] hot dog      | nan    | [x] pizza          | nan    |
| [x] donut         | nan    | [x] cake         | nan    | [x] chair          | nan    |
| [x] couch         | nan    | [x] potted plant | nan    | [x] bed            | nan    |
| [x] dining table  | nan    | [x] toilet       | nan    | [x] tv             | nan    |
| [x] laptop        | nan    | [x] mouse        | nan    | [x] remote         | nan    |
| [x] keyboard      | nan    | [x] cell phone   | nan    | [x] microwave      | nan    |
| [x] oven          | nan    | [x] toaster      | nan    | [x] sink           | nan    |
| [x] refrigerator  | nan    | [x] book         | nan    | [x] clock          | nan    |
| [x] vase          | nan    | [x] scissors     | nan    | [x] teddy bear     | nan    |
| [x] hair drier    | nan    | [x] toothbrush   | nan    |                    |        |
[11/23 08:14:54 d2.engine.defaults]: Evaluation results for cityscapes_fine_instance_seg_val@coco_2014_minival_100 in csv format:
[11/23 08:14:54 d2.evaluation.testing]: copypaste: Task: bbox
[11/23 08:14:54 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[11/23 08:14:54 d2.evaluation.testing]: copypaste: 27.3912,45.0415,27.9896,8.4683,27.0764,49.9263
[11/23 08:14:54 d2.evaluation.testing]: copypaste: Task: segm
[11/23 08:14:54 d2.evaluation.testing]: copypaste: AP,AP50,AP75,APs,APm,APl
[11/23 08:14:54 d2.evaluation.testing]: copypaste: 22.8019,40.0550,22.5683,3.9309,18.8544,46.1869
```