### PR TITLE
Expose select_foreground_proposals and select_proposals_with_visible_keypoints.

### DIFF
--- a/detectron2/modeling/roi_heads/__init__.py
+++ b/detectron2/modeling/roi_heads/__init__.py
@@ -2,7 +2,8 @@
 from .box_head import ROI_BOX_HEAD_REGISTRY, build_box_head
 from .keypoint_head import ROI_KEYPOINT_HEAD_REGISTRY, build_keypoint_head
 from .mask_head import ROI_MASK_HEAD_REGISTRY, build_mask_head
-from .roi_heads import ROI_HEADS_REGISTRY, ROIHeads, StandardROIHeads, build_roi_heads
+from .roi_heads import ROI_HEADS_REGISTRY, ROIHeads, StandardROIHeads, build_roi_heads, select_foreground_proposals, \
+    select_proposals_with_visible_keypoints
 from .rotated_fast_rcnn import RROIHeads
 
 from . import cascade_rcnn  # isort:skip


### PR DESCRIPTION
Expose select_foreground_proposals and select_proposals_with_visible_keypoints, as proposed in the densepose example.

If this was to be merged, it would be sensible to update other code passages (e.g. the densepose example) to reflect this change.
