### PR TITLE
Support empty predictions when visualizing results

### DIFF
--- a/tools/visualize_json_results.py
+++ b/tools/visualize_json_results.py
@@ -22,6 +22,9 @@ def create_instances(predictions, image_size):
     score = np.asarray([x["score"] for x in predictions])
     chosen = (score > args.conf_threshold).nonzero()[0]
     score = score[chosen]
+    if score.shape[0] == 0:
+        return None
+
     bbox = np.asarray([predictions[i]["bbox"] for i in chosen])
     bbox = BoxMode.convert(bbox, BoxMode.XYWH_ABS, BoxMode.XYXY_ABS)
 
@@ -80,6 +83,9 @@ if __name__ == "__main__":
         basename = os.path.basename(dic["file_name"])
 
         predictions = create_instances(pred_by_image[dic["image_id"]], img.shape[:2])
+        if predictions is None:
+            continue
+
         vis = Visualizer(img, metadata)
         vis_pred = vis.draw_instance_predictions(predictions).get_image()
 

--- a/tools/visualize_json_results.py
+++ b/tools/visualize_json_results.py
@@ -23,7 +23,7 @@ def create_instances(predictions, image_size):
     chosen = (score > args.conf_threshold).nonzero()[0]
     score = score[chosen]
     if score.shape[0] == 0:
-        return None
+        return ret
 
     bbox = np.asarray([predictions[i]["bbox"] for i in chosen])
     bbox = BoxMode.convert(bbox, BoxMode.XYWH_ABS, BoxMode.XYXY_ABS)
@@ -83,9 +83,6 @@ if __name__ == "__main__":
         basename = os.path.basename(dic["file_name"])
 
         predictions = create_instances(pred_by_image[dic["image_id"]], img.shape[:2])
-        if predictions is None:
-            continue
-
         vis = Visualizer(img, metadata)
         vis_pred = vis.draw_instance_predictions(predictions).get_image()
 

--- a/tools/visualize_json_results.py
+++ b/tools/visualize_json_results.py
@@ -21,10 +21,8 @@ def create_instances(predictions, image_size):
 
     score = np.asarray([x["score"] for x in predictions])
     chosen = (score > args.conf_threshold).nonzero()[0]
-    if chosen.shape[0] == 0:
-        return None
     score = score[chosen]
-    bbox = np.asarray([predictions[i]["bbox"] for i in chosen])
+    bbox = np.asarray([predictions[i]["bbox"] for i in chosen]).reshape(-1, 4)
     bbox = BoxMode.convert(bbox, BoxMode.XYWH_ABS, BoxMode.XYXY_ABS)
 
     labels = np.asarray([dataset_id_map(predictions[i]["category_id"]) for i in chosen])

--- a/tools/visualize_json_results.py
+++ b/tools/visualize_json_results.py
@@ -21,10 +21,9 @@ def create_instances(predictions, image_size):
 
     score = np.asarray([x["score"] for x in predictions])
     chosen = (score > args.conf_threshold).nonzero()[0]
+    if chosen.shape[0] == 0:
+        return None
     score = score[chosen]
-    if score.shape[0] == 0:
-        return ret
-
     bbox = np.asarray([predictions[i]["bbox"] for i in chosen])
     bbox = BoxMode.convert(bbox, BoxMode.XYWH_ABS, BoxMode.XYXY_ABS)
 


### PR DESCRIPTION
This PR fixes a potential error when no predictions found in `tools/visualize_json_results.py`.