### PR TITLE
Refactor test_boxes, test_model_zoo, test_rpn

### DIFF
--- a/tests/test_boxes.py
+++ b/tests/test_boxes.py
@@ -18,8 +18,8 @@ class TestBoxMode(unittest.TestCase):
         for tp in [list, tuple]:
             box = tp([5, 5, 10, 10])
             output = self._convert_xy_to_wh(box)
-            self.assertTrue(isinstance(output, tp))
-            self.assertTrue(output == tp([5, 5, 5, 5]))
+            self.assertIsInstance(output, tp)
+            self.assertEqual(output, tp([5, 5, 5, 5]))
 
             with self.assertRaises(Exception):
                 self._convert_xy_to_wh([box])
@@ -45,8 +45,8 @@ class TestBoxMode(unittest.TestCase):
         for tp in [list, tuple]:
             box = tp([50, 50, 30, 20, 0])
             output = self._convert_xywha_to_xyxy(box)
-            self.assertTrue(isinstance(output, tp))
-            self.assertTrue(output == tp([35, 40, 65, 60]))
+            self.assertIsInstance(output, tp)
+            self.assertEqual(output, tp([35, 40, 65, 60]))
 
             with self.assertRaises(Exception):
                 self._convert_xywha_to_xyxy([box])
@@ -107,7 +107,7 @@ class TestBoxIOU(unittest.TestCase):
 
         ious = pairwise_iou(Boxes(boxes1), Boxes(boxes2))
 
-        assert torch.allclose(ious, expected_ious)
+        self.assertTrue(torch.allclose(ious, expected_ious))
 
 
 if __name__ == "__main__":

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 class TestModelZoo(unittest.TestCase):
     def test_get_returns_model(self):
         model = model_zoo.get("Misc/scratch_mask_rcnn_R_50_FPN_3x_gn.yaml", trained=False)
-        assert isinstance(model, GeneralizedRCNN), model
-        assert isinstance(model.backbone, FPN), model.backbone
+        self.assertIsInstance(model, GeneralizedRCNN)
+        self.assertIsInstance(model.backbone, FPN)
 
     def test_get_invalid_model(self):
         self.assertRaises(RuntimeError, model_zoo.get, "Invalid/config.yaml")

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -63,13 +63,15 @@ class RPNTest(unittest.TestCase):
             torch.tensor([0.1415634006, 0.0989848152, 0.0565387346, -0.0072308783, -0.0428492837]),
         ]
 
-        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(proposals,
-                                                                                       expected_proposal_boxes,
-                                                                                       image_sizes,
-                                                                                       expected_objectness_logits):
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in \
+                zip(proposals,
+                    expected_proposal_boxes,
+                    image_sizes,
+                    expected_objectness_logits):
             self.assertEqual(len(proposal), len(expected_proposal_box))
             self.assertEqual(proposal.image_size, im_size)
-            self.assertTrue(torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor))
+            self.assertTrue(
+                torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor))
             self.assertTrue(torch.allclose(proposal.objectness_logits, expected_objectness_logit))
 
     def test_rrpn(self):
@@ -186,10 +188,11 @@ class RPNTest(unittest.TestCase):
 
         torch.set_printoptions(precision=8, sci_mode=False)
 
-        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(proposals,
-                                                                                       expected_proposal_boxes,
-                                                                                       image_sizes,
-                                                                                       expected_objectness_logits):
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in \
+                zip(proposals,
+                    expected_proposal_boxes,
+                    image_sizes,
+                    expected_objectness_logits):
             self.assertEqual(len(proposal), len(expected_proposal_box))
             self.assertEqual(proposal.image_size, im_size)
             # It seems that there's some randomness in the result across different machines:
@@ -198,12 +201,16 @@ class RPNTest(unittest.TestCase):
             # thus the atol here.
             err_msg = "computed proposal boxes = {}, expected {}".format(
                 proposal.proposal_boxes.tensor, expected_proposal_box.tensor)
-            self.assertTrue(torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor, atol=1e-5),
-                            err_msg)
+            self.assertTrue(
+                torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor,
+                               atol=1e-5),
+                err_msg)
 
             err_msg = "computed objectness logits = {}, expected {}".format(
                 proposal.objectness_logits, expected_objectness_logit)
-            self.assertTrue(torch.allclose(proposal.objectness_logits, expected_objectness_logit, atol=1e-5), err_msg)
+            self.assertTrue(
+                torch.allclose(proposal.objectness_logits, expected_objectness_logit, atol=1e-5),
+                err_msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -63,15 +63,14 @@ class RPNTest(unittest.TestCase):
             torch.tensor([0.1415634006, 0.0989848152, 0.0565387346, -0.0072308783, -0.0428492837]),
         ]
 
-        for proposal, expected_proposal_box, im_size, expected_objectness_logit in \
-                zip(proposals,
-                    expected_proposal_boxes,
-                    image_sizes,
-                    expected_objectness_logits):
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(
+            proposals, expected_proposal_boxes, image_sizes, expected_objectness_logits
+        ):
             self.assertEqual(len(proposal), len(expected_proposal_box))
             self.assertEqual(proposal.image_size, im_size)
             self.assertTrue(
-                torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor))
+                torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor)
+            )
             self.assertTrue(torch.allclose(proposal.objectness_logits, expected_objectness_logit))
 
     def test_rrpn(self):
@@ -188,11 +187,9 @@ class RPNTest(unittest.TestCase):
 
         torch.set_printoptions(precision=8, sci_mode=False)
 
-        for proposal, expected_proposal_box, im_size, expected_objectness_logit in \
-                zip(proposals,
-                    expected_proposal_boxes,
-                    image_sizes,
-                    expected_objectness_logits):
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(
+            proposals, expected_proposal_boxes, image_sizes, expected_objectness_logits
+        ):
             self.assertEqual(len(proposal), len(expected_proposal_box))
             self.assertEqual(proposal.image_size, im_size)
             # It seems that there's some randomness in the result across different machines:
@@ -200,17 +197,22 @@ class RPNTest(unittest.TestCase):
             # However, a different machine might produce slightly different results,
             # thus the atol here.
             err_msg = "computed proposal boxes = {}, expected {}".format(
-                proposal.proposal_boxes.tensor, expected_proposal_box.tensor)
+                proposal.proposal_boxes.tensor, expected_proposal_box.tensor
+            )
             self.assertTrue(
-                torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor,
-                               atol=1e-5),
-                err_msg)
+                torch.allclose(
+                    proposal.proposal_boxes.tensor, expected_proposal_box.tensor, atol=1e-5
+                ),
+                err_msg,
+            )
 
             err_msg = "computed objectness logits = {}, expected {}".format(
-                proposal.objectness_logits, expected_objectness_logit)
+                proposal.objectness_logits, expected_objectness_logit
+            )
             self.assertTrue(
                 torch.allclose(proposal.objectness_logits, expected_objectness_logit, atol=1e-5),
-                err_msg)
+                err_msg,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
 import unittest
+
 import torch
 
 from detectron2.config import get_cfg
@@ -41,7 +42,7 @@ class RPNTest(unittest.TestCase):
             "loss_rpn_loc": torch.tensor(0.0990132466),
         }
         for name in expected_losses.keys():
-            assert torch.allclose(proposal_losses[name], expected_losses[name])
+            self.assertTrue(torch.allclose(proposal_losses[name], expected_losses[name]))
 
         expected_proposal_boxes = [
             Boxes(torch.tensor([[0, 0, 10, 10], [7.3365392685, 0, 10, 10]])),
@@ -63,13 +64,14 @@ class RPNTest(unittest.TestCase):
             torch.tensor([0.1415634006, 0.0989848152, 0.0565387346, -0.0072308783, -0.0428492837]),
         ]
 
-        for i in range(len(image_sizes)):
-            assert len(proposals[i]) == len(expected_proposal_boxes[i])
-            assert proposals[i].image_size == (image_sizes[i][0], image_sizes[i][1])
-            assert torch.allclose(
-                proposals[i].proposal_boxes.tensor, expected_proposal_boxes[i].tensor
-            )
-            assert torch.allclose(proposals[i].objectness_logits, expected_objectness_logits[i])
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(proposals,
+                                                                                       expected_proposal_boxes,
+                                                                                       image_sizes,
+                                                                                       expected_objectness_logits):
+            self.assertEqual(len(proposal), len(expected_proposal_box))
+            self.assertEqual(proposal.image_size, im_size)
+            self.assertTrue(torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor))
+            self.assertTrue(torch.allclose(proposal.objectness_logits, expected_objectness_logit))
 
     def test_rrpn(self):
         torch.manual_seed(121)
@@ -103,7 +105,7 @@ class RPNTest(unittest.TestCase):
             "loss_rpn_loc": torch.tensor(0.1552739739),
         }
         for name in expected_losses.keys():
-            assert torch.allclose(proposal_losses[name], expected_losses[name])
+            self.assertTrue(torch.allclose(proposal_losses[name], expected_losses[name]))
 
         expected_proposal_boxes = [
             RotatedBoxes(
@@ -185,25 +187,24 @@ class RPNTest(unittest.TestCase):
 
         torch.set_printoptions(precision=8, sci_mode=False)
 
-        for i in range(len(image_sizes)):
-            assert len(proposals[i]) == len(expected_proposal_boxes[i])
-            assert proposals[i].image_size == (image_sizes[i][0], image_sizes[i][1])
+        for proposal, expected_proposal_box, im_size, expected_objectness_logit in zip(proposals,
+                                                                                       expected_proposal_boxes,
+                                                                                       image_sizes,
+                                                                                       expected_objectness_logits):
+            self.assertEqual(len(proposal), len(expected_proposal_box))
+            self.assertEqual(proposal.image_size, im_size)
             # It seems that there's some randomness in the result across different machines:
             # This test can be run on a local machine for 100 times with exactly the same result,
             # However, a different machine might produce slightly different results,
             # thus the atol here.
             err_msg = "computed proposal boxes = {}, expected {}".format(
-                proposals[i].proposal_boxes.tensor, expected_proposal_boxes[i].tensor
-            )
-            assert torch.allclose(
-                proposals[i].proposal_boxes.tensor, expected_proposal_boxes[i].tensor, atol=1e-5
-            ), err_msg
+                proposal.proposal_boxes.tensor, expected_proposal_box.tensor)
+            self.assertTrue(torch.allclose(proposal.proposal_boxes.tensor, expected_proposal_box.tensor, atol=1e-5),
+                            err_msg)
+
             err_msg = "computed objectness logits = {}, expected {}".format(
-                proposals[i].objectness_logits, expected_objectness_logits[i]
-            )
-            assert torch.allclose(
-                proposals[i].objectness_logits, expected_objectness_logits[i], atol=1e-5
-            ), err_msg
+                proposal.objectness_logits, expected_objectness_logit)
+            self.assertTrue(torch.allclose(proposal.objectness_logits, expected_objectness_logit, atol=1e-5), err_msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_rpn.py
+++ b/tests/test_rpn.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import logging
 import unittest
-
 import torch
 
 from detectron2.config import get_cfg


### PR DESCRIPTION
I've noticed that there is some inconsistency between different tests, i.e. some use python's builtin `assert` while others use `unittest.TestCase` asserts (a clear preference is for the latter). I went through `test_boxes.py`, `test_model_zoo.py`, and `test_rpn.py` and refactored it. Also some asserting did not work so I fixed that as well + did some minor refactoring in general. 
