### PR TITLE
Another "avoid `torch/extension.h` in ops to be friendly to nvcc9.0"

### DIFF
--- a/detectron2/layers/csrc/deformable/deform_conv_cuda.cu
+++ b/detectron2/layers/csrc/deformable/deform_conv_cuda.cu
@@ -8,7 +8,7 @@
 // https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/deform_conv_cuda.c
 // Original license: Apache 2.0
 
-#include <torch/extension.h>
+#include <torch/types.h>
 
 #include "deform_conv.h"
 


### PR DESCRIPTION
Follow-up to #414: by replacing this additional torch/extension.h include I am able to successfully build detectron2 with nvcc9.0.
Disclaimer: I haven't tested applying deformable convolution with this change, I can only verify that this fixes the build problem for me.