### PR TITLE
Create and switch to non-root user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,12 @@ RUN pip install -e /detectron2_repo
 
 WORKDIR /detectron2_repo
 
+# create and switch to non-root user
+ENV FVCORE_CACHE="/tmp"
+RUN groupadd -g 999 appuser && \
+    useradd -r -u 999 -g appuser appuser
+USER appuser
+
 # run it, for example:
 # wget http://images.cocodataset.org/val2017/000000439715.jpg -O input.jpg
 # python3 demo/demo.py  \


### PR DESCRIPTION
Fixes #381 
The container does not operate as root anymore, but as a new user `appuser` with limited rights, which improves security.

However, this does not fix the fact that outputfiles cannot be deleted without `sudo` (because they belong to `appuser`. To prevent that, docker can be called with the parameter `--user=$UID`. Doing so results in files that belong to the host user.

This could be added as an instructional comment int the Dockerfile. However, the Dockerfile becomes more and more bloated with instructions. It might be preferable, to introduce a docker-compose file, which includes default settings, like `user: $UID` or the GUI support, discussed in #379.