### PR TITLE
Add registry.__doc__ in missing cases

### DIFF
--- a/detectron2/modeling/anchor_generator.py
+++ b/detectron2/modeling/anchor_generator.py
@@ -10,7 +10,7 @@ from detectron2.structures import Boxes, RotatedBoxes
 from detectron2.utils.registry import Registry
 
 ANCHOR_GENERATOR_REGISTRY = Registry("ANCHOR_GENERATOR")
-"""
+ANCHOR_GENERATOR_REGISTRY.__doc__ = """
 Registry for modules that creates object detection anchors for feature maps.
 
 The registered object will be called with `obj(cfg, input_shape)`.

--- a/detectron2/modeling/meta_arch/semantic_seg.py
+++ b/detectron2/modeling/meta_arch/semantic_seg.py
@@ -18,7 +18,7 @@ __all__ = ["SemanticSegmentor", "SEM_SEG_HEADS_REGISTRY", "SemSegFPNHead", "buil
 
 
 SEM_SEG_HEADS_REGISTRY = Registry("SEM_SEG_HEADS")
-"""
+SEM_SEG_HEADS_REGISTRY.__doc__ = """
 Registry for semantic segmentation heads, which make semantic segmentation predictions
 from feature maps.
 """

--- a/detectron2/modeling/proposal_generator/rpn.py
+++ b/detectron2/modeling/proposal_generator/rpn.py
@@ -14,7 +14,7 @@ from .build import PROPOSAL_GENERATOR_REGISTRY
 from .rpn_outputs import RPNOutputs, find_top_rpn_proposals
 
 RPN_HEAD_REGISTRY = Registry("RPN_HEAD")
-"""
+RPN_HEAD_REGISTRY.__doc__ = """
 Registry for RPN heads, which take feature maps and perform
 objectness classification and bounding box regression for anchors.
 


### PR DESCRIPTION
Some `doc` of `REGISTRY` are not assignd in `Registry.__doc__`

So I changed comments to `__doc__`