### PR TITLE
Fix multiple processes writing coco json to same file

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from fvcore.common.timer import Timer
 from detectron2.structures import BoxMode, PolygonMasks, Boxes
+from detectron2.utils import comm
 from fvcore.common.file_io import PathManager
 
 
@@ -408,7 +409,8 @@ def convert_to_coco_json(dataset_name, output_folder="", allow_cached=True):
     PathManager.mkdirs(output_folder)
     if os.path.exists(cache_path) and allow_cached:
         logger.info(f"Reading cached annotations in COCO format from:{cache_path} ...")
-    else:
+    elif comm.is_main_process():
+        # Only convert/dump in the main process to avoid multiple processes writing to file
         logger.info(f"Converting dataset annotations in '{dataset_name}' to COCO format ...)")
         coco_dict = convert_to_coco_dict(dataset_name)
 

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -398,26 +398,22 @@ def convert_to_coco_json(dataset_name, output_file, allow_cached=True):
             must be registered in DatasetCatalog and in detectron2's standard format
         output_file: path of json file that will be saved to
         allow_cached: if json file is already present then skip conversion
-    Returns:
-        cache_path: path to the COCO-format json file
     """
 
     # TODO: The dataset or the conversion script *may* change,
     # a checksum would be useful for validating the cached data
 
     PathManager.mkdirs(os.path.dirname(output_file))
-    if os.path.exists(output_file) and allow_cached:
-        logger.info(f"Cached annotations in COCO format already exist: {output_file}")
-    else:
-        logger.info(f"Converting dataset annotations in '{dataset_name}' to COCO format ...)")
-        coco_dict = convert_to_coco_dict(dataset_name)
+    with file_lock(output_file):
+        if os.path.exists(output_file) and allow_cached:
+            logger.info(f"Cached annotations in COCO format already exist: {output_file}")
+        else:
+            logger.info(f"Converting dataset annotations in '{dataset_name}' to COCO format ...)")
+            coco_dict = convert_to_coco_dict(dataset_name)
 
-        with file_lock(output_file):
             with PathManager.open(output_file, "w") as json_file:
                 logger.info(f"Caching annotations in COCO format: {output_file}")
                 json.dump(coco_dict, json_file)
-
-    return output_file
 
 
 if __name__ == "__main__":

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -59,11 +59,7 @@ class COCOEvaluator(DatasetEvaluator):
 
             cache_path = os.path.join(output_dir, f"{dataset_name}_coco_format.json")
             self._metadata.json_file = cache_path
-            if not distributed or comm.is_main_process():
-                convert_to_coco_json(dataset_name, cache_path)
-            if distributed:
-                # Wait until the json file has been written by the main process
-                comm.synchronize()
+            convert_to_coco_json(dataset_name, cache_path)
 
         json_file = PathManager.get_local_path(self._metadata.json_file)
         with contextlib.redirect_stdout(io.StringIO()):

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -57,8 +57,13 @@ class COCOEvaluator(DatasetEvaluator):
         if not hasattr(self._metadata, "json_file"):
             self._logger.warning(f"json_file was not found in MetaDataCatalog for '{dataset_name}'")
 
-            cache_path = convert_to_coco_json(dataset_name, output_dir)
+            cache_path = os.path.join(output_dir, f"{dataset_name}_coco_format.json")
             self._metadata.json_file = cache_path
+            if not distributed or comm.is_main_process():
+                convert_to_coco_json(dataset_name, cache_path)
+            if distributed:
+                # Wait until the json file has been written by the main process
+                comm.synchronize()
 
         json_file = PathManager.get_local_path(self._metadata.json_file)
         with contextlib.redirect_stdout(io.StringIO()):


### PR DESCRIPTION
When CocoEvaluator with multiple workers using a custom loader, it appears that each worker converts the Detectron2 dataset to COCO json and then dump to disk. This can cause the output file to be corrupted. Here my fix is to only convert/dump on the main process/