### PR TITLE
Support exporting to Caffe2 on cuda (gpu) device

### DIFF
--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -296,8 +296,10 @@ class Caffe2ROIPooler(Caffe2Compatible, poolers.ROIPooler):
         assert (
             self.max_level - self.min_level + 1 == 4
         ), "Currently DistributeFpnProposals only support 4 levels"
+        # DistributeFpnProposals only has a CPU implementation, so copy the pooler_fmt_boxes to cpu
+        pooler_fmt_boxes_cpu = pooler_fmt_boxes.cpu().clone()
         fpn_outputs = torch.ops._caffe2.DistributeFpnProposals(
-            pooler_fmt_boxes,
+            pooler_fmt_boxes_cpu,
             roi_canonical_scale=self.canonical_box_size,
             roi_canonical_level=self.canonical_level,
             roi_max_level=self.max_level,

--- a/detectron2/export/caffe2_export.py
+++ b/detectron2/export/caffe2_export.py
@@ -28,10 +28,12 @@ from .shared import (
 )
 
 """
-IMPORTANT NOTE: This module relies on Caffe2 C++ operators defined in the pytorch repo, eg BatchPermutationOp.
+IMPORTANT NOTE: This module relies on Caffe2 C++ operators defined in the pytorch repo, eg
+BatchPermutationOp.
 As of [Jan 8th 2020], your pytorch installation must match or exceed this commit:
     https://github.com/pytorch/pytorch/commit/d9c3913dfc4ac1812ef0e0e180f0433884758d7d
-Notably, this is not included in pytorch==1.3.1, but will (hopefully) be included in pytorch==1.4.0 (not released yet).
+Notably, this is not included in pytorch==1.3.1, but will (hopefully) be included in
+pytorch==1.4.0 (not released yet).
 Feel free to remove this text once pytorch==1.4.0 is released.
 """
 
@@ -56,7 +58,7 @@ def _export_via_onnx(model, inputs, device="CPU"):
     model.apply(_check_eval)
 
     # Export the model to ONNX
-    # Set operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK to fix this onnx.optimizer.optimize() error:
+    # Set OperatorExportTypes.ONNX_ATEN_FALLBACK to fix this onnx.optimizer.optimize() error:
     #   https://github.com/onnx/onnx/issues/2417#issuecomment-546063460
     with torch.no_grad():
         with io.BytesIO() as f:
@@ -81,9 +83,10 @@ def _export_via_onnx(model, inputs, device="CPU"):
     init_net, predict_net = Caffe2Backend.onnx_graph_to_caffe2_net(onnx_model, device=device)
 
     if device == "CUDA":
-        # Context: onnx does not set any of the device_option's for init_net and predict_net. Since detection models,
-        # eg FRCNN, utilize several CPU-only operators, eg GenerateProposals, we must explicitly set device_option's in
-        # the init and predict nets (as well as CopyXToY ops) to avoid runtime errors
+        # Context: onnx does not set any of the device_option's for init_net and predict_net. Since
+        # detection models, eg FRCNN, utilize several CPU-only operators, eg GenerateProposals, we
+        # must explicitly set device_option's in the init and predict nets (as well as CopyXToY ops)
+        # to avoid runtime errors
         predict_net_net = core.Net(predict_net)
         init_net_net = core.Net(init_net)
 
@@ -136,7 +139,8 @@ def export_caffe2_detection_model(model: torch.nn.Module, tensor_inputs: List[to
     params = get_params_from_init_net(init_net)
     predict_net, params = remove_reshape_for_fc(predict_net, params)
     group_norm_replace_aten_with_caffe2(predict_net)
-    # if we don't pass device_option here, then this function will return a new init_net with NO device_option's set
+    # if we don't pass device_option here, then this function will return a new init_net with NO
+    # device_option's set
     init_net = construct_init_net_from_params(params, device_option=device_option)
 
     # Record necessary information for running the pb model in Detectron2 system.

--- a/detectron2/export/caffe2_inference.py
+++ b/detectron2/export/caffe2_inference.py
@@ -1,15 +1,249 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import collections
+import io
 import logging
+import numpy as np
 import torch
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core
 
-from .caffe2_modeling import META_ARCH_CAFFE2_EXPORT_TYPE_MAP, convert_batched_inputs_to_c2_format
-from .shared import ScopedWS, get_pb_arg_vali, get_pb_arg_vals
+from detectron2.export.caffe2_modeling import convert_batched_inputs_to_c2_format
+from detectron2.modeling.box_regression import Box2BoxTransform
+from detectron2.modeling.meta_arch.panoptic_fpn import combine_semantic_and_instance_outputs
+from detectron2.modeling.meta_arch.retinanet import RetinaNet
+from detectron2.modeling.postprocessing import detector_postprocess, sem_seg_postprocess
+from detectron2.modeling.roi_heads import keypoint_head
+from detectron2.structures import Boxes, Instances
+
+from .shared import ScopedWS, get_pb_arg_floats, get_pb_arg_valf, get_pb_arg_vali, get_pb_arg_vals
 
 logger = logging.getLogger(__name__)
+
+
+def is_valid_model_output_blob(blob):
+    return isinstance(blob, np.ndarray)
+
+
+def assemble_rcnn_outputs_by_name(image_sizes, tensor_outputs, force_mask_on=False):
+    """
+    A function to assemble caffe2 model's outputs (i.e. Dict[str, Tensor])
+    to detectron2's format (i.e. list of Instances instance).
+    This only works when the model follows the Caffe2 detectron's naming convention.
+
+    Args:
+        image_sizes (List[List[int, int]]): [H, W] of every image.
+        tensor_outputs (Dict[str, Tensor]): external_output to its tensor.
+
+        force_mask_on (Bool): if true, the it make sure there'll be pred_masks even
+            if the mask is not found from tensor_outputs (usually due to model crash)
+    """
+
+    results = [Instances(image_size) for image_size in image_sizes]
+
+    batch_splits = tensor_outputs.get("batch_splits", None)
+    if batch_splits:
+        raise NotImplementedError()
+    assert len(image_sizes) == 1
+    result = results[0]
+
+    bbox_nms = tensor_outputs["bbox_nms"]
+    score_nms = tensor_outputs["score_nms"]
+    class_nms = tensor_outputs["class_nms"]
+    # Detection will always success because Conv support 0-batch
+    assert is_valid_model_output_blob(bbox_nms)
+    assert is_valid_model_output_blob(score_nms)
+    assert is_valid_model_output_blob(class_nms)
+    result.pred_boxes = Boxes(torch.Tensor(bbox_nms))
+    result.scores = torch.Tensor(score_nms)
+    result.pred_classes = torch.Tensor(class_nms).to(torch.int64)
+
+    mask_fcn_probs = tensor_outputs.get("mask_fcn_probs", None)
+    if is_valid_model_output_blob(mask_fcn_probs):
+        # finish the mask pred
+        mask_probs_pred = torch.Tensor(mask_fcn_probs)
+        num_masks = mask_probs_pred.shape[0]
+        class_pred = result.pred_classes
+        indices = torch.arange(num_masks, device=class_pred.device)
+        mask_probs_pred = mask_probs_pred[indices, class_pred][:, None]
+        result.pred_masks = mask_probs_pred
+    elif force_mask_on:
+        # NOTE: there's no way to know the height/width of mask here, it won't be
+        # used anyway when batch size is 0, so just set them to 0.
+        result.pred_masks = torch.zeros([0, 1, 0, 0], dtype=torch.uint8)
+
+    keypoints_out = tensor_outputs.get("keypoints_out", None)
+    kps_score = tensor_outputs.get("kps_score", None)
+    if is_valid_model_output_blob(keypoints_out):
+        # keypoints_out: [N, 4, #kypoints], where 4 is in order of (x, y, score, prob)
+        keypoints_tensor = torch.Tensor(keypoints_out)
+        # NOTE: it's possible that prob is not calculated if "should_output_softmax"
+        # is set to False in HeatmapMaxKeypoint, so just using raw score, seems
+        # it doesn't affect mAP. TODO: check more carefully.
+        keypoint_xyp = keypoints_tensor.transpose(1, 2)[:, :, [0, 1, 2]]
+        result.pred_keypoints = keypoint_xyp
+    elif is_valid_model_output_blob(kps_score):
+        # keypoint heatmap to sparse data structure
+        pred_keypoint_logits = torch.Tensor(kps_score)
+        keypoint_head.keypoint_rcnn_inference(pred_keypoint_logits, [result])
+
+    return results
+
+
+class GeneralizedRCNNAssembler(object):
+    """
+    A class whose instance can assemble caffe2 model's outputs
+    """
+
+    def __init__(self):
+        pass
+
+    def post_processing(self, batched_inputs, results, image_sizes):
+        processed_results = []
+        for results_per_image, input_per_image, image_size in zip(
+            results, batched_inputs, image_sizes
+        ):
+            height = input_per_image.get("height", image_size[0])
+            width = input_per_image.get("width", image_size[1])
+            r = detector_postprocess(results_per_image, height, width)
+            processed_results.append({"instances": r})
+        return processed_results
+
+    def assemble(self, batched_inputs, c2_inputs, c2_results):
+        image_sizes = [[int(im[0]), int(im[1])] for im in c2_inputs["im_info"]]
+        results = assemble_rcnn_outputs_by_name(image_sizes, c2_results)
+        return self.post_processing(batched_inputs, results, image_sizes)
+
+
+class PanopticFPNAssembler(object):
+    def __init__(
+        self,
+        combine_on,
+        combine_overlap_threshold,
+        combine_stuff_area_limit,
+        combine_instances_confidence_threshold,
+    ):
+        self.combine_on = combine_on
+        self.combine_overlap_threshold = combine_overlap_threshold
+        self.combine_stuff_area_limit = combine_stuff_area_limit
+        self.combine_instances_confidence_threshold = combine_instances_confidence_threshold
+
+    def assemble(self, batched_inputs, c2_inputs, c2_results):
+        image_sizes = [[int(im[0]), int(im[1])] for im in c2_inputs["im_info"]]
+        detector_results = assemble_rcnn_outputs_by_name(
+            image_sizes, c2_results, force_mask_on=True
+        )
+        sem_seg_results = torch.Tensor(c2_results["sem_seg"])
+
+        processed_results = []
+        for sem_seg_result, detector_result, input_per_image, image_size in zip(
+            sem_seg_results, detector_results, batched_inputs, image_sizes
+        ):
+            height = input_per_image.get("height", image_size[0])
+            width = input_per_image.get("width", image_size[1])
+            sem_seg_r = sem_seg_postprocess(sem_seg_result, image_size, height, width)
+            detector_r = detector_postprocess(detector_result, height, width)
+
+            processed_results.append({"sem_seg": sem_seg_r, "instances": detector_r})
+
+            if self.combine_on:
+                panoptic_r = combine_semantic_and_instance_outputs(
+                    detector_r,
+                    sem_seg_r.argmax(dim=0),
+                    self.combine_overlap_threshold,
+                    self.combine_stuff_area_limit,
+                    self.combine_instances_confidence_threshold,
+                )
+                processed_results[-1]["panoptic_seg"] = panoptic_r
+        return processed_results
+
+
+class RetinaNetAssembler(object):
+    def __init__(
+        self,
+        anchor_generator,
+        box2box_transform,
+        score_threshold,
+        topk_candidates,
+        nms_threshold,
+        max_detections_per_image,
+    ):
+        # num_classes cannot be determined during initialization, it'll be filled
+        # before calling inference
+        self.num_classes = None
+
+        self.anchor_generator = anchor_generator
+        self.box2box_transform = box2box_transform
+
+        self.score_threshold = score_threshold
+        self.topk_candidates = topk_candidates
+        self.nms_threshold = nms_threshold
+        self.max_detections_per_image = max_detections_per_image
+
+    def inference_single_image(self, *args, **kwargs):
+        return RetinaNet.inference_single_image(self, *args, **kwargs)
+
+    def inference(self, *args, **kwargs):
+        return RetinaNet.inference(self, *args, **kwargs)
+
+    def assemble(self, batched_inputs, c2_inputs, c2_results):
+        c2_results = {k: torch.Tensor(v) for k, v in c2_results.items()}
+
+        image_sizes = [[int(im[0]), int(im[1])] for im in c2_inputs["im_info"]]
+
+        num_features = len([x for x in c2_results.keys() if x.startswith("box_cls_")])
+        box_cls = [c2_results["box_cls_{}".format(i)] for i in range(num_features)]
+        box_delta = [c2_results["box_delta_{}".format(i)] for i in range(num_features)]
+
+        # For each feature level, feature should have the same batch size and
+        # spatial dimension as the box_cls and box_delta.
+        dummy_features = [box_delta[i].clone()[:, 0:0, :, :] for i in range(num_features)]
+        anchors = self.anchor_generator(dummy_features)
+
+        # self.num_classess can be inferred
+        self.num_classes = box_cls[0].shape[1] // (box_delta[0].shape[1] // 4)
+
+        results = self.inference(box_cls, box_delta, anchors, image_sizes)
+        processed_results = []
+        for results_per_image, input_per_image, image_size in zip(
+            results, batched_inputs, image_sizes
+        ):
+            height = input_per_image.get("height", image_size[0])
+            width = input_per_image.get("width", image_size[1])
+            r = detector_postprocess(results_per_image, height, width)
+            processed_results.append({"instances": r})
+        return processed_results
+
+
+def best_assembler_from_predict_net(predict_net):
+    meta_arch = get_pb_arg_vals(predict_net, "meta_architecture", "GeneralizedRCNN")
+
+    if meta_arch == b"GeneralizedRCNN":
+        return GeneralizedRCNNAssembler()
+    elif meta_arch == b"PanopticFPN":
+        return PanopticFPNAssembler(
+            get_pb_arg_vali(predict_net, "combine_on", None),
+            get_pb_arg_valf(predict_net, "combine_overlap_threshold", None),
+            get_pb_arg_vali(predict_net, "combine_stuff_area_limit", None),
+            get_pb_arg_valf(predict_net, "combine_instances_confidence_threshold", None),
+        )
+    elif meta_arch == b"RetinaNet":
+        serialized_anchor_generator = io.BytesIO(
+            get_pb_arg_vals(predict_net, "serialized_anchor_generator", None)
+        )
+        anchor_generator = torch.load(serialized_anchor_generator)
+        bbox_reg_weights = get_pb_arg_floats(predict_net, "bbox_reg_weights", None)
+        box2box_transform = Box2BoxTransform(weights=tuple(bbox_reg_weights))
+        return RetinaNetAssembler(
+            anchor_generator,
+            box2box_transform,
+            get_pb_arg_valf(predict_net, "score_threshold", None),
+            get_pb_arg_vali(predict_net, "topk_candidates", None),
+            get_pb_arg_valf(predict_net, "nms_threshold", None),
+            get_pb_arg_vali(predict_net, "max_detections_per_image", None),
+        )
+
+    raise ValueError("Unsupported meta architecture: {}".format(meta_arch))
 
 
 class ProtobufModel(torch.nn.Module):
@@ -66,37 +300,28 @@ class ProtobufModel(torch.nn.Module):
 
 class ProtobufDetectionModel(torch.nn.Module):
     """
-    A class works just like a pytorch meta arch in terms of inference, but running
+    A class works just like GeneralizedRCNN in terms of inference, but running
     caffe2 model under the hood.
     """
 
-    def __init__(self, predict_net, init_net, *, convert_outputs=None):
-        """
-        Args:
-            predict_net, init_net (core.Net): caffe2 nets
-            convert_outptus (callable): a function that converts caffe2
-                outputs to the same format of the original pytorch model.
-                By default, use the one defined in the caffe2 meta_arch.
-        """
+    def __init__(self, predict_net, init_net, assembler=None):
         super().__init__()
         self.protobuf_model = ProtobufModel(predict_net, init_net)
+
         self.size_divisibility = get_pb_arg_vali(predict_net, "size_divisibility", 0)
+        self.assembler = assembler or best_assembler_from_predict_net(predict_net)
 
-        if convert_outputs is None:
-            meta_arch = get_pb_arg_vals(predict_net, "meta_architecture", b"GeneralizedRCNN")
-            meta_arch = META_ARCH_CAFFE2_EXPORT_TYPE_MAP[meta_arch.decode("ascii")]
-            self._convert_outputs = meta_arch.get_outputs_converter(predict_net, init_net)
-        else:
-            self._convert_outputs = convert_outputs
-
-    def _convert_inputs(self, batched_inputs):
-        # currently all models convert inputs in the same way
+    def forward(self, batched_inputs):
         data, im_info = convert_batched_inputs_to_c2_format(
             batched_inputs, self.size_divisibility, torch.device("cpu")
         )
-        return {"data": data, "im_info": im_info}
-
-    def forward(self, batched_inputs):
-        c2_inputs = self._convert_inputs(batched_inputs)
+        # passing in model inputs as numpy arrays works for both cpu and cuda models
+        # (notably, this is what Caffe2Model.save_graph() does as well)
+        # alternately, if we really want to pass a Tensor instead of an ndarray, one could infer whether the inputs
+        # should be torch.device("cpu") or torch.device("cuda") based on the predict_net operator(s)'s device_option,
+        # or add a input_device_option map to this function as a kwarg
+        c2_inputs = {"data": data.numpy(), "im_info": im_info.numpy()}
         c2_results = self.protobuf_model(c2_inputs)
-        return self._convert_outputs(batched_inputs, c2_inputs, c2_results)
+
+        results = self.assembler.assemble(batched_inputs, c2_inputs, c2_results)
+        return results

--- a/detectron2/export/caffe2_inference.py
+++ b/detectron2/export/caffe2_inference.py
@@ -317,9 +317,9 @@ class ProtobufDetectionModel(torch.nn.Module):
         )
         # passing in model inputs as numpy arrays works for both cpu and cuda models
         # (notably, this is what Caffe2Model.save_graph() does as well)
-        # alternately, if we really want to pass a Tensor instead of an ndarray, one could infer whether the inputs
-        # should be torch.device("cpu") or torch.device("cuda") based on the predict_net operator(s)'s device_option,
-        # or add a input_device_option map to this function as a kwarg
+        # alternately, if we really want to pass a Tensor instead of an ndarray, one could infer
+        # whether the inputs should be torch.device("cpu")/cuda based on the predict_net
+        # operator(s)'s device_option, or add a input_device_option map to this function as a kwarg
         c2_inputs = {"data": data.numpy(), "im_info": im_info.numpy()}
         c2_results = self.protobuf_model(c2_inputs)
 

--- a/detectron2/export/model_convert_utils_2.py
+++ b/detectron2/export/model_convert_utils_2.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##############################################################################
+
+'''Helper functions for model conversion to pb'''
+# This is a copy+paste from Detectron:
+#   PinDetectron/detectron/utils/model_convert_utils.py
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from functools import wraps
+import copy
+import numpy as np
+
+from caffe2.python import core, workspace
+from caffe2.proto import caffe2_pb2
+
+
+class OpFilter(object):
+    def __init__(self, **kwargs):
+        self.type = None
+        self.type_in = None
+        self.inputs = None
+        self.outputs = None
+        self.input_has = None
+        self.output_has = None
+        self.cond = None
+        self.reverse = False
+
+        assert all([x in self.__dict__ for x in kwargs])
+        self.__dict__.update(kwargs)
+
+    def check(self, op):
+        ret = self.reverse
+        if self.type and op.type != self.type:
+            return ret
+        if self.type_in and op.type not in self.type_in:
+            return ret
+        if self.inputs and set(op.input) != set(self.inputs):
+            return ret
+        if self.outputs and set(op.output) != set(self.outputs):
+            return ret
+        if self.input_has and self.input_has not in op.input:
+            return ret
+        if self.output_has and self.output_has not in op.output:
+            return ret
+        if self.cond is not None and not self.cond:
+            return ret
+        return not ret
+
+
+def filter_op(op, **kwargs):
+    ''' Returns true if passed all checks '''
+    return OpFilter(**kwargs).check(op)
+
+
+def op_filter(**filter_args):
+    ''' Returns None if no condition is satisfied '''
+    def actual_decorator(f):
+        @wraps(f)
+        def wrapper(op, **params):
+            if not filter_op(op, **filter_args):
+                return None
+            return f(op, **params)
+        return wrapper
+    return actual_decorator
+
+
+def op_func_chain(convert_func_list):
+    ''' Run funcs one by one until func return is not None '''
+    assert isinstance(convert_func_list, list)
+
+    def _chain(op):
+        for x in convert_func_list:
+            ret = x(op)
+            if ret is not None:
+                return ret
+        return None
+
+    return _chain
+
+
+def convert_op_in_ops(ops_ref, func_or_list):
+    func = func_or_list
+    if isinstance(func_or_list, list):
+        func = op_func_chain(func_or_list)
+    ops = [op for op in ops_ref]
+    converted_ops = []
+    for op in ops:
+        new_ops = func(op)
+        if new_ops is not None and not isinstance(new_ops, list):
+            new_ops = [new_ops]
+        converted_ops.extend(new_ops if new_ops is not None else [op])
+    del ops_ref[:]
+    # ops_ref maybe of type RepeatedCompositeFieldContainer
+    # which does not have append()
+    ops_ref.extend(converted_ops)
+
+
+def convert_op_in_proto(proto, func_or_list):
+    convert_op_in_ops(proto.op, func_or_list)
+
+
+def get_op_arg(op, arg_name):
+    for x in op.arg:
+        if x.name == arg_name:
+            return x
+    return None
+
+
+def get_op_arg_valf(op, arg_name, default_val):
+    arg = get_op_arg(op, arg_name)
+    return arg.f if arg is not None else default_val
+
+
+def update_mobile_engines(net):
+    for op in net.op:
+        if op.type == "Conv":
+            op.engine = "NNPACK"
+        if op.type == "ConvTranspose":
+            op.engine = "BLOCK"
+
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    from itertools import tee
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+def blob_uses(net, blob):
+    u = []
+    for i, op in enumerate(net.op):
+        if blob in op.input or blob in op.control_input:
+            u.append(i)
+    return u
+
+
+def fuse_first_affine(net, params, removed_tensors):
+    net = copy.deepcopy(net)
+    params = copy.deepcopy(params)
+
+    for ((i, current), (j, next_)) in pairwise(enumerate(net.op)):
+        if next_.input[0] != current.output[0]:
+            continue
+
+        if current.type not in ("Conv", "ConvTranspose") \
+           or next_.type != "AffineChannel":
+            continue
+        if current.output[0] != next_.output[0] and \
+                len(blob_uses(net, current.output[0])) != 1:
+            # Can't fuse if more than one user unless AffineChannel is inplace
+            continue
+
+        # else, can fuse
+        conv = current
+        affine = next_
+        fused_conv = copy.deepcopy(conv)
+        fused_conv.output[0] = affine.output[0]
+        conv_weight = params[conv.input[1]]
+        conv_has_bias = len(conv.input) > 2
+        conv_bias = params[conv.input[2]] if conv_has_bias else 0
+
+        A = params[affine.input[1]]
+        B = params[affine.input[2]]
+
+        # Thus, can just have the affine transform
+        # X * A + B
+        # where
+        # A = bn_scale * 1.0 / (sqrt(running_var + eps))
+        # B =  (bias - running_mean * (1.0 / sqrt(running_var + eps))
+        # * bn_scale)
+
+        # This identify should hold if we have correctly fused
+        # np.testing.assert_array_equal(
+        #     params[conv.output[0]] * A + B,
+        #     params[bn.output[0]])
+
+        # Now, we have that the computation made is the following:
+        # ((X `conv` W) + b) * A + B
+        # Then, we can simply fuse this as follows:
+        # (X `conv` (W * A)) + b * A + B
+        # which is simply
+        # (X `conv` Q) + C
+        # where
+
+        # Q = W * A
+        # C = b * A + B
+
+        # For ConvTranspose, from the view of convolutions as a
+        # Toepeliz multiplication, we have W_ = W^T, so the weights
+        # are laid out as (R, S, K, K) (vs (S, R, K, K) for a Conv),
+        # so the weights broadcast slightly differently. Remember, our
+        # BN scale 'B' is of size (S,)
+
+        A_ = A.reshape(-1, 1, 1, 1) if conv.type == "Conv" else \
+            A.reshape(1, -1, 1, 1)
+
+        C = conv_bias * A + B
+        Q = conv_weight * A_
+
+        assert params[conv.input[1]].shape == Q.shape
+
+        params[conv.input[1]] = Q
+        if conv_has_bias:
+            assert params[conv.input[2]].shape == C.shape
+            params[conv.input[2]] = C
+        else:
+            # make af_bias to be bias of the conv layer
+            fused_conv.input.append(affine.input[2])
+            params[affine.input[2]] = B
+
+        new_ops = net.op[:i] + [fused_conv] + net.op[j + 1:]
+        del net.op[:]
+        if conv_has_bias:
+            del params[affine.input[2]]
+            removed_tensors.append(affine.input[2])
+        removed_tensors.append(affine.input[1])
+        del params[affine.input[1]]
+        net.op.extend(new_ops)
+        break
+    return net, params, removed_tensors
+
+
+def fuse_affine(net, params, ignore_failure):
+    # Run until we hit a fixed point
+    removed_tensors = []
+    while True:
+        (next_net, next_params, removed_tensors) = \
+            fuse_first_affine(net, params, removed_tensors)
+        if len(next_net.op) == len(net.op):
+            if (
+                any(op.type == "AffineChannel" for op in next_net.op) and
+                not ignore_failure
+            ):
+                raise Exception(
+                    "Model contains AffineChannel op after fusion: %s", next_net)
+            return (next_net, next_params, removed_tensors)
+        net, params, removed_tensors = (next_net, next_params, removed_tensors)
+
+
+def fuse_net(fuse_func, net, blobs, ignore_failure=False):
+    is_core_net = isinstance(net, core.Net)
+    if is_core_net:
+        net = net.Proto()
+
+    net, params, removed_tensors = fuse_func(net, blobs, ignore_failure)
+    for rt in removed_tensors:
+        net.external_input.remove(rt)
+
+    if is_core_net:
+        net = core.Net(net)
+
+    return net, params
+
+
+def fuse_net_affine(net, blobs):
+    return fuse_net(fuse_affine, net, blobs)
+
+
+def add_tensor(net, name, blob):
+    ''' Create an operator to store the tensor 'blob',
+        run the operator to put the blob to workspace.
+        uint8 is stored as an array of string with one element.
+    '''
+    kTypeNameMapper = {
+        np.dtype('float32'): "GivenTensorFill",
+        np.dtype('int32'): "GivenTensorIntFill",
+        np.dtype('int64'): "GivenTensorInt64Fill",
+        np.dtype('uint8'): "GivenTensorStringFill",
+    }
+
+    shape = blob.shape
+    values = blob
+    # pass array of uint8 as a string to save storage
+    # storing uint8_t has a large overhead for now
+    if blob.dtype == np.dtype('uint8'):
+        shape = [1]
+        values = [str(blob.data)]
+
+    op = core.CreateOperator(
+        kTypeNameMapper[blob.dtype],
+        [], [name],
+        shape=shape,
+        values=values,
+        # arg=[
+        #     putils.MakeArgument("shape", shape),
+        #     putils.MakeArgument("values", values),
+        # ]
+    )
+    net.op.extend([op])
+
+
+def gen_init_net_from_blobs(blobs, blobs_to_use=None, excluded_blobs=None):
+    ''' Generate an initialization net based on a blob dict '''
+    ret = caffe2_pb2.NetDef()
+    if blobs_to_use is None:
+        blobs_to_use = {x for x in blobs}
+    else:
+        blobs_to_use = copy.deepcopy(blobs_to_use)
+    if excluded_blobs is not None:
+        blobs_to_use = [x for x in blobs_to_use if x not in excluded_blobs]
+    for name in blobs_to_use:
+        blob = blobs[name]
+        if isinstance(blob, str):
+            print('Blob {} with type {} is not supported in generating init net,'
+                  ' skipped.'.format(name, type(blob)))
+            continue
+        add_tensor(ret, name, blob)
+
+    return ret
+
+
+def get_ws_blobs(blob_names=None):
+    ''' Get blobs in 'blob_names' in the default workspace,
+        get all blobs if blob_names is None '''
+    blobs = {}
+    if blob_names is None:
+        blob_names = workspace.Blobs()
+    blobs = {x: workspace.FetchBlob(x) for x in blob_names}
+
+    return blobs
+
+
+def get_device_option_cpu():
+    device_option = core.DeviceOption(caffe2_pb2.CPU)
+    return device_option
+
+
+def get_device_option_cuda(gpu_id=0):
+    device_option = caffe2_pb2.DeviceOption()
+    device_option.device_type = caffe2_pb2.CUDA
+    device_option.device_id = gpu_id
+    return device_option
+
+
+def create_input_blobs_for_net(net_def):
+    for op in net_def.op:
+        for blob_in in op.input:
+            if not workspace.HasBlob(blob_in):
+                workspace.CreateBlob(blob_in)
+
+
+def compare_model(model1_func, model2_func, test_image, check_blobs):
+    ''' model_func(test_image, check_blobs)
+    '''
+    cb1, cb2 = check_blobs, check_blobs
+    if isinstance(check_blobs, dict):
+        cb1 = check_blobs.keys()
+        cb2 = check_blobs.values()
+    print('Running the first model...')
+    res1 = model1_func(test_image, check_blobs)
+    print('Running the second model...')
+    res2 = model2_func(test_image, check_blobs)
+    for idx in range(len(cb1)):
+        print('Checking {} -> {}...'.format(cb1[idx], cb2[idx]))
+        n1, n2 = cb1[idx], cb2[idx]
+        r1 = res1[n1] if n1 in res1 else None
+        r2 = res2[n2] if n2 in res2 else None
+        assert r1 is not None or r2 is None, \
+            "Blob {} in model1 is None".format(n1)
+        assert r2 is not None or r1 is None, \
+            "Blob {} in model2 is None".format(n2)
+        assert r1.shape == r2.shape, \
+            "Blob {} and {} shape mismatched: {} vs {}".format(
+                n1, n2, r1.shape, r2.shape)
+
+        np.testing.assert_array_almost_equal(
+            r1, r2, decimal=3,
+            err_msg='{} and {} not matched. Max diff: {}'.format(
+                n1, n2, np.amax(np.absolute(r1 - r2))))
+
+    return True
+
+
+# graph_name could not contain word 'graph'
+def save_graph(net, file_name, graph_name="net", op_only=True):
+    from caffe2.python import net_drawer
+    graph = None
+    ops = net.op
+    if not op_only:
+        graph = net_drawer.GetPydotGraph(
+            ops, graph_name,
+            rankdir="TB")
+    else:
+        graph = net_drawer.GetPydotGraphMinimal(
+            ops, graph_name,
+            rankdir="TB", minimal_dependency=True)
+
+    try:
+        graph.write_png(file_name)
+    except Exception as e:
+        print('Error when writing graph to image {}'.format(e))
+
+
+def convert_model_gpu(net, init_net):
+    """Given a predict/init net with no device_option's set, eg a CPU only model, this upgrades the predict/init nets
+    to run on the GPU device.
+    In summary, this performs:
+    (1) init_net: Set device_option's for parameter-populating ops to the GPU device
+    (2) predict_net: Set device_option's to GPU/CPU as appropriate, and also add CopyCPUToGPU/CopyGPUToCPU ops
+        as appropriate
+    Copied+modified from: Detectron/tools/convert_pkl_to_pb.py
+    Args:
+        net (core.Net): A predict net, containing inference operators.
+        init_net (core.Net): An init net, containing parameter-blob populating operators.
+    Returns:
+        predict_net_out (core.Net):
+        init_net_out (core.Net):
+    """
+    ret_net = copy.deepcopy(net)
+    ret_init_net = copy.deepcopy(init_net)
+
+    cdo_cuda = get_device_option_cuda()
+    cdo_cpu = get_device_option_cpu()
+
+    # Caffe2 operators that only have a CPU implementation, eg no GPU implementation
+    CPU_OPS = [
+        # Detectron
+        ["CollectAndDistributeFpnRpnProposals", None],
+        ["GenerateProposals", None],
+        ["BBoxTransform", None],
+        ["BoxWithNMSLimit", None],
+        ["Slice", None],
+        ["FlattenToVec", None],
+        ["Negative", None],
+        ["Cast", None],
+        ["Shape", None],
+        ["FlexibleTopK", None],
+        ["Gather", None],
+        # Detectron2
+        ["CollectRpnProposals", None],
+        ["DistributeFpnProposals", None]
+    ]
+    # Blobs that reside on CPU memory
+    CPU_BLOBS = ["im_info", "anchor"]
+
+    @op_filter()
+    def convert_op_gpu(op):
+        for x in CPU_OPS:
+            if filter_op(op, type=x[0], inputs=x[1]):
+                op.device_option.CopyFrom(cdo_cpu)
+                return None
+        op.device_option.CopyFrom(cdo_cuda)
+        return [op]
+
+    @op_filter()
+    def convert_init_op_gpu(op):
+        if op.output[0] in CPU_BLOBS:
+            op.device_option.CopyFrom(cdo_cpu)
+        else:
+            op.device_option.CopyFrom(cdo_cuda)
+        return [op]
+
+    convert_op_in_proto(ret_init_net.Proto(), convert_init_op_gpu)
+    convert_op_in_proto(ret_net.Proto(), convert_op_gpu)
+
+    ret = core.InjectDeviceCopiesAmongNets([ret_init_net, ret_net])
+
+    return [ret[0][1], ret[0][0]]

--- a/detectron2/export/model_convert_utils_2.py
+++ b/detectron2/export/model_convert_utils_2.py
@@ -404,13 +404,13 @@ def save_graph(net, file_name, graph_name="net", op_only=True):
 
 
 def convert_model_gpu(net, init_net):
-    """Given a predict/init net with no device_option's set, eg a CPU only model, this upgrades the predict/init nets
-    to run on the GPU device.
+    """Given a predict/init net with no device_option's set, eg a CPU only model, this upgrades the
+    predict/init nets to run on the GPU device.
     In summary, this performs:
     (1) init_net: Set device_option's for parameter-populating ops to the GPU device
-    (2) predict_net: Set device_option's to GPU/CPU as appropriate, and also add CopyCPUToGPU/CopyGPUToCPU ops
-        as appropriate
-    Copied+modified from: Detectron/tools/convert_pkl_to_pb.py
+    (2) predict_net: Set device_option's to GPU/CPU as appropriate, and also add CopyCPUToGPU,
+        CopyGPUToCPU ops appropriate
+    Copied + modified from: Detectron/tools/convert_pkl_to_pb.py
     Args:
         net (core.Net): A predict net, containing inference operators.
         init_net (core.Net): An init net, containing parameter-blob populating operators.

--- a/projects/DensePose/densepose/structures.py
+++ b/projects/DensePose/densepose/structures.py
@@ -158,7 +158,7 @@ class DensePoseDataRelative(object):
         pt_label_symmetries = dp_transform_data.point_label_symmetries
         for i in range(self.N_PART_LABELS):
             if i + 1 in i_old:
-                annot_indices_i = (i_old == i + 1)
+                annot_indices_i = i_old == i + 1
                 if pt_label_symmetries[i + 1] != i + 1:
                     self.i[annot_indices_i] = pt_label_symmetries[i + 1]
                 u_loc = (self.u[annot_indices_i] * 255).long()

--- a/tools/caffe2_converter.py
+++ b/tools/caffe2_converter.py
@@ -1,6 +1,12 @@
 import argparse
+import io
 import os
+import requests
+import time
 
+from PIL import Image
+import numpy as np
+import torchvision
 from detectron2.checkpoint import DetectionCheckpointer
 from detectron2.config import get_cfg
 from detectron2.data import build_detection_test_loader
@@ -8,15 +14,124 @@ from detectron2.evaluation import COCOEvaluator, inference_on_dataset, print_csv
 from detectron2.export import add_export_config, export_caffe2_model
 from detectron2.modeling import build_model
 from detectron2.utils.logger import setup_logger
+from detectron2.model_zoo import get_checkpoint_url
+from detectron2.model_zoo import get_config_file
+
+"""
+CLI tool to export a Detectron2 pytorch model to Caffe2 protobuf init+predict nets. Supports cpu and cuda devices.
+
+Tip: when using --from-model-zoo, config-file should be relative to detectron2/configs, eg:
+    --config-file COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml
+
+Example usage:
+
+# (cuda) Download a pretrained Detectron2 pytorch model from the model zoo, and export it to Caffe2
+$ python3.6 tools/caffe2_converter.py \
+    --config-file COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml \
+    --output /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda \
+    --from-model-zoo \
+    --test-image-path https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg \
+    MODEL.DEVICE cuda
+
+To export to cpu device, set MODEL.DEVICE to cpu.
+"""
 
 
-def setup_cfg(args):
+def _create_and_setup_cfg(config_path, opts):
+    """Creates and initializes a Detectron2 Config.
+    Args:
+        config_path (str):
+        opts (list[str]): List of Config options. Overrides the values in config_path.
+            Example: ["MODEL.DEVICE", "cpu", "DATASETS.TEST", "('my_test_set',)"]
+    Returns:
+        config:
+    """
     cfg = get_cfg()
     cfg = add_export_config(cfg)
-    cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
+    cfg.merge_from_file(config_path)
+    cfg.merge_from_list(opts)
     cfg.freeze()
     return cfg
+
+
+def _download_image_to_pil(image_url):
+    """Downloads an image from a URL.
+    Args:
+        image_url (str): Target image to download.
+    Returns:
+        image (PIL.Image): Image in PIL form.
+    """
+    response = requests.get(image_url)
+    return Image.open(io.BytesIO(response.content))
+
+
+def is_url(path):
+    """Returns True if path is a URL.
+    Args:
+        path (str):
+            Example: "http://foo/bar.jpg"
+    Returns:
+        out (bool):
+    """
+    # simple heuristic
+    path_lower = path.lower()
+    return path_lower.startswith("http://") or path_lower.startswith("https://")
+
+
+def _build_batch_from_image_path(test_image_path):
+    """Builds a batch from an image path.
+    Args:
+        test_image_path (str): Can either be a local path to an image, or an image URL.
+    Returns:
+        first_batch (list[dict]):
+    """
+    if is_url(test_image_path):
+        test_image_pil = _download_image_to_pil(test_image_path)
+    else:
+        test_image_pil = Image.open(test_image_path)
+
+    # torchvision ToTensor() scales pixel values from [0,255] to [0,1]. Detection data loaders do not perform
+    # this scaling, so undo it.
+    # Return image as float32, to avoid unnecessary Cast ops in caffe2 exported model
+    test_image_tensor = torchvision.transforms.ToTensor()(test_image_pil).float() * 255.0  # [C, H, W]
+    first_batch = [
+        {
+            "file_name": test_image_path,
+            "width": test_image_pil.size[0],
+            "height": test_image_pil.size[1],
+            "image_id": 0,
+            "image": test_image_tensor
+        }
+    ]
+    return first_batch
+
+
+def infer_and_record_latency(caffe2_model, first_batch, nb_trials=25):
+    """Performs an inference benchmark, and logs the model output.
+    Args:
+        caffe2_model:
+        first_batch (list[dict]):
+        nb_trials (int):
+    Returns:
+        model_output:
+        tocs (list[float]): Inference latencies for each trial. Length should be nb_trials.
+    """
+    logger.info("Running inference benchmark on: {}".format(first_batch[0]["file_name"]))
+    # warm up
+    for _ in range(10):
+        caffe2_model(first_batch)
+    # perform benchmark
+    tocs = []
+    for _ in range(nb_trials):
+        tic_i = time.time()
+        caffe2_model(first_batch)
+        tocs.append(time.time() - tic_i)
+    model_output = caffe2_model(first_batch)
+    logger.info("model_output: {}".format(model_output))
+    logger.info("inference latency: mn={:.4f}s std={:.4f}s min={:.4f}s max={:.4f}s ({} trials)".format(
+        np.mean(tocs), np.std(tocs), np.min(tocs), np.max(tocs), nb_trials
+    ))
+    return model_output, tocs
 
 
 if __name__ == "__main__":
@@ -24,6 +139,16 @@ if __name__ == "__main__":
     parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
     parser.add_argument("--run-eval", action="store_true")
     parser.add_argument("--output", help="output directory for the converted caffe2 model")
+    parser.add_argument("--from-model-zoo", action="store_true",
+                        help="Optional. If set, this will load the config and model snapshot weights from the "
+                             "Detectron2 model zoo API. --config-file should refer to a config file relative to "
+                             "detectron2/configs, eg 'configs/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml'")
+    parser.add_argument("--test-image-path",
+                        help="Optional. Use a provided image as the sample image used to trace the model during "
+                             "conversion. Can be either a local image path or a URL. Overrides the DATASETS.TEST "
+                             "behavior")
+    parser.add_argument("--skip-infer-benchmark", action="store_true",
+                        help="Skips the inference benchmark after model export")
     parser.add_argument(
         "opts",
         help="Modify config options using the command-line",
@@ -34,21 +159,54 @@ if __name__ == "__main__":
     logger = setup_logger()
     logger.info("Command line arguments: " + str(args))
 
-    cfg = setup_cfg(args)
+    tic_start = time.time()
+
+    # Create Config
+    opts = list(args.opts)
+    if args.from_model_zoo:
+        # Use Detectron2 model zoo API to retrieve Config and model snapshot
+        local_config_fullpath = get_config_file(args.config_file)
+        model_snapshot_url = get_checkpoint_url(args.config_file)
+        assert "MODEL.WEIGHTS" not in opts
+        opts.extend(["MODEL.WEIGHTS", model_snapshot_url])
+    else:
+        # directly use local config file
+        local_config_fullpath = args.config_file
+    if not os.path.isfile(local_config_fullpath):
+        raise OSError("Could not find config file: {}".format(local_config_fullpath))
+    if "MODEL.WEIGHTS" not in opts:
+        # For most usecases, the user should pass MODEL.WEIGHTS in the CLI opts to point to their trained weights.
+        # Most config files have MODEL.WEIGHTS set to the backbone weights only, eg ResNet101 trained on ImageNet.
+        logger.info(
+            "Warning: MODEL.WEIGHTS was not passed in CLI. Take care to ensure that MODEL.WEIGHTS in the config file "
+            "points to your trained weights, otherwise your exported model will contain uninitialized weights!")
+    logger.info("Creating config from: {}, with opts={}".format(local_config_fullpath, opts))
+    cfg = _create_and_setup_cfg(local_config_fullpath, opts)
+    logger.info("Exporting model for {} device, using weights from {}".format(cfg.MODEL.DEVICE, cfg.MODEL.WEIGHTS))
+
+    # Create sample image to run detector on during conversion ("first_batch")
+    if args.test_image_path:
+        # (simple) use a single image
+        logger.info("Using test_image_path={}".format(args.test_image_path))
+        first_batch = _build_batch_from_image_path(args.test_image_path)
+    else:
+        # get a sample data from the test set
+        data_loader = build_detection_test_loader(cfg, cfg.DATASETS.TEST[0])
+        first_batch = next(iter(data_loader))
 
     # create a torch model
     torch_model = build_model(cfg)
     DetectionCheckpointer(torch_model).resume_or_load(cfg.MODEL.WEIGHTS)
-
-    # get a sample data
-    data_loader = build_detection_test_loader(cfg, cfg.DATASETS.TEST[0])
-    first_batch = next(iter(data_loader))
 
     # convert and save caffe2 model
     caffe2_model = export_caffe2_model(cfg, torch_model, first_batch)
     caffe2_model.save_protobuf(args.output)
     # draw the caffe2 graph
     caffe2_model.save_graph(os.path.join(args.output, "model_def.svg"), inputs=first_batch)
+
+    if not args.skip_infer_benchmark:
+        # run model on sample image
+        infer_and_record_latency(caffe2_model, first_batch)
 
     # run evaluation with the converted model
     if args.run_eval:
@@ -58,3 +216,4 @@ if __name__ == "__main__":
         evaluator = COCOEvaluator(dataset, cfg, True, args.output)
         metrics = inference_on_dataset(caffe2_model, data_loader, evaluator)
         print_csv_format(metrics)
+    logger.info("Done ({:.4f}s)".format(time.time() - tic_start))

--- a/tools/caffe2_converter.py
+++ b/tools/caffe2_converter.py
@@ -19,7 +19,8 @@ import requests
 
 
 """
-CLI tool to export a Detectron2 pytorch model to Caffe2 protobuf init+predict nets. Supports cpu and cuda devices.
+CLI tool to export a Detectron2 pytorch model to Caffe2 protobuf init+predict nets. Supports cpu
+and cuda devices.
 
 Tip: when using --from-model-zoo, config-file should be relative to detectron2/configs, eg:
     --config-file COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml
@@ -91,8 +92,8 @@ def _build_batch_from_image_path(test_image_path):
     else:
         test_image_pil = Image.open(test_image_path)
 
-    # torchvision ToTensor() scales pixel values from [0,255] to [0,1]. Detection data loaders do not perform
-    # this scaling, so undo it.
+    # torchvision ToTensor() scales pixel values from [0,255] to [0,1]. Detection data loaders do
+    # not perform this scaling, so undo it.
     # Return image as float32, to avoid unnecessary Cast ops in caffe2 exported model
     test_image_tensor = (
         torchvision.transforms.ToTensor()(test_image_pil).float() * 255.0
@@ -188,11 +189,14 @@ if __name__ == "__main__":
     if not os.path.isfile(local_config_fullpath):
         raise OSError("Could not find config file: {}".format(local_config_fullpath))
     if "MODEL.WEIGHTS" not in opts:
-        # For most usecases, the user should pass MODEL.WEIGHTS in the CLI opts to point to their trained weights.
-        # Most config files have MODEL.WEIGHTS set to the backbone weights only, eg ResNet101 trained on ImageNet.
+        # For most usecases, the user should pass MODEL.WEIGHTS in the CLI opts to point to their
+        # trained weights.
+        # Most config files have MODEL.WEIGHTS set to the backbone weights only, eg ResNet101
+        # trained on ImageNet.
         logger.info(
-            "Warning: MODEL.WEIGHTS was not passed in CLI. Take care to ensure that MODEL.WEIGHTS in the config file "
-            "points to your trained weights, otherwise your exported model will contain uninitialized weights!"
+            "Warning: MODEL.WEIGHTS was not passed in CLI. Take care to ensure that MODEL.WEIGHTS"
+            "in the config file points to your trained weights, otherwise your exported model will "
+            "contain uninitialized weights!"
         )
     logger.info("Creating config from: {}, with opts={}".format(local_config_fullpath, opts))
     cfg = _create_and_setup_cfg(local_config_fullpath, opts)


### PR DESCRIPTION
Summary: The pytorch->onnx->Caffe2 conversion tooling currently does not support exporting Detectron2 models to Caffe2 init/predict nets for the cuda (gpu) device. This PR adds cuda support to the conversion tooling.

* Proof of PR correctness

I successfully ran the caffe2_exporter.py tool to export a Detectron2 model (from model zoo) to Caffe2, in both cuda and cpu modes:

(1) cuda device

```
$ python3.6 tools/caffe2_converter.py     --config-file COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml     --output /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda     --from-model-zoo     --test-image-path https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg     MODEL.DEVICE cuda > /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda/log.txt 2>&1
```

output:
```
[32m[01/10 07:25:51 detectron2]: [0mCommand line arguments: Namespace(config_file='COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml', from_model_zoo=True, opts=['MODEL.DEVICE', 'cuda'], output='/data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda_opexporttypeonnx', run_eval=False, skip_infer_benchmark=False, test_image_path='https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg')
[32m[01/10 07:25:51 detectron2]: [0mCreating config from: /opt/PinDetectron2/detectron2/model_zoo/configs/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml, with opts=['MODEL.DEVICE', 'cuda', 'MODEL.WEIGHTS', 'https://dl.fbaipublicfiles.com/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl']
[32m[01/10 07:25:51 detectron2]: [0mExporting model for cuda device, using weights from https://dl.fbaipublicfiles.com/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl
[32m[01/10 07:25:51 detectron2]: [0mUsing test_image_path=https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg
[32m[01/10 07:25:56 d2.export.caffe2_export]: [0mExporting a Caffe2GeneralizedRCNN model via ONNX ...
[32m[01/10 07:27:14 d2.export.caffe2_export]: [0mONNX export Done.
[32m[01/10 07:27:33 d2.export.caffe2_export]: [0mOperators used in predict_net: 
 127x Conv
 107x Relu
  36x Add
  28x Cast
  18x CopyGPUToCPU
   8x CopyCPUToGPU
   5x GenerateProposals
   4x FC
   4x RoIAlign
   3x ResizeNearest
   2x MaxPool
   1x BBoxTransform
   1x BatchPermutation
   1x BoxWithNMSLimit
   1x CollectRpnProposals
   1x Concat
   1x DistributeFpnProposals
   1x Div
   1x Flatten
   1x Softmax
   1x Sub
[32m[01/10 07:27:33 d2.export.caffe2_export]: [0mOperators used in init_net: 
 245x GivenTensorFill
[32m[01/10 07:27:33 d2.export.api]: [0mSaving model to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda_opexporttypeonnx ...
[32m[01/10 07:27:37 d2.export.caffe2_export]: [0mSaving graph of ONNX exported model to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda_opexporttypeonnx/model_def.svg ...
[32m[01/10 07:27:40 d2.export.caffe2_export]: [0mRunning ONNX exported model ...
[32m[01/10 07:27:47 d2.export.caffe2_export]: [0mSaving graph with blob shapes to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cuda_opexporttypeonnx/model_def.svg ...
[32m[01/10 07:27:50 detectron2]: [0mRunning inference benchmark on: https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg
[32m[01/10 07:27:50 d2.export.caffe2_inference]: [0mInitializing ProtobufModel ...
[32m[01/10 07:27:58 detectron2]: [0mmodel_output: [{'instances': Instances(num_instances=3, image_height=384, image_width=512, fields=[pred_boxes = Boxes(tensor([[132.9581, 125.0548, 510.1971, 381.6506],
        [  8.3807, 129.7021, 171.5774, 363.3076],
        [312.2091, 171.7258, 355.0722, 202.3485]])), scores = tensor([0.9990, 0.9752, 0.1274]), pred_classes = tensor([ 0, 16, 45]), ])}]
[32m[01/10 07:27:58 detectron2]: [0minference latency: mn=0.0683s std=0.0012s min=0.0669s max=0.0698s (25 trials)
[32m[01/10 07:27:58 detectron2]: [0mDone (127.0172s)
/usr/local/lib/python3.6/site-packages/torch/onnx/utils.py:206: UserWarning: `add_node_names' can be set to True only when 'operator_export_type' is `ONNX`. Since 'operator_export_type' is not set to 'ONNX', `add_node_names` argument will be ignored.
  "`{}` argument will be ignored.".format(arg_name, arg_name))
/usr/local/lib/python3.6/site-packages/torch/onnx/utils.py:206: UserWarning: `do_constant_folding' can be set to True only when 'operator_export_type' is `ONNX`. Since 'operator_export_type' is not set to 'ONNX', `do_constant_folding` argument will be ignored.
  "`{}` argument will be ignored.".format(arg_name, arg_name))
/opt/PinDetectron2/detectron2/export/c10.py:29: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert tensor.dim() == 2 and tensor.size(-1) in [4, 5], tensor.size()
/opt/PinDetectron2/detectron2/export/c10.py:92: TracerWarning: Converting a tensor to a Python index might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  return len(self.indices)
/opt/PinDetectron2/detectron2/export/c10.py:346: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert box_regression.shape[1] % 4 == 0
/opt/PinDetectron2/detectron2/export/c10.py:355: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if not input_tensor_mode
/opt/PinDetectron2/detectron2/export/c10.py:361: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if not input_tensor_mode:
/opt/PinDetectron2/detectron2/export/c10.py:404: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  legacy_plus_one=False,
/usr/local/lib/python3.6/site-packages/torch/tensor.py:461: RuntimeWarning: Iterating over a tensor might cause the trace to be incorrect. Passing a tensor of different shape won't change the number of iterations executed (and might lead to errors or silently give incorrect results).
  'incorrect results).', category=RuntimeWarning)
/opt/PinDetectron2/detectron2/export/c10.py:418: TracerWarning: Converting a tensor to a Python number might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  for i, b in enumerate(int(x.item()) for x in roi_batch_splits_nms)
```

(2) cpu device

```
$ python3.6 tools/caffe2_converter.py     --config-file COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml     --output /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu     --from-model-zoo     --test-image-path https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg     MODEL.DEVICE cpu > /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu/log.txt 2>&1
```
output:
```
[32m[01/10 07:22:59 detectron2]: [0mCommand line arguments: Namespace(config_file='COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml', from_model_zoo=True, opts=['MODEL.DEVICE', 'cpu'], output='/data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu_opexporttypeonnx/', run_eval=False, skip_infer_benchmark=False, test_image_path='https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg')
[32m[01/10 07:22:59 detectron2]: [0mCreating config from: /opt/PinDetectron2/detectron2/model_zoo/configs/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml, with opts=['MODEL.DEVICE', 'cpu', 'MODEL.WEIGHTS', 'https://dl.fbaipublicfiles.com/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl']
[32m[01/10 07:22:59 detectron2]: [0mExporting model for cpu device, using weights from https://dl.fbaipublicfiles.com/detectron2/COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl
[32m[01/10 07:22:59 detectron2]: [0mUsing test_image_path=https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg
[32m[01/10 07:23:02 d2.export.caffe2_export]: [0mExporting a Caffe2GeneralizedRCNN model via ONNX ...
[32m[01/10 07:23:34 d2.export.caffe2_export]: [0mONNX export Done.
[32m[01/10 07:23:52 d2.export.caffe2_export]: [0mOperators used in predict_net: 
 127x Conv
 107x Relu
  36x Add
   5x GenerateProposals
   4x FC
   4x RoIAlign
   3x ResizeNearest
   2x MaxPool
   1x BBoxTransform
   1x BatchPermutation
   1x BoxWithNMSLimit
   1x Cast
   1x CollectRpnProposals
   1x Concat
   1x DistributeFpnProposals
   1x Div
   1x Flatten
   1x Softmax
   1x Sub
[32m[01/10 07:23:52 d2.export.caffe2_export]: [0mOperators used in init_net: 
 245x GivenTensorFill
[32m[01/10 07:23:52 d2.export.api]: [0mSaving model to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu_opexporttypeonnx/ ...
[32m[01/10 07:23:55 d2.export.caffe2_export]: [0mSaving graph of ONNX exported model to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu_opexporttypeonnx/model_def.svg ...
[32m[01/10 07:23:57 d2.export.caffe2_export]: [0mRunning ONNX exported model ...
[32m[01/10 07:24:05 d2.export.caffe2_export]: [0mSaving graph with blob shapes to /data1/erickim/demo_caffe2_converter/faster_rcnn_X_101_32x8d_FPN_3x_cpu_opexporttypeonnx/model_def.svg ...
[32m[01/10 07:24:07 detectron2]: [0mRunning inference benchmark on: https://farm1.staticflickr.com/33/38956064_47b68504cb_z.jpg
[32m[01/10 07:24:07 d2.export.caffe2_inference]: [0mInitializing ProtobufModel ...
[32m[01/10 07:25:09 detectron2]: [0mmodel_output: [{'instances': Instances(num_instances=3, image_height=384, image_width=512, fields=[pred_boxes = Boxes(tensor([[132.9581, 125.0549, 510.1972, 381.6506],
        [  8.3807, 129.7021, 171.5774, 363.3076],
        [312.2091, 171.7258, 355.0722, 202.3485]])), scores = tensor([0.9990, 0.9752, 0.1274]), pred_classes = tensor([ 0, 16, 45]), ])}]
[32m[01/10 07:25:09 detectron2]: [0minference latency: mn=1.4884s std=0.0459s min=1.4077s max=1.5825s (25 trials)
[32m[01/10 07:25:09 detectron2]: [0mDone (129.4599s)
/usr/local/lib/python3.6/site-packages/torch/onnx/utils.py:206: UserWarning: `add_node_names' can be set to True only when 'operator_export_type' is `ONNX`. Since 'operator_export_type' is not set to 'ONNX', `add_node_names` argument will be ignored.
  "`{}` argument will be ignored.".format(arg_name, arg_name))
/usr/local/lib/python3.6/site-packages/torch/onnx/utils.py:206: UserWarning: `do_constant_folding' can be set to True only when 'operator_export_type' is `ONNX`. Since 'operator_export_type' is not set to 'ONNX', `do_constant_folding` argument will be ignored.
  "`{}` argument will be ignored.".format(arg_name, arg_name))
/opt/PinDetectron2/detectron2/export/c10.py:29: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert tensor.dim() == 2 and tensor.size(-1) in [4, 5], tensor.size()
/opt/PinDetectron2/detectron2/export/c10.py:92: TracerWarning: Converting a tensor to a Python index might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  return len(self.indices)
/opt/PinDetectron2/detectron2/export/c10.py:346: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert box_regression.shape[1] % 4 == 0
/opt/PinDetectron2/detectron2/export/c10.py:355: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if not input_tensor_mode
/opt/PinDetectron2/detectron2/export/c10.py:361: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if not input_tensor_mode:
/opt/PinDetectron2/detectron2/export/c10.py:404: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  legacy_plus_one=False,
/usr/local/lib/python3.6/site-packages/torch/tensor.py:461: RuntimeWarning: Iterating over a tensor might cause the trace to be incorrect. Passing a tensor of different shape won't change the number of iterations executed (and might lead to errors or silently give incorrect results).
  'incorrect results).', category=RuntimeWarning)
/opt/PinDetectron2/detectron2/export/c10.py:418: TracerWarning: Converting a tensor to a Python number might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  for i, b in enumerate(int(x.item()) for x in roi_batch_splits_nms)
```

* Implementation Details

* Enabling gpu device exporting

The primary change is to modify the emitted init/predict nets in the following way:
[init net]: Set all parameter-filling ops, eg `GivenTensorFill`, to run on the GPU device, eg setting `device_option`.
[predict net]: We explicitly set `op.device_option` for each operator, and take care with operators that only have CPU-only implementations, eg `BoxWithNMSLimit`. To implement this, I re-used the functionality from Detectron1, `model_convert_utils_2.py:convert_model_gpu()`, which will also insert the required `CopyGPUToCPU/CopyCPUToGPU` ops to handle the boundaries between GPU and CPU ops.

* Improvements to caffe2_converter.py

Also, this PR adds convenience improvements to the CLI tool `tools/caffe2_converter.py` to more-easily demonstrate that this PR works correctly, namely:
(1) --from-model-zoo: Convenience flag for demonstrating the Caffe2 export for Detectron2 model zoo models.
(2) --test-image-path: Convenience arg for passing a single test image (either local image path or URL) to run conversion tracing + benchmarks for. This overrides the existing DATASETS.TEST behavior, and for my usecase I found it easier to simply pass a single image, rather than set up a dummy dataset for DATASETS.TEST to parse.
(3) --skip-infer-benchmark / infer_and_record_latency: Optionally, the tool will also perform a quick inference benchmark on the sample image, reporting mean/std/min/max forward pass latencies, and also output the model predictions to stdout. This is useful as a sanity check whether the converted model is correct + running on the correct device (gpu device latencies will be far faster than cpu device latencies).

This PR address the following issues:
https://github.com/facebookresearch/detectron2/issues/666
https://github.com/facebookresearch/detectron2/issues/657
