### PR TITLE
Optimize summing of losses in run_step() & Fix typos

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -204,16 +204,16 @@ class SimpleTrainer(TrainerBase):
         assert self.model.training, "[SimpleTrainer] model was changed to eval mode!"
         start = time.perf_counter()
         """
-        If your want to do something with the data, you can wrap the dataloader.
+        If you want to do something with the data, you can wrap the dataloader.
         """
         data = next(self._data_loader_iter)
         data_time = time.perf_counter() - start
 
         """
-        If your want to do something with the losses, you can wrap the model.
+        If you want to do something with the losses, you can wrap the model.
         """
         loss_dict = self.model(data)
-        losses = sum(loss for loss in loss_dict.values())
+        losses = sum(loss_dict.values())
         self._detect_anomaly(losses, loss_dict)
 
         metrics_dict = loss_dict
@@ -221,7 +221,7 @@ class SimpleTrainer(TrainerBase):
         self._write_metrics(metrics_dict)
 
         """
-        If you need accumulate gradients or something similar, you can
+        If you need to accumulate gradients or something similar, you can
         wrap the optimizer with your custom `zero_grad()` method.
         """
         self.optimizer.zero_grad()

--- a/tools/plain_train_net.py
+++ b/tools/plain_train_net.py
@@ -153,7 +153,7 @@ def do_train(cfg, model, resume=False):
             storage.step()
 
             loss_dict = model(data)
-            losses = sum(loss for loss in loss_dict.values())
+            losses = sum(loss_dict.values())
             assert torch.isfinite(losses).all(), loss_dict
 
             loss_dict_reduced = {k: v.item() for k, v in comm.reduce_dict(loss_dict).items()}

--- a/tools/plain_train_net.py
+++ b/tools/plain_train_net.py
@@ -154,7 +154,8 @@ def do_train(cfg, model, resume=False):
 
             loss_dict = model(data)
             losses = sum(loss_dict.values())
-            assert torch.isfinite(losses).all(), loss_dict
+            assert torch.isfinite(losses).all()
+            assert loss_dict
 
             loss_dict_reduced = {k: v.item() for k, v in comm.reduce_dict(loss_dict).items()}
             losses_reduced = sum(loss for loss in loss_dict_reduced.values())

--- a/tools/plain_train_net.py
+++ b/tools/plain_train_net.py
@@ -154,8 +154,7 @@ def do_train(cfg, model, resume=False):
 
             loss_dict = model(data)
             losses = sum(loss_dict.values())
-            assert torch.isfinite(losses).all()
-            assert loss_dict
+            assert torch.isfinite(losses).all(), loss_dict
 
             loss_dict_reduced = {k: v.item() for k, v in comm.reduce_dict(loss_dict).items()}
             losses_reduced = sum(loss for loss in loss_dict_reduced.values())


### PR DESCRIPTION
I noticed that the `run_step()` method uses `sum(loss for loss in loss_dict.values())` which could be simplified to `sum(loss_dict.values())`. A side benefit is faster execution.
Tested locally with a `loss_dict` consisting of 32 losses:

Proposed: `482 ns ± 53.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)`
Original: `2.02 µs ± 77.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)`

Plus I fixed some typos and an assertion along the way :) 
