### PR TITLE
Make FPN work when exported to TensorRT

### DIFF
--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import math
 import fvcore.nn.weight_init as weight_init
+import torch
 import torch.nn.functional as F
 from torch import nn
 
@@ -128,7 +129,10 @@ class FPN(Backbone):
         for features, lateral_conv, output_conv in zip(
             x[1:], self.lateral_convs[1:], self.output_convs[1:]
         ):
-            top_down_features = F.interpolate(prev_features, scale_factor=2, mode="nearest")
+            # Using F.interpolate with scale_factor instead of size  creates a Gather op in the ONNX model
+            # that onnx2trt tool doesn't like. See https://github.com/onnx/onnx-tensorrt/issues/192
+            sh = torch.tensor(prev_features.shape)
+            top_down_features = F.interpolate(prev_features, size=(prev_features.shape(2) * 2, prev_features.shape(3) * 2), mode="nearest")
             lateral_features = lateral_conv(features)
             prev_features = lateral_features + top_down_features
             if self._fuse_type == "avg":

--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -129,7 +129,7 @@ class FPN(Backbone):
         for features, lateral_conv, output_conv in zip(
             x[1:], self.lateral_convs[1:], self.output_convs[1:]
         ):
-            # Using F.interpolate with scale_factor instead of size  creates a Gather op in the ONNX model
+            # Using F.interpolate with scale_factor instead of size creates a Gather op in the ONNX model
             # that onnx2trt tool doesn't like. See https://github.com/onnx/onnx-tensorrt/issues/192
             sh = torch.tensor(prev_features.shape)
             top_down_features = F.interpolate(prev_features, size=(prev_features.shape(2) * 2, prev_features.shape(3) * 2), mode="nearest")

--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -129,8 +129,9 @@ class FPN(Backbone):
         for features, lateral_conv, output_conv in zip(
             x[1:], self.lateral_convs[1:], self.output_convs[1:]
         ):
-            # Using F.interpolate with scale_factor instead of size creates a Gather op in the ONNX model
-            # that onnx2trt tool doesn't like. See https://github.com/onnx/onnx-tensorrt/issues/192
+            # Using F.interpolate with scale_factor instead of size creates a Gather op in the ONNX
+            # model that onnx2trt tool doesn't like.
+            # See https://github.com/onnx/onnx-tensorrt/issues/192
             sh = torch.tensor(prev_features.shape)
             top_down_features = F.interpolate(
                 prev_features, size=(sh[2] * 2, sh[3] * 2), mode="nearest"

--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -132,7 +132,9 @@ class FPN(Backbone):
             # Using F.interpolate with scale_factor instead of size creates a Gather op in the ONNX model
             # that onnx2trt tool doesn't like. See https://github.com/onnx/onnx-tensorrt/issues/192
             sh = torch.tensor(prev_features.shape)
-            top_down_features = F.interpolate(prev_features, size=(sh[2] * 2, sh[3] * 2), mode="nearest")
+            top_down_features = F.interpolate(
+                prev_features, size=(sh[2] * 2, sh[3] * 2), mode="nearest"
+            )
             lateral_features = lateral_conv(features)
             prev_features = lateral_features + top_down_features
             if self._fuse_type == "avg":

--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -132,7 +132,7 @@ class FPN(Backbone):
             # Using F.interpolate with scale_factor instead of size creates a Gather op in the ONNX model
             # that onnx2trt tool doesn't like. See https://github.com/onnx/onnx-tensorrt/issues/192
             sh = torch.tensor(prev_features.shape)
-            top_down_features = F.interpolate(prev_features, size=(prev_features.shape(2) * 2, prev_features.shape(3) * 2), mode="nearest")
+            top_down_features = F.interpolate(prev_features, size=(sh[2] * 2, sh[3] * 2), mode="nearest")
             lateral_features = lateral_conv(features)
             prev_features = lateral_features + top_down_features
             if self._fuse_type == "avg":


### PR DESCRIPTION
I have been working towards exporting RetinaNet to ONNX and then TensorRT. I use the onnx2trt tool to convert from the ONNX model to TensorRT, but the `F.interpolate` layers in the FPN cause the conversion to fail with an error like:
```While parsing node number 127 [Gather -> "487"]:
ERROR: /home/jack/dev3/TensorRT/parsers/onnx/onnx2trt_utils.hpp:412 In function convert_axis:
[8] Assertion failed: axis >= 0 && axis < nbDims
```
This change seems harmless for all other purposes and fixes the error. Let me know what you think as it's much easier to make the fix upstream than in my own code.