### PR TITLE
Update detection_utils.py

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -10,6 +10,8 @@ import numpy as np
 import torch
 from fvcore.common.file_io import PathManager
 from PIL import Image, ImageOps
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 from detectron2.structures import (
     BitMasks,


### PR DESCRIPTION
To except following error https://stackoverflow.com/questions/12984426/python-pil-ioerror-image-file-truncated-with-big-images.

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

Before submitting a PR, please run `dev/linter.sh` to lint the code.
