### PR TITLE
add `evaluator.process` time to ETA

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -400,7 +400,7 @@ def convert_to_coco_json(dataset_name, output_file, allow_cached=True):
 
     PathManager.mkdirs(os.path.dirname(output_file))
     with file_lock(output_file):
-        if os.path.exists(output_file) and allow_cached:
+        if PathManager.exists(output_file) and allow_cached:
             logger.info(f"Cached annotations in COCO format already exist: {output_file}")
         else:
             logger.info(f"Converting dataset annotations in '{dataset_name}' to COCO format ...)")

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -185,7 +185,7 @@ Category ids in annotations are not in [1, #categories]! We'll apply a mapping f
         dataset_dicts.append(record)
 
     if num_instances_without_valid_segmentation > 0:
-        logger.warn(
+        logger.warning(
             "Filtered out {} instances without valid segmentation. "
             "There might be issues in your dataset generation process.".format(
                 num_instances_without_valid_segmentation

--- a/detectron2/evaluation/evaluator.py
+++ b/detectron2/evaluation/evaluator.py
@@ -111,6 +111,7 @@ def inference_on_dataset(model, data_loader, evaluator):
     num_warmup = min(5, total - 1)
     start_time = time.perf_counter()
     total_compute_time = 0
+    total_time = 0
     with inference_context(model), torch.no_grad():
         for idx, inputs in enumerate(data_loader):
             if idx == num_warmup:

--- a/detectron2/evaluation/evaluator.py
+++ b/detectron2/evaluation/evaluator.py
@@ -111,7 +111,6 @@ def inference_on_dataset(model, data_loader, evaluator):
     num_warmup = min(5, total - 1)
     start_time = time.perf_counter()
     total_compute_time = 0
-    total_time = 0
     with inference_context(model), torch.no_grad():
         for idx, inputs in enumerate(data_loader):
             if idx == num_warmup:
@@ -124,11 +123,10 @@ def inference_on_dataset(model, data_loader, evaluator):
                 torch.cuda.synchronize()
             total_compute_time += time.perf_counter() - start_compute_time
             evaluator.process(inputs, outputs)
-            total_time += time.perf_counter() - start_compute_time
 
             if idx >= num_warmup * 2:
                 seconds_per_img = total_compute_time / (idx + 1 - num_warmup)
-                total_seconds_per_img = total_time / (idx + 1 - num_warmup)
+                total_seconds_per_img = (time.perf_counter() - start_time) / (idx + 1 - num_warmup)
                 eta = datetime.timedelta(seconds=int(total_seconds_per_img * (total - idx - 1)))
                 log_every_n_seconds(
                     logging.INFO,

--- a/detectron2/evaluation/evaluator.py
+++ b/detectron2/evaluation/evaluator.py
@@ -123,10 +123,12 @@ def inference_on_dataset(model, data_loader, evaluator):
                 torch.cuda.synchronize()
             total_compute_time += time.perf_counter() - start_compute_time
             evaluator.process(inputs, outputs)
+            total_time += time.perf_counter() - start_compute_time
 
             if idx >= num_warmup * 2:
                 seconds_per_img = total_compute_time / (idx + 1 - num_warmup)
-                eta = datetime.timedelta(seconds=int(seconds_per_img * (total - idx - 1)))
+                total_seconds_per_img = total_time / (idx + 1 - num_warmup)
+                eta = datetime.timedelta(seconds=int(total_seconds_per_img * (total - idx - 1)))
                 log_every_n_seconds(
                     logging.INFO,
                     "Inference done {}/{}. {:.4f} s / img. ETA={}".format(


### PR DESCRIPTION
The time needed for `evaluator.process()` is not negligible, and it often leads to wrong ETA calculation

```
[12/27 20:06:29 d2.evaluation.evaluator]: Inference done 11/3944. 0.1170 s / img. ETA=0:07:39
[12/27 20:06:35 d2.evaluation.evaluator]: Inference done 29/3944. 0.1192 s / img. ETA=0:07:42
[12/27 20:06:40 d2.evaluation.evaluator]: Inference done 46/3944. 0.1206 s / img. ETA=0:07:42
....
....
[12/27 20:14:33 d2.evaluation.evaluator]: Inference done 1777/3944. 0.1248 s / img. ETA=0:00:06
[12/27 20:14:38 d2.evaluation.evaluator]: Inference done 1816/3944. 0.1245 s / img. ETA=0:00:00
[12/27 20:14:43 d2.evaluation.evaluator]: Inference done 1840/3944. 0.1245 s / img. ETA=-1 day, 23:59:55
[12/27 20:14:49 d2.evaluation.evaluator]: Inference done 1860/3944. 0.1246 s / img. ETA=-1 day, 23:59:50
[12/27 20:14:54 d2.evaluation.evaluator]: Inference done 1879/3944. 0.1246 s / img. ETA=-1 day, 23:59:45
[12/27 20:14:59 d2.evaluation.evaluator]: Inference done 1918/3944. 0.1244 s / img. ETA=-1 day, 23:59:39
```