### PR TITLE
Support for loading / visualizing rotated box annotations / predictions

### DIFF
--- a/configs/Base-RRCNN-FPN.yaml
+++ b/configs/Base-RRCNN-FPN.yaml
@@ -1,0 +1,54 @@
+MODEL:
+  META_ARCHITECTURE: "GeneralizedRCNN"
+  BACKBONE:
+    NAME: "build_resnet_fpn_backbone"
+  RESNETS:
+    OUT_FEATURES: ["res2", "res3", "res4", "res5"]
+  FPN:
+    IN_FEATURES: ["res2", "res3", "res4", "res5"]
+  ANCHOR_GENERATOR:
+    NAME: "RotatedAnchorGenerator"
+    SIZES: [[32], [64], [128], [256], [512]]  # One size for each in feature map
+    ASPECT_RATIOS: [[0.5, 1.0, 2.0]]
+    ANGLES: [[0, 30, 60]]
+  PROPOSAL_GENERATOR:
+    NAME: "RRPN"
+    MIN_SIZE: 1 # VERY IMPORTANT! otherwise various crashes
+  RPN:
+    HEAD_NAME: "StandardRPNHead"
+    BBOX_REG_WEIGHTS: [1, 1, 1, 1, 1]
+    IN_FEATURES: ["p2", "p3", "p4", "p5", "p6"]
+    PRE_NMS_TOPK_TRAIN: 2000  # Per FPN level
+    PRE_NMS_TOPK_TEST: 1000  # Per FPN level
+    # Detectron1 uses 2000 proposals per-batch,
+    # (See "modeling/rpn/rpn_outputs.py" for details of this legacy issue)
+    # which is approximately 1000 proposals per-image since the default batch size for FPN is 2.
+    POST_NMS_TOPK_TRAIN: 1000
+    POST_NMS_TOPK_TEST: 1000
+    IOU_THRESHOLDS: [0.3, 0.7]
+  ROI_HEADS:
+    NAME: "RROIHeads"
+    IN_FEATURES: ["p2", "p3", "p4", "p5"]
+    IOU_THRESHOLDS: [0.5]
+    PROPOSAL_APPEND_GT: True
+    NUM_CLASSES: 2
+  ROI_BOX_HEAD:
+    NAME: "FastRCNNConvFCHead"
+    NUM_FC: 2
+    POOLER_RESOLUTION: 7
+    POOLER_TYPE: "ROIAlignRotated"
+    BBOX_REG_WEIGHTS: [10, 10, 5, 5, 1]
+    CLS_AGNOSTIC_BBOX_REG: False
+DATASETS:
+  TRAIN: ("coco_2017_train",)
+  TEST: ("coco_2017_val",)
+SOLVER:
+  IMS_PER_BATCH: 16
+  BASE_LR: 0.02
+  WEIGHT_DECAY: 0.0001
+  STEPS: (60000, 80000)
+  MAX_ITER: 90000
+  CHECKPOINT_PERIOD: 10000
+INPUT:
+  MIN_SIZE_TRAIN: (640, 672, 704, 736, 768, 800)
+VERSION: 2

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -487,7 +487,12 @@ class Visualizer:
             else:
                 keypts = None
 
-            boxes = [BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) for x in annos]
+            if annos[0]["bbox_mode"] == BoxMode.XYWHA_ABS:
+                boxes = RotatedBoxes(torch.stack([torch.as_tensor(x["bbox"]) for x in annos]))
+            else:
+                boxes = [
+                    BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) for x in annos
+                ]
 
             labels = [x["category_id"] for x in annos]
             names = self.metadata.get("thing_classes", None)


### PR DESCRIPTION
This PR provides the bare minimum changes to allow detectron2 users to load rotated ground truth boxes and display rotated box predictions. Further, an example config file for RRPN/FPN is provided, which definitely fixes #21 and #572.

Problem statement: Currently detectron2 doesn't allow for loading rotated `XYWHA` box ground truth instances. The loaded instances get transformed to 4 dimensional `XYWH` boxes in the annotation instance loader and visualization.

Code changes: The visualizer and `annotations_to_instances` function now handle rotated instance boxes. The `annotations_to_instances_rotated` function has been removed to eliminate redundant code. No further changes are required in the calling code (dataset mapper can be left unchanged).

The changes have been used together with (custom) dataloaders for the Jacquard and Cornell robotic grasping dataset which load rotated boxes annotating robotic grasps.

To validate the changes you can just take the example config provided together with a custom dataloader which loads box annotations in the `XYWHA` format.

I'm aware of #996: while we have similar goals, my PR has fewer changes limited only on fixing the box conversion handling in the loader and visualizer.