### PR TITLE
Install opencv via pip instead of apt-get, to have the most current version.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 
 # install dependencies
 # See https://pytorch.org/ for other options if you use a different version of CUDA
-RUN pip install --user torch torchvision tensorboard cython
+RUN pip install --user torch torchvision tensorboard cython opencv-python
 RUN pip install --user 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
 
 RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'


### PR DESCRIPTION
Fixes #87. 

Although it would be reasonable to remove the apt-get installation of open cv, doing this results in an error when opencv is imported.