### PR TITLE
Fix bug in class GeneralizedRCNNWithTTA.

### DIFF
--- a/detectron2/modeling/test_time_augmentation.py
+++ b/detectron2/modeling/test_time_augmentation.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from itertools import count
 import torch
 from torch import nn
+from torch.nn.parallel import DistributedDataParallel
 
 from detectron2.data.detection_utils import read_image
 from detectron2.data.transforms import ResizeShortestEdge
@@ -83,6 +84,8 @@ class GeneralizedRCNNWithTTA(nn.Module):
             batch_size (int): batch the augmented images into this batch size for inference.
         """
         super().__init__()
+        if isinstance(model, DistributedDataParallel):
+            model = model.module
         assert isinstance(
             model, GeneralizedRCNN
         ), "TTA is only supported on GeneralizedRCNN. Got a model of type {}".format(type(model))


### PR DESCRIPTION
In multi-gpu training, the model is wrapped with DDP.
```
# For training, wrap with DDP. But don't need this for inference.
if comm.get_world_size() > 1:
    model = DistributedDataParallel(
        model, device_ids=[comm.get_local_rank()], broadcast_buffers=False
    )
```
Or [see here](https://github.com/facebookresearch/detectron2/blob/master/detectron2/engine/defaults.py#L229).

Therefore, when set cfg.TEST.AUG.ENABLED to True, the input model of GeneralizedRCNNWithTTA is instance of DistributedDataParallel rather than GeneralizedRCNN.
```
if cfg.TEST.AUG.ENABLED:
    trainer.register_hooks(
        [hooks.EvalHook(0, lambda: trainer.test_with_TTA(cfg, trainer.model))]
)
```
Or [see here](https://github.com/facebookresearch/detectron2/blob/master/tools/train_net.py#L145).

In this case, it brings errors in class GeneralizedRCNNWithTTA, such as "AssertionError: TTA is only supported on GeneralizedRCNN. Got a model of type <class 'torch.nn.parallel.distributed.DistributedDataParallel'>".

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

Before submitting a PR, please run `dev/linter.sh` to lint the code.
