### PR TITLE
Enabling detectron2 on AMD's ROCM stack

### DIFF
--- a/detectron2/layers/csrc/ROIAlign/ROIAlign.h
+++ b/detectron2/layers/csrc/ROIAlign/ROIAlign.h
@@ -26,7 +26,7 @@ at::Tensor ROIAlign_backward_cpu(
     const int sampling_ratio,
     bool aligned);
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 at::Tensor ROIAlign_forward_cuda(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -60,7 +60,7 @@ inline at::Tensor ROIAlign_forward(
     const int sampling_ratio,
     bool aligned) {
   if (input.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return ROIAlign_forward_cuda(
         input,
         rois,
@@ -96,7 +96,7 @@ inline at::Tensor ROIAlign_backward(
     const int sampling_ratio,
     bool aligned) {
   if (grad.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return ROIAlign_backward_cuda(
         grad,
         rois,

--- a/detectron2/layers/csrc/ROIAlignRotated/ROIAlignRotated.h
+++ b/detectron2/layers/csrc/ROIAlignRotated/ROIAlignRotated.h
@@ -24,7 +24,7 @@ at::Tensor ROIAlignRotated_backward_cpu(
     const int width,
     const int sampling_ratio);
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 at::Tensor ROIAlignRotated_forward_cuda(
     const at::Tensor& input,
     const at::Tensor& rois,
@@ -55,7 +55,7 @@ inline at::Tensor ROIAlignRotated_forward(
     const int pooled_width,
     const int sampling_ratio) {
   if (input.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return ROIAlignRotated_forward_cuda(
         input,
         rois,
@@ -83,7 +83,7 @@ inline at::Tensor ROIAlignRotated_backward(
     const int width,
     const int sampling_ratio) {
   if (grad.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return ROIAlignRotated_backward_cuda(
         grad,
         rois,

--- a/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated.h
+++ b/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated.h
@@ -8,7 +8,7 @@ at::Tensor box_iou_rotated_cpu(
     const at::Tensor& boxes1,
     const at::Tensor& boxes2);
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 at::Tensor box_iou_rotated_cuda(
     const at::Tensor& boxes1,
     const at::Tensor& boxes2);
@@ -22,7 +22,7 @@ inline at::Tensor box_iou_rotated(
     const at::Tensor& boxes2) {
   assert(boxes1.device().is_cuda() == boxes2.device().is_cuda());
   if (boxes1.device().is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return box_iou_rotated_cuda(boxes1.contiguous(), boxes2.contiguous());
 #else
     AT_ERROR("Not compiled with GPU support");

--- a/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h
+++ b/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <cmath>
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || __HCC__==1 ||  __HIP__==1
 // Designates functions callable from the host (CPU) and the device (GPU)
 #define HOST_DEVICE __host__ __device__
 #define HOST_DEVICE_INLINE HOST_DEVICE __forceinline__
@@ -192,7 +192,7 @@ HOST_DEVICE_INLINE int convex_hull_graham(
   // (essentially sorting according to angles)
   // If the angles are the same, sort according to their distance to origin
   T dist[24];
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || __HCC__==1 || __HIP__==1
   // compute distance to origin before sort, and sort them together with the
   // points
   for (int i = 0; i < num_in; i++) {

--- a/detectron2/layers/csrc/cuda_version.cu
+++ b/detectron2/layers/csrc/cuda_version.cu
@@ -4,6 +4,23 @@
 
 namespace detectron2 {
 int get_cudart_version() {
+// Not a ROCM platform: Either HIP is not used, or
+// it is used, but platform is not ROCM (i.e. it is CUDA) 
+#if !defined(__HIP_PLATFORM_HCC__) 
   return CUDART_VERSION;
+#else
+  int version = 0;
+  
+#if HIP_VERSION_MAJOR != 0
+// Create a convention similar to that of CUDA, as assumed by other 
+// parts of the code.
+
+  version = HIP_VERSION_MINOR;
+  version += (HIP_VERSION_MAJOR*100);
+#else
+  hipRuntimeGetVersion( &version );  
+#endif
+  return version;
+#endif
 }
 } // namespace detectron2

--- a/detectron2/layers/csrc/deformable/deform_conv.h
+++ b/detectron2/layers/csrc/deformable/deform_conv.h
@@ -4,7 +4,7 @@
 
 namespace detectron2 {
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 int deform_conv_forward_cuda(
     at::Tensor input,
     at::Tensor weight,
@@ -132,7 +132,7 @@ inline int deform_conv_forward(
     int deformable_group,
     int im2col_step) {
   if (input.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     TORCH_CHECK(weight.is_cuda(), "weight tensor is not on GPU!");
     TORCH_CHECK(offset.is_cuda(), "offset tensor is not on GPU!");
     return deform_conv_forward_cuda(
@@ -180,7 +180,7 @@ inline int deform_conv_backward_input(
     int deformable_group,
     int im2col_step) {
   if (gradOutput.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     TORCH_CHECK(input.is_cuda(), "input tensor is not on GPU!");
     TORCH_CHECK(weight.is_cuda(), "weight tensor is not on GPU!");
     TORCH_CHECK(offset.is_cuda(), "offset tensor is not on GPU!");
@@ -230,7 +230,7 @@ inline int deform_conv_backward_filter(
     float scale,
     int im2col_step) {
   if (gradOutput.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     TORCH_CHECK(input.is_cuda(), "input tensor is not on GPU!");
     TORCH_CHECK(offset.is_cuda(), "offset tensor is not on GPU!");
     return deform_conv_backward_parameters_cuda(
@@ -280,7 +280,7 @@ inline void modulated_deform_conv_forward(
     const int deformable_group,
     const bool with_bias) {
   if (input.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     TORCH_CHECK(weight.is_cuda(), "weight tensor is not on GPU!");
     TORCH_CHECK(bias.is_cuda(), "bias tensor is not on GPU!");
     TORCH_CHECK(offset.is_cuda(), "offset tensor is not on GPU!");
@@ -337,7 +337,7 @@ inline void modulated_deform_conv_backward(
     int deformable_group,
     const bool with_bias) {
   if (grad_output.is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     TORCH_CHECK(input.is_cuda(), "input tensor is not on GPU!");
     TORCH_CHECK(weight.is_cuda(), "weight tensor is not on GPU!");
     TORCH_CHECK(bias.is_cuda(), "bias tensor is not on GPU!");

--- a/detectron2/layers/csrc/nms_rotated/nms_rotated.h
+++ b/detectron2/layers/csrc/nms_rotated/nms_rotated.h
@@ -9,7 +9,7 @@ at::Tensor nms_rotated_cpu(
     const at::Tensor& scores,
     const float iou_threshold);
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 at::Tensor nms_rotated_cuda(
     const at::Tensor& dets,
     const at::Tensor& scores,
@@ -25,7 +25,7 @@ inline at::Tensor nms_rotated(
     const float iou_threshold) {
   assert(dets.device().is_cuda() == scores.device().is_cuda());
   if (dets.device().is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return nms_rotated_cuda(
         dets.contiguous(), scores.contiguous(), iou_threshold);
 #else

--- a/detectron2/layers/csrc/nms_rotated/nms_rotated_cuda.cu
+++ b/detectron2/layers/csrc/nms_rotated/nms_rotated_cuda.cu
@@ -3,7 +3,12 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
+#ifdef WITH_CUDA
 #include "../box_iou_rotated/box_iou_rotated_utils.h"
+#endif
+#ifdef WITH_HIP
+#include "box_iou_rotated/box_iou_rotated_utils.h"
+#endif
 
 using namespace detectron2;
 

--- a/detectron2/layers/csrc/vision.cpp
+++ b/detectron2/layers/csrc/vision.cpp
@@ -9,13 +9,20 @@
 
 namespace detectron2 {
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 extern int get_cudart_version();
 #endif
 
 std::string get_cuda_version() {
-#ifdef WITH_CUDA
+
+#if defined (WITH_CUDA) || defined (WITH_HIP)
   std::ostringstream oss;
+
+#if defined (WITH_CUDA)
+  oss << "CUDA ";
+#else
+  oss << "HIP ";
+#endif
 
   // copied from
   // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/cuda/detail/CUDAHooks.cpp#L231
@@ -27,7 +34,7 @@ std::string get_cuda_version() {
   };
   printCudaStyleVersion(get_cudart_version());
   return oss.str();
-#else
+#else // neither CUDA nor HIP
   return std::string("not available");
 #endif
 }

--- a/detectron2/utils/collect_env.py
+++ b/detectron2/utils/collect_env.py
@@ -54,15 +54,17 @@ def detect_compute_compatibility(CUDA_HOME, so_file):
 
 def collect_env_info():
 
-    # "has_gpu" really. 
+    # "has_gpu" really.
     has_cuda = torch.cuda.is_available()
-    
+
     # NOTE: the use of CUDA_HOME and ROCM_HOME requires the CUDA/ROCM build deps, though in
     # theory detectron2 should be made runnable with only the corresponding runtimes
     from torch.utils.cpp_extension import CUDA_HOME, ROCM_HOME
 
-    is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
-    
+    is_rocm_pytorch = (
+        True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
+    )
+
     data = []
     data.append(("sys.platform", sys.platform))
     data.append(("Python", sys.version.replace("\n", "")))
@@ -122,7 +124,7 @@ def collect_env_info():
             devices[torch.cuda.get_device_name(k)].append(str(k))
         for name, devids in devices.items():
             data.append(("GPU " + ",".join(devids), name))
-        
+
         if is_rocm_pytorch:
             data.append(("ROCM_HOME", str(ROCM_HOME)))
         else:

--- a/projects/TensorMask/tensormask/layers/csrc/SwapAlign2Nat/SwapAlign2Nat.h
+++ b/projects/TensorMask/tensormask/layers/csrc/SwapAlign2Nat/SwapAlign2Nat.h
@@ -4,7 +4,7 @@
 
 namespace tensormask {
 
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
 at::Tensor SwapAlign2Nat_forward_cuda(
     const at::Tensor& X,
     const int lambda_val,
@@ -24,7 +24,7 @@ inline at::Tensor SwapAlign2Nat_forward(
     const int lambda_val,
     const float pad_val) {
   if (X.type().is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return SwapAlign2Nat_forward_cuda(X, lambda_val, pad_val);
 #else
     AT_ERROR("Not compiled with GPU support");
@@ -41,7 +41,7 @@ inline at::Tensor SwapAlign2Nat_backward(
     const int height,
     const int width) {
   if (gY.type().is_cuda()) {
-#ifdef WITH_CUDA
+#if defined (WITH_CUDA) || defined (WITH_HIP)
     return SwapAlign2Nat_backward_cuda(
         gY, lambda_val, batch_size, channel, height, width);
 #else

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,10 @@ def get_extensions():
     is_rocm_pytorch = False
     if torch_ver >= [1, 5]:
         from torch.utils.cpp_extension import ROCM_HOME
-        is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
+
+        is_rocm_pytorch = (
+            True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
+        )
 
     if is_rocm_pytorch:
         hipify_python.hipify(
@@ -56,25 +59,32 @@ def get_extensions():
             output_directory=this_dir,
             includes="/detectron2/layers/csrc/*",
             show_detailed=True,
-            is_pytorch_extension=True)
+            is_pytorch_extension=True,
+        )
 
         # Current version of hipify function in pytorch creates an intermediate directory
         # named "hip" at the same level of the path hierarchy if a "cuda" directory exists,
-        # or modifying the hierarchy, if it doesn't. Once pytorch supports 
+        # or modifying the hierarchy, if it doesn't. Once pytorch supports
         # "same directory" hipification (PR pendeing), the source_cuda will be set
         # similarly in both cuda and hip paths, and the explicit header file copy
         # (below) will not be needed.
-        source_cuda = glob.glob(path.join(extensions_dir, "**", 'hip', "*.hip")) + glob.glob(
-            path.join(extensions_dir, 'hip', "*.hip"))
+        source_cuda = glob.glob(path.join(extensions_dir, "**", "hip", "*.hip")) + glob.glob(
+            path.join(extensions_dir, "hip", "*.hip")
+        )
 
-        shutil.copy("detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h", 
-                    "detectron2/layers/csrc/box_iou_rotated/hip/box_iou_rotated_utils.h")
-        shutil.copy("detectron2/layers/csrc/deformable/deform_conv.h", 
-                    "detectron2/layers/csrc/deformable/hip/deform_conv.h")
+        shutil.copy(
+            "detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h",
+            "detectron2/layers/csrc/box_iou_rotated/hip/box_iou_rotated_utils.h",
+        )
+        shutil.copy(
+            "detectron2/layers/csrc/deformable/deform_conv.h",
+            "detectron2/layers/csrc/deformable/hip/deform_conv.h",
+        )
 
     else:
         source_cuda = glob.glob(path.join(extensions_dir, "**", "*.cu")) + glob.glob(
-            path.join(extensions_dir, "*.cu"))
+            path.join(extensions_dir, "*.cu")
+        )
 
     sources = [main_source] + sources
 
@@ -83,7 +93,9 @@ def get_extensions():
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if (torch.cuda.is_available() and ((CUDA_HOME is not None)  or is_rocm_pytorch)) or os.getenv('FORCE_CUDA', '0') == '1':
+    if (torch.cuda.is_available() and ((CUDA_HOME is not None) or is_rocm_pytorch)) or os.getenv(
+        "FORCE_CUDA", "0"
+    ) == "1":
         extension = CUDAExtension
         sources += source_cuda
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 from typing import List
 import torch
 from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
+from torch.utils.hipify import hipify_python
 
 torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
 assert torch_ver >= [1, 4], "Requires PyTorch >= 1.4"
@@ -43,28 +44,60 @@ def get_extensions():
 
     main_source = path.join(extensions_dir, "vision.cpp")
     sources = glob.glob(path.join(extensions_dir, "**", "*.cpp"))
-    source_cuda = glob.glob(path.join(extensions_dir, "**", "*.cu")) + glob.glob(
-        path.join(extensions_dir, "*.cu")
-    )
+
+    is_rocm_pytorch = False
+    if torch_ver >= [1, 5]:
+        from torch.utils.cpp_extension import ROCM_HOME
+        is_rocm_pytorch = True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
+
+    if is_rocm_pytorch:
+        hipify_python.hipify(
+            project_directory=this_dir,
+            output_directory=this_dir,
+            includes="/detectron2/layers/csrc/*",
+            show_detailed=True,
+            is_pytorch_extension=True)
+
+        # Current version of hipify function in pytorch creates an intermediate directory
+        # named "hip" at the same level of the path hierarchy if a "cuda" directory exists,
+        # or modifying the hierarchy, if it doesn't. Once pytorch supports 
+        # "same directory" hipification (PR pendeing), the source_cuda will be set
+        # similarly in both cuda and hip paths, and the explicit header file copy
+        # (below) will not be needed.
+        source_cuda = glob.glob(path.join(extensions_dir, "**", 'hip', "*.hip")) + glob.glob(
+            path.join(extensions_dir, 'hip', "*.hip"))
+
+        shutil.copy("detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h", 
+                    "detectron2/layers/csrc/box_iou_rotated/hip/box_iou_rotated_utils.h")
+        shutil.copy("detectron2/layers/csrc/deformable/deform_conv.h", 
+                    "detectron2/layers/csrc/deformable/hip/deform_conv.h")
+
+    else:
+        source_cuda = glob.glob(path.join(extensions_dir, "**", "*.cu")) + glob.glob(
+            path.join(extensions_dir, "*.cu"))
 
     sources = [main_source] + sources
+
     extension = CppExtension
 
     extra_compile_args = {"cxx": []}
     define_macros = []
 
-    if (
-        torch.cuda.is_available() and CUDA_HOME is not None and os.path.isdir(CUDA_HOME)
-    ) or os.getenv("FORCE_CUDA", "0") == "1":
+    if (torch.cuda.is_available() and ((CUDA_HOME is not None)  or is_rocm_pytorch)) or os.getenv('FORCE_CUDA', '0') == '1':
         extension = CUDAExtension
         sources += source_cuda
-        define_macros += [("WITH_CUDA", None)]
-        extra_compile_args["nvcc"] = [
-            "-DCUDA_HAS_FP16=1",
-            "-D__CUDA_NO_HALF_OPERATORS__",
-            "-D__CUDA_NO_HALF_CONVERSIONS__",
-            "-D__CUDA_NO_HALF2_OPERATORS__",
-        ]
+
+        if not is_rocm_pytorch:
+            define_macros += [("WITH_CUDA", None)]
+            extra_compile_args["nvcc"] = [
+                "-DCUDA_HAS_FP16=1",
+                "-D__CUDA_NO_HALF_OPERATORS__",
+                "-D__CUDA_NO_HALF_CONVERSIONS__",
+                "-D__CUDA_NO_HALF2_OPERATORS__",
+            ]
+        else:
+            define_macros += [("WITH_HIP", None)]
+            extra_compile_args["nvcc"] = []
 
         # It's better if pytorch can do this by default ..
         CC = os.environ.get("CC", None)

--- a/tests/data/test_detection_utils.py
+++ b/tests/data/test_detection_utils.py
@@ -114,3 +114,6 @@ class TestTransformAnnotations(unittest.TestCase):
         instance = {"bbox": [10, 10, 100, 100], "bbox_mode": BoxMode.XYXY_ABS}
         with self.assertRaises(AssertionError):
             detection_utils.gen_crop_transform_with_instance((10, 10), (15, 15), instance)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data/test_detection_utils.py
+++ b/tests/data/test_detection_utils.py
@@ -115,5 +115,6 @@ class TestTransformAnnotations(unittest.TestCase):
         with self.assertRaises(AssertionError):
             detection_utils.gen_crop_transform_with_instance((10, 10), (15, 15), instance)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -141,3 +141,8 @@ class TestVisualizer(unittest.TestCase):
 
         v = Visualizer(img, MetadataCatalog.get("asdfasdf"))
         v.draw_instance_predictions(inst)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -143,6 +143,5 @@ class TestVisualizer(unittest.TestCase):
         v.draw_instance_predictions(inst)
 
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

Following the changes in pytorch to enable extensions, and in torchvision, to enable it as an extension on AMD's rocm stack, this pull request follows the same pattern of changes to also enable detectron2 on AMD's rocm stack. 

