### PR TITLE
Add linear wrapper because of pytorch bug

### DIFF
--- a/detectron2/layers/__init__.py
+++ b/detectron2/layers/__init__.py
@@ -6,6 +6,6 @@ from .nms import batched_nms, batched_nms_rotated, nms, nms_rotated
 from .roi_align import ROIAlign, roi_align
 from .roi_align_rotated import ROIAlignRotated, roi_align_rotated
 from .shape_spec import ShapeSpec
-from .wrappers import BatchNorm2d, Conv2d, ConvTranspose2d, cat, interpolate
+from .wrappers import BatchNorm2d, Conv2d, ConvTranspose2d, cat, interpolate, Linear
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -161,9 +161,6 @@ else:
         Because of https://github.com/pytorch/pytorch/issues/34202
         """
 
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
         def forward(self, x):
             if x.numel() == 0:
                 output_shape = [x.shape[0], self.weight.shape[0]]

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -154,7 +154,7 @@ else:
 if TORCH_VERSION > (1, 4):
     Linear = torch.nn.Linear
 else:
-    
+
     class Linear(torch.nn.Linear):
         """
         A wrapper around :class:`torch.nn.Linear` to support empty inputs and more features.
@@ -167,7 +167,7 @@ else:
         def forward(self, x):
             if x.numel() == 0:
                 output_shape = [x.shape[0], self.weight.shape[0]]
-                
+
                 empty = _NewEmptyTensorOp.apply(x, output_shape)
                 if self.training:
                     # This is to make DDP happy.

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -151,6 +151,36 @@ else:
             return _NewEmptyTensorOp.apply(x, output_shape)
 
 
+if TORCH_VERSION > (1, 4):
+    Linear = torch.nn.Linear
+else:
+    
+    class Linear(torch.nn.Linear):
+        """
+        A wrapper around :class:`torch.nn.Linear` to support empty inputs and more features.
+        Because of https://github.com/pytorch/pytorch/issues/34202
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def forward(self, x):
+            if x.numel() == 0:
+                output_shape = [x.shape[0], self.weight.shape[0]]
+                
+                empty = _NewEmptyTensorOp.apply(x, output_shape)
+                if self.training:
+                    # This is to make DDP happy.
+                    # DDP expects all workers to have gradient w.r.t the same set of parameters.
+                    _dummy = sum(x.view(-1)[0] for x in self.parameters()) * 0.0
+                    return empty + _dummy
+                else:
+                    return empty
+
+            x = super().forward(x)
+            return x
+
+
 def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corners=None):
     """
     A wrapper around :func:`torch.nn.functional.interpolate` to support zero-size tensor.

--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -9,7 +9,6 @@ from detectron2.layers import (
     Conv2d,
     DeformConv,
     FrozenBatchNorm2d,
-    Linear,
     ModulatedDeformConv,
     ShapeSpec,
     get_norm,
@@ -362,7 +361,7 @@ class ResNet(Backbone):
 
         if num_classes is not None:
             self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
-            self.linear = Linear(curr_channels, num_classes)
+            self.linear = nn.Linear(curr_channels, num_classes)
 
             # Sec 5.1 in "Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour":
             # "The 1000-way fully-connected layer is initialized by

--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -9,10 +9,10 @@ from detectron2.layers import (
     Conv2d,
     DeformConv,
     FrozenBatchNorm2d,
+    Linear,
     ModulatedDeformConv,
     ShapeSpec,
     get_norm,
-    Linear
 )
 
 from .backbone import Backbone

--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -12,6 +12,7 @@ from detectron2.layers import (
     ModulatedDeformConv,
     ShapeSpec,
     get_norm,
+    Linear
 )
 
 from .backbone import Backbone
@@ -361,7 +362,7 @@ class ResNet(Backbone):
 
         if num_classes is not None:
             self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
-            self.linear = nn.Linear(curr_channels, num_classes)
+            self.linear = Linear(curr_channels, num_classes)
 
             # Sec 5.1 in "Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour":
             # "The 1000-way fully-connected layer is initialized by

--- a/detectron2/modeling/roi_heads/box_head.py
+++ b/detectron2/modeling/roi_heads/box_head.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from detectron2.layers import Conv2d, ShapeSpec, get_norm, Linear
+from detectron2.layers import Conv2d, Linear, ShapeSpec, get_norm
 from detectron2.utils.registry import Registry
 
 ROI_BOX_HEAD_REGISTRY = Registry("ROI_BOX_HEAD")

--- a/detectron2/modeling/roi_heads/box_head.py
+++ b/detectron2/modeling/roi_heads/box_head.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from detectron2.layers import Conv2d, ShapeSpec, get_norm
+from detectron2.layers import Conv2d, ShapeSpec, get_norm, Linear
 from detectron2.utils.registry import Registry
 
 ROI_BOX_HEAD_REGISTRY = Registry("ROI_BOX_HEAD")
@@ -60,7 +60,7 @@ class FastRCNNConvFCHead(nn.Module):
 
         self.fcs = []
         for k in range(num_fc):
-            fc = nn.Linear(np.prod(self._output_size), fc_dim)
+            fc = Linear(np.prod(self._output_size), fc_dim)
             self.add_module("fc{}".format(k + 1), fc)
             self.fcs.append(fc)
             self._output_size = fc_dim

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -6,7 +6,7 @@ from fvcore.nn import smooth_l1_loss
 from torch import nn
 from torch.nn import functional as F
 
-from detectron2.layers import batched_nms, cat, Linear
+from detectron2.layers import Linear, batched_nms, cat
 from detectron2.structures import Boxes, Instances
 from detectron2.utils.events import get_event_storage
 

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -6,7 +6,7 @@ from fvcore.nn import smooth_l1_loss
 from torch import nn
 from torch.nn import functional as F
 
-from detectron2.layers import batched_nms, cat
+from detectron2.layers import batched_nms, cat, Linear
 from detectron2.structures import Boxes, Instances
 from detectron2.utils.events import get_event_storage
 
@@ -376,9 +376,9 @@ class FastRCNNOutputLayers(nn.Module):
 
         # The prediction layer for num_classes foreground classes and one background class
         # (hence + 1)
-        self.cls_score = nn.Linear(input_size, num_classes + 1)
+        self.cls_score = Linear(input_size, num_classes + 1)
         num_bbox_reg_classes = 1 if cls_agnostic_bbox_reg else num_classes
-        self.bbox_pred = nn.Linear(input_size, num_bbox_reg_classes * box_dim)
+        self.bbox_pred = Linear(input_size, num_bbox_reg_classes * box_dim)
 
         nn.init.normal_(self.cls_score.weight, std=0.01)
         nn.init.normal_(self.bbox_pred.weight, std=0.001)


### PR DESCRIPTION
Because of [Linear with empty tensor backward error](https://github.com/pytorch/pytorch/issues/34202)
I made a wrapper for linear layer. This bug is occurred version 1.3 and 1.4 (not > 1.4).