### PR TITLE
Set min size for proposal generator

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -156,7 +156,7 @@ _C.MODEL.PROPOSAL_GENERATOR = CN()
 _C.MODEL.PROPOSAL_GENERATOR.NAME = "RPN"
 # Proposal height and width both need to be greater than MIN_SIZE
 # (a the scale used during training or inference)
-_C.MODEL.PROPOSAL_GENERATOR.MIN_SIZE = 0
+_C.MODEL.PROPOSAL_GENERATOR.MIN_SIZE = 1
 
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
This change sets the minimum size for generated proposals from '0' to '1'. While this may seem like a small change it has a significant effect: It prevents box regression deltas from becoming negative. The way box regression 'width' (and 'height') are calculated is by doing `dw = ww * torch.log(target_widths / src_widths)` (see `box_regression.py`). The log becomes negative when 'target_widths / src_widths' < 1 which is always the case when 'target_widths' (generated proposal widths) is < 1.

To get back to the width of the predicted box in the code we calculate `pred_w = torch.exp(dw) * widths[:, None]`. Because exp of 'dw' now becomes really small we get almost '0' width. The area becomes almost '0', which in the cuda kernel leads to computation of negative IoU values.

While we could alternatively capture or clamp values in the code this is the cleanest way to solve this.

Fixes #350, it was closed without solution and people were still reporting the error
