### PR TITLE
rename in_channels variable used in FPN constructor

### DIFF
--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -58,12 +58,16 @@ class FPN(Backbone):
         output_convs = []
 
         use_bias = norm == ""
-        for idx, in_channels_idx in enumerate(in_channels):
+        for idx, in_channels_per_feature in enumerate(in_channels):
             lateral_norm = get_norm(norm, out_channels)
             output_norm = get_norm(norm, out_channels)
 
             lateral_conv = Conv2d(
-                in_channels_idx, out_channels, kernel_size=1, bias=use_bias, norm=lateral_norm
+                in_channels_per_feature,
+                out_channels,
+                kernel_size=1,
+                bias=use_bias,
+                norm=lateral_norm,
             )
             output_conv = Conv2d(
                 out_channels,

--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -58,12 +58,12 @@ class FPN(Backbone):
         output_convs = []
 
         use_bias = norm == ""
-        for idx, in_channels in enumerate(in_channels):
+        for idx, in_channels_idx in enumerate(in_channels):
             lateral_norm = get_norm(norm, out_channels)
             output_norm = get_norm(norm, out_channels)
 
             lateral_conv = Conv2d(
-                in_channels, out_channels, kernel_size=1, bias=use_bias, norm=lateral_norm
+                in_channels_idx, out_channels, kernel_size=1, bias=use_bias, norm=lateral_norm
             )
             output_conv = Conv2d(
                 out_channels,


### PR DESCRIPTION
This PR renames the `in_channels` variable used in constructing the FPN.

I found it a bit confusing that we were both enumerating over `in_channels` and assigning each element to a variable also called `in_channels` so at the end of the for loop, `in_channels` would actually be the last element of the original `in_channels` list.