### PR TITLE
Fix no attribute error in inference_on_dataset

### DIFF
--- a/detectron2/evaluation/evaluator.py
+++ b/detectron2/evaluation/evaluator.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 import torch
 
-from detectron2.utils.comm import is_main_process
+from detectron2.utils.comm import get_world_size, is_main_process
 from detectron2.utils.logger import log_every_n_seconds
 
 
@@ -100,7 +100,7 @@ def inference_on_dataset(model, data_loader, evaluator):
     Returns:
         The return value of `evaluator.evaluate()`
     """
-    num_devices = torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
+    num_devices = get_world_size()
     logger = logging.getLogger(__name__)
     logger.info("Start inference on {} images".format(len(data_loader)))
 


### PR DESCRIPTION
Fix for `'torch.distributed' has no attribute 'is_initialized'` when pytorch version does not support distributing training (Windows).
Same issue as https://github.com/facebookresearch/maskrcnn-benchmark/issues/280 , https://github.com/facebookresearch/maskrcnn-benchmark/pull/511 .