### PR TITLE
fix bug in coco dataset categories mapping

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -294,14 +294,11 @@ def convert_to_coco_dict(dataset_name):
     # unmap the category ids for COCO
     if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
         reverse_id_mapping = {v: k for k, v in metadata.thing_dataset_id_to_contiguous_id.items()}
-        for dataset_dict in dataset_dicts:
-            dataset_dict["category_id"] = reverse_id_mapping[dataset_dict["category_id"]]
         categories = [
             {"id": reverse_id_mapping[id], "name": name}
             for id, name in enumerate(metadata.thing_classes)
         ]
     else:
-
         categories = [{"id": id, "name": name} for id, name in enumerate(metadata.thing_classes)]
 
     logger.info("Converting dataset dicts into COCO format")
@@ -360,8 +357,10 @@ def convert_to_coco_dict(dataset_name):
             coco_annotation["image_id"] = coco_image["id"]
             coco_annotation["bbox"] = [round(float(x), 3) for x in bbox]
             coco_annotation["area"] = area
-            coco_annotation["category_id"] = annotation["category_id"]
             coco_annotation["iscrowd"] = annotation.get("iscrowd", 0)
+            coco_annotation["category_id"] = annotation["category_id"]
+            if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
+                coco_annotation["category_id"] = reverse_id_mapping(coco_annotation["category_id"])
 
             # Add optional fields
             if "keypoints" in annotation:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -294,9 +294,9 @@ def convert_to_coco_dict(dataset_name):
     # unmap the category mapping ids for COCO
     if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
         reverse_id_mapping = {v: k for k, v in metadata.thing_dataset_id_to_contiguous_id.items()}
-        reverse_id_mapper = lambda contiguous_id: reverse_id_mapping[contiguous_id]
+        reverse_id_mapper = lambda contiguous_id: reverse_id_mapping[contiguous_id] #noqa
     else:
-        reverse_id_mapper = lambda contiguous_id: contiguous_id
+        reverse_id_mapper = lambda contiguous_id: contiguous_id #noqa
 
     categories = [
         {"id": reverse_id_mapper(id), "name": name}

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -289,10 +289,20 @@ def convert_to_coco_dict(dataset_name):
     """
 
     dataset_dicts = DatasetCatalog.get(dataset_name)
-    categories = [
-        {"id": id, "name": name}
-        for id, name in enumerate(MetadataCatalog.get(dataset_name).thing_classes)
-    ]
+    metadata = MetadataCatalog.get(dataset_name)
+
+    # unmap the category ids for COCO
+    if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
+        reverse_id_mapping = {v: k for k, v in metadata.thing_dataset_id_to_contiguous_id.items()}
+        for dataset_dict in dataset_dicts:
+            dataset_dict["category_id"] = reverse_id_mapping[dataset_dict["category_id"]]
+        categories = [
+            {"id": reverse_id_mapping[id], "name": name}
+            for id, name in enumerate(metadata.thing_classes)
+        ]
+    else:
+
+        categories = [{"id": id, "name": name} for id, name in enumerate(metadata.thing_classes)]
 
     logger.info("Converting dataset dicts into COCO format")
     coco_images = []

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -291,15 +291,17 @@ def convert_to_coco_dict(dataset_name):
     dataset_dicts = DatasetCatalog.get(dataset_name)
     metadata = MetadataCatalog.get(dataset_name)
 
-    # unmap the category ids for COCO
+    # unmap the category mapping ids for COCO
     if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
         reverse_id_mapping = {v: k for k, v in metadata.thing_dataset_id_to_contiguous_id.items()}
-        categories = [
-            {"id": reverse_id_mapping[id], "name": name}
-            for id, name in enumerate(metadata.thing_classes)
-        ]
+        reverse_id_mapper = lambda contiguous_id: reverse_id_mapping[contiguous_id]
     else:
-        categories = [{"id": id, "name": name} for id, name in enumerate(metadata.thing_classes)]
+        reverse_id_mapper = lambda contiguous_id: contiguous_id
+
+    categories = [
+        {"id": reverse_id_mapper(id), "name": name}
+        for id, name in enumerate(metadata.thing_classes)
+    ]
 
     logger.info("Converting dataset dicts into COCO format")
     coco_images = []
@@ -358,9 +360,7 @@ def convert_to_coco_dict(dataset_name):
             coco_annotation["bbox"] = [round(float(x), 3) for x in bbox]
             coco_annotation["area"] = area
             coco_annotation["iscrowd"] = annotation.get("iscrowd", 0)
-            coco_annotation["category_id"] = annotation["category_id"]
-            if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
-                coco_annotation["category_id"] = reverse_id_mapping(coco_annotation["category_id"])
+            coco_annotation["category_id"] = reverse_id_mapper(annotation["category_id"])
 
             # Add optional fields
             if "keypoints" in annotation:

--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -294,9 +294,9 @@ def convert_to_coco_dict(dataset_name):
     # unmap the category mapping ids for COCO
     if hasattr(metadata, "thing_dataset_id_to_contiguous_id"):
         reverse_id_mapping = {v: k for k, v in metadata.thing_dataset_id_to_contiguous_id.items()}
-        reverse_id_mapper = lambda contiguous_id: reverse_id_mapping[contiguous_id] #noqa
+        reverse_id_mapper = lambda contiguous_id: reverse_id_mapping[contiguous_id]  # noqa
     else:
-        reverse_id_mapper = lambda contiguous_id: contiguous_id #noqa
+        reverse_id_mapper = lambda contiguous_id: contiguous_id  # noqa
 
     categories = [
         {"id": reverse_id_mapper(id), "name": name}


### PR DESCRIPTION

The function `convert_to_coco_dict` doesn't currently take into account whether there is a `thing_dataset_id_to_contiguous_id` mapping in metadata, which is inconsistent with the behavior of `COCOEvaluator` when generating coco format predictions (uses `thing_dataset_id_to_contiguous_id` for category mapping) 