### PR TITLE
Soft NMS for Boxes and RotatedBoxes

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -274,6 +274,13 @@ _C.MODEL.ROI_HEADS.NMS_THRESH_TEST = 0.5
 # train ROI heads.
 _C.MODEL.ROI_HEADS.PROPOSAL_APPEND_GT = True
 
+# Use soft NMS instead of standard NMS if set to True
+_C.MODEL.ROI_HEADS.SOFT_NMS_ENABLED = False
+# See soft NMS paper for definition of these options
+_C.MODEL.ROI_HEADS.SOFT_NMS_METHOD = "linear"
+_C.MODEL.ROI_HEADS.SOFT_NMS_SIGMA = 0.5
+# For the threshold we use NMS_THRESH_TEST
+
 # ---------------------------------------------------------------------------- #
 # Box Head
 # ---------------------------------------------------------------------------- #
@@ -432,6 +439,13 @@ _C.MODEL.RETINANET.PRIOR_PROB = 0.01
 _C.MODEL.RETINANET.SCORE_THRESH_TEST = 0.05
 _C.MODEL.RETINANET.TOPK_CANDIDATES_TEST = 1000
 _C.MODEL.RETINANET.NMS_THRESH_TEST = 0.5
+
+# Use soft NMS instead of standard NMS if set to True
+_C.MODEL.RETINANET.SOFT_NMS_ENABLED = False
+# See soft NMS paper for definition of these options
+_C.MODEL.RETINANET.SOFT_NMS_METHOD = "linear"
+_C.MODEL.RETINANET.SOFT_NMS_SIGMA = 0.5
+# For the threshold we use NMS_THRESH_TEST
 
 # Weights on (dx, dy, dw, dh) for normalizing Retinanet anchor regression targets
 _C.MODEL.RETINANET.BBOX_REG_WEIGHTS = (1.0, 1.0, 1.0, 1.0)

--- a/detectron2/layers/__init__.py
+++ b/detectron2/layers/__init__.py
@@ -6,6 +6,9 @@ from .nms import batched_nms, batched_nms_rotated, nms, nms_rotated
 from .roi_align import ROIAlign, roi_align
 from .roi_align_rotated import ROIAlignRotated, roi_align_rotated
 from .shape_spec import ShapeSpec
+
+# If I do this import, we get a circular dependency. TODO: Restructure?!
+# from .soft_nms import batched_soft_nms, batched_soft_nms_rotated, soft_nms, soft_nms_rotated
 from .wrappers import BatchNorm2d, Conv2d, ConvTranspose2d, cat, interpolate, Linear
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/detectron2/layers/soft_nms.py
+++ b/detectron2/layers/soft_nms.py
@@ -1,0 +1,200 @@
+import torch
+
+from detectron2.structures import Boxes, RotatedBoxes, pairwise_iou, pairwise_iou_rotated
+
+
+def soft_nms(boxes, scores, method, sigma, threshold):
+    """
+    Peforms soft non-maximum suppression algorithm on axis aligned boxes
+
+    Args:
+        boxes (Tensor[N, 5]):
+           boxes where NMS will be performed. They
+           are expected to be in (x_ctr, y_ctr, width, height, angle_degrees) format
+        scores (Tensor[N]):
+           scores for each one of the boxes
+        method (str):
+           one of ['gaussian', 'linear', 'hard']
+        sigma (float):
+           param for gaussian
+        threshold (float):
+           discards all boxes with decayed confidence < threshold
+
+    Returns:
+        Tensor:
+            int64 tensor with the indices of the elements that have been kept
+            by NMS, sorted in decreasing order of scores
+    """
+    return _soft_nms(Boxes, pairwise_iou, boxes, scores, method, sigma, threshold)
+
+
+def soft_nms_rotated(boxes, scores, method, sigma, threshold):
+    """
+    Performs soft non-maximum suppression algorithm on rotated boxes
+
+    Args:
+        boxes (Tensor[N, 5]):
+           boxes where NMS will be performed. They
+           are expected to be in (x_ctr, y_ctr, width, height, angle_degrees) format
+        scores (Tensor[N]):
+           scores for each one of the boxes
+        method (str):
+           one of ['gaussian', 'linear', 'hard']
+        sigma (float):
+           param for gaussian
+        threshold (float):
+           discards all boxes with decayed confidence < threshold
+
+    Returns:
+        Tensor:
+            int64 tensor with the indices of the elements that have been kept
+            by NMS, sorted in decreasing order of scores
+    """
+    return _soft_nms(RotatedBoxes, pairwise_iou_rotated, boxes, scores, method, sigma, threshold)
+
+
+def batched_soft_nms(boxes, scores, idxs, method, sigma, threshold):
+    """
+    Performs soft non-maximum suppression in a batched fashion.
+
+    Each index value correspond to a category, and NMS
+    will not be applied between elements of different categories.
+
+    Args:
+        boxes (Tensor[N, 4]):
+           boxes where NMS will be performed. They
+           are expected to be in (x1, y1, x2, y2) format
+        scores (Tensor[N]):
+           scores for each one of the boxes
+        idxs (Tensor[N]):
+           indices of the categories for each one of the boxes.
+        method (str):
+           one of ['gaussian', 'linear', 'hard']
+        sigma (float):
+           param for gaussian
+        threshold (float):
+           discards all boxes with decayed confidence < threshold
+
+    Returns:
+        Tensor:
+            int64 tensor with the indices of the elements that have been kept
+            by NMS, sorted in decreasing order of scores
+    """
+    if boxes.numel() == 0:
+        return torch.empty((0,), dtype=torch.int64, device=boxes.device)
+    # strategy: in order to perform NMS independently per class.
+    # we add an offset to all the boxes. The offset is dependent
+    # only on the class idx, and is large enough so that boxes
+    # from different classes do not overlap
+    max_coordinate = boxes.max()
+    offsets = idxs.to(boxes) * (max_coordinate + 1)
+    boxes_for_nms = boxes + offsets[:, None]
+    keep = soft_nms(boxes_for_nms, scores, method, sigma, threshold)
+    return keep
+
+
+def batched_soft_nms_rotated(boxes, scores, idxs, method, sigma, threshold):
+    """
+    Performs soft non-maximum suppression in a batched fashion on rotated bounding boxes.
+
+    Each index value correspond to a category, and NMS
+    will not be applied between elements of different categories.
+
+    Args:
+        boxes (Tensor[N, 5]):
+           boxes where NMS will be performed. They
+           are expected to be in (x_ctr, y_ctr, width, height, angle_degrees) format
+        scores (Tensor[N]):
+           scores for each one of the boxes
+        idxs (Tensor[N]):
+           indices of the categories for each one of the boxes.
+        method (str):
+           one of ['gaussian', 'linear', 'hard']
+        sigma (float):
+           param for gaussian
+        threshold (float):
+           discards all boxes with decayed confidence < threshold
+
+    Returns:
+        Tensor:
+            int64 tensor with the indices of the elements that have been kept
+            by NMS, sorted in decreasing order of scores
+    """
+    if boxes.numel() == 0:
+        return torch.empty((0,), dtype=torch.int64, device=boxes.device)
+    # strategy: in order to perform NMS independently per class.
+    # we add an offset to all the boxes. The offset is dependent
+    # only on the class idx, and is large enough so that boxes
+    # from different classes do not overlap
+    max_coordinate = boxes[:, :2].max() + torch.norm(boxes[:, 2:4], 2, dim=1).max()
+    offsets = idxs.to(boxes) * (max_coordinate + 1)
+    boxes_for_nms = boxes.clone()
+    boxes_for_nms[:, :2] += offsets[:, None]
+    keep = soft_nms_rotated(boxes_for_nms, scores, method, sigma, threshold)
+    return keep
+
+
+def _soft_nms(box_class, pairwise_iou_func, boxes, scores, method, sigma, threshold):
+    """
+    Soft non-max suppression algorithm.
+
+    Implementation of [Soft-NMS -- Improving Object Detection With One Line of Codec](https://arxiv.org/abs/1704.04503)
+
+    Each index value correspond to a category, and NMS
+    will not be applied between elements of different categories.
+
+    Args:
+        box_class (cls): one of Box, RotatedBoxes
+        pairwise_iou_func (func): one of pairwise_iou, pairwise_iou_rotated
+        boxes (Tensor[N, ?]):
+           boxes where NMS will be performed
+           if Boxes, in (x1, y1, x2, y2) format
+           if RotatedBoxes, in (x_ctr, y_ctr, width, height, angle_degrees) format
+        scores (Tensor[N]):
+           scores for each one of the boxes
+        method (str):
+           one of ['gaussian', 'linear', 'hard']
+        sigma (float):
+           param for gaussian
+        threshold (float):
+           discards all boxes with decayed confidence < threshold
+
+    Returns:
+        Tensor:
+            int64 tensor with the indices of the elements that have been kept
+            by Soft NMS, sorted in decreasing order of scores
+    """
+
+    out = []
+
+    boxes = boxes.clone()
+    scores = scores.clone()
+    idxs = torch.arange(scores.size()[0])
+
+    while scores.numel() > 0:
+        top_idx = torch.argmax(scores)
+        top_box = boxes[top_idx]
+        ious = pairwise_iou_func(box_class(top_box.unsqueeze(0)), box_class(boxes))[0]
+
+        if method == "linear":
+            decay = torch.ones_like(ious)
+            decay_mask = ious > threshold
+            decay[decay_mask] = 1 - ious[decay_mask]
+        elif method == "gaussian":
+            decay = torch.exp(-torch.pow(ious, 2) / sigma)
+        elif method == "hard":  # standard NMS
+            decay = (ious < threshold).float()
+        else:
+            raise NotImplementedError("{} soft nms method not implemented.".format(method))
+
+        scores *= decay
+        keep = scores > threshold
+        keep[top_idx] = False
+
+        out.append(idxs[top_idx])
+
+        boxes = boxes[keep]
+        scores = scores[keep]
+        idxs = idxs[keep]
+
+    return torch.tensor(out)

--- a/detectron2/modeling/roi_heads/cascade_rcnn.py
+++ b/detectron2/modeling/roi_heads/cascade_rcnn.py
@@ -149,6 +149,9 @@ class CascadeROIHeads(StandardROIHeads):
                 image_sizes,
                 predictor.test_score_thresh,
                 predictor.test_nms_thresh,
+                predictor.soft_nms_enabled,
+                predictor.soft_nms_method,
+                predictor.soft_nms_sigma,
                 predictor.test_topk_per_image,
             )
             return pred_instances

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -7,6 +7,7 @@ from torch.nn import functional as F
 
 from detectron2.config import configurable
 from detectron2.layers import Linear, ShapeSpec, batched_nms, cat
+from detectron2.layers.soft_nms import batched_soft_nms
 from detectron2.modeling.box_regression import Box2BoxTransform
 from detectron2.structures import Boxes, Instances
 from detectron2.utils.events import get_event_storage
@@ -39,7 +40,17 @@ Naming convention:
 """
 
 
-def fast_rcnn_inference(boxes, scores, image_shapes, score_thresh, nms_thresh, topk_per_image):
+def fast_rcnn_inference(
+    boxes,
+    scores,
+    image_shapes,
+    score_thresh,
+    nms_thresh,
+    soft_nms_enabled,
+    soft_nms_method,
+    soft_nms_sigma,
+    topk_per_image,
+):
     """
     Call `fast_rcnn_inference_single_image` for all images.
 
@@ -56,6 +67,9 @@ def fast_rcnn_inference(boxes, scores, image_shapes, score_thresh, nms_thresh, t
         score_thresh (float): Only return detections with a confidence score exceeding this
             threshold.
         nms_thresh (float):  The threshold to use for box non-maximum suppression. Value in [0, 1].
+        soft_nms_enabled (bool): Indicate to use soft non-maximum suppression.
+        soft_nms_method: (str): One of ['gaussian', 'linear', 'hard']
+        soft_nms_sigma: (float): Sigma for gaussian soft nms. Value in (0, inf)
         topk_per_image (int): The number of top scoring detections to return. Set < 0 to return
             all detections.
 
@@ -67,7 +81,15 @@ def fast_rcnn_inference(boxes, scores, image_shapes, score_thresh, nms_thresh, t
     """
     result_per_image = [
         fast_rcnn_inference_single_image(
-            boxes_per_image, scores_per_image, image_shape, score_thresh, nms_thresh, topk_per_image
+            boxes_per_image,
+            scores_per_image,
+            image_shape,
+            score_thresh,
+            nms_thresh,
+            soft_nms_enabled,
+            soft_nms_method,
+            soft_nms_sigma,
+            topk_per_image,
         )
         for scores_per_image, boxes_per_image, image_shape in zip(scores, boxes, image_shapes)
     ]
@@ -75,7 +97,15 @@ def fast_rcnn_inference(boxes, scores, image_shapes, score_thresh, nms_thresh, t
 
 
 def fast_rcnn_inference_single_image(
-    boxes, scores, image_shape, score_thresh, nms_thresh, topk_per_image
+    boxes,
+    scores,
+    image_shape,
+    score_thresh,
+    nms_thresh,
+    soft_nms_enabled,
+    soft_nms_method,
+    soft_nms_sigma,
+    topk_per_image,
 ):
     """
     Single-image inference. Return bounding-box detection results by thresholding
@@ -112,7 +142,12 @@ def fast_rcnn_inference_single_image(
     scores = scores[filter_mask]
 
     # Apply per-class NMS
-    keep = batched_nms(boxes, scores, filter_inds[:, 1], nms_thresh)
+    if not soft_nms_enabled:
+        keep = batched_nms(boxes, scores, filter_inds[:, 1], nms_thresh)
+    else:
+        keep = batched_soft_nms(
+            boxes, scores, filter_inds[:, 1], soft_nms_method, soft_nms_sigma, nms_thresh
+        )
     if topk_per_image >= 0:
         keep = keep[:topk_per_image]
     boxes, scores, filter_inds = boxes[keep], scores[keep], filter_inds[keep]
@@ -362,11 +397,22 @@ class FastRCNNOutputs(object):
         probs = F.softmax(self.pred_class_logits, dim=-1)
         return probs.split(self.num_preds_per_image, dim=0)
 
-    def inference(self, score_thresh, nms_thresh, topk_per_image):
+    def inference(
+        self,
+        score_thresh,
+        nms_thresh,
+        soft_nms_enabled,
+        soft_nms_method,
+        soft_nms_sigma,
+        topk_per_image,
+    ):
         """
         Args:
             score_thresh (float): same as fast_rcnn_inference.
             nms_thresh (float): same as fast_rcnn_inference.
+            soft_nms_enabled (bool): same as fast_rcnn_inference.
+            soft_nms_method: (str): same as fast_rcnn_inference.
+            soft_nms_sigma: (float): same as fast_rcnn_inference.
             topk_per_image (int): same as fast_rcnn_inference.
         Returns:
             list[Instances]: same as fast_rcnn_inference.
@@ -377,7 +423,15 @@ class FastRCNNOutputs(object):
         image_shapes = self.image_shapes
 
         return fast_rcnn_inference(
-            boxes, scores, image_shapes, score_thresh, nms_thresh, topk_per_image
+            boxes,
+            scores,
+            image_shapes,
+            score_thresh,
+            nms_thresh,
+            soft_nms_enabled,
+            soft_nms_method,
+            soft_nms_sigma,
+            topk_per_image,
         )
 
 
@@ -398,6 +452,9 @@ class FastRCNNOutputLayers(nn.Module):
         smooth_l1_beta=0.0,
         test_score_thresh=0.0,
         test_nms_thresh=0.5,
+        soft_nms_enabled=False,
+        soft_nms_method="gaussian",
+        soft_nms_sigma=0.5,
         test_topk_per_image=100,
     ):
         """
@@ -431,6 +488,9 @@ class FastRCNNOutputLayers(nn.Module):
         self.smooth_l1_beta = smooth_l1_beta
         self.test_score_thresh = test_score_thresh
         self.test_nms_thresh = test_nms_thresh
+        self.soft_nms_enabled = soft_nms_enabled
+        self.soft_nms_method = soft_nms_method
+        self.soft_nms_sigma = soft_nms_sigma
         self.test_topk_per_image = test_topk_per_image
 
     @classmethod
@@ -444,6 +504,9 @@ class FastRCNNOutputLayers(nn.Module):
             "smooth_l1_beta"        : cfg.MODEL.ROI_BOX_HEAD.SMOOTH_L1_BETA,
             "test_score_thresh"     : cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST,
             "test_nms_thresh"       : cfg.MODEL.ROI_HEADS.NMS_THRESH_TEST,
+            "soft_nms_enabled"      : cfg.MODEL.ROI_HEADS.SOFT_NMS_ENABLED,
+            "soft_nms_method"       : cfg.MODEL.ROI_HEADS.SOFT_NMS_METHOD,
+            "soft_nms_sigma"        : cfg.MODEL.ROI_HEADS.SOFT_NMS_SIGMA,
             "test_topk_per_image"   : cfg.TEST.DETECTIONS_PER_IMAGE
             # fmt: on
         }
@@ -477,7 +540,14 @@ class FastRCNNOutputLayers(nn.Module):
         scores, proposal_deltas = predictions
         return FastRCNNOutputs(
             self.box2box_transform, scores, proposal_deltas, proposals, self.smooth_l1_beta
-        ).inference(self.test_score_thresh, self.test_nms_thresh, self.test_topk_per_image)
+        ).inference(
+            self.test_score_thresh,
+            self.test_nms_thresh,
+            self.soft_nms_enabled,
+            self.soft_nms_method,
+            self.soft_nms_sigma,
+            self.test_topk_per_image,
+        )
 
     def predict_boxes_for_gt_classes(self, predictions, proposals):
         scores, proposal_deltas = predictions

--- a/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
@@ -5,6 +5,7 @@ from typing import Dict
 import torch
 
 from detectron2.layers import ShapeSpec, batched_nms_rotated
+from detectron2.layers.soft_nms import batched_soft_nms_rotated
 from detectron2.structures import Instances, RotatedBoxes, pairwise_iou_rotated
 from detectron2.utils.events import get_event_storage
 
@@ -44,7 +45,15 @@ Naming convention:
 
 
 def fast_rcnn_inference_rotated(
-    boxes, scores, image_shapes, score_thresh, nms_thresh, topk_per_image
+    boxes,
+    scores,
+    image_shapes,
+    score_thresh,
+    nms_thresh,
+    soft_nms_enabled,
+    soft_nms_method,
+    soft_nms_sigma,
+    topk_per_image,
 ):
     """
     Call `fast_rcnn_inference_single_image_rotated` for all images.
@@ -62,6 +71,9 @@ def fast_rcnn_inference_rotated(
         score_thresh (float): Only return detections with a confidence score exceeding this
             threshold.
         nms_thresh (float):  The threshold to use for box non-maximum suppression. Value in [0, 1].
+        soft_nms_enabled (bool): Indicate to use soft non-maximum suppression.
+        soft_nms_method: (str): One of ['gaussian', 'linear', 'hard']
+        soft_nms_sigma: (float): Sigma for gaussian soft nms. Value in (0, inf)
         topk_per_image (int): The number of top scoring detections to return. Set < 0 to return
             all detections.
 
@@ -73,7 +85,15 @@ def fast_rcnn_inference_rotated(
     """
     result_per_image = [
         fast_rcnn_inference_single_image_rotated(
-            boxes_per_image, scores_per_image, image_shape, score_thresh, nms_thresh, topk_per_image
+            boxes_per_image,
+            scores_per_image,
+            image_shape,
+            score_thresh,
+            nms_thresh,
+            soft_nms_enabled,
+            soft_nms_method,
+            soft_nms_sigma,
+            topk_per_image,
         )
         for scores_per_image, boxes_per_image, image_shape in zip(scores, boxes, image_shapes)
     ]
@@ -81,7 +101,15 @@ def fast_rcnn_inference_rotated(
 
 
 def fast_rcnn_inference_single_image_rotated(
-    boxes, scores, image_shape, score_thresh, nms_thresh, topk_per_image
+    boxes,
+    scores,
+    image_shape,
+    score_thresh,
+    nms_thresh,
+    soft_nms_enabled,
+    soft_nms_method,
+    soft_nms_sigma,
+    topk_per_image,
 ):
     """
     Single-image inference. Return rotated bounding-box detection results by thresholding
@@ -118,7 +146,12 @@ def fast_rcnn_inference_single_image_rotated(
     scores = scores[filter_mask]
 
     # Apply per-class Rotated NMS
-    keep = batched_nms_rotated(boxes, scores, filter_inds[:, 1], nms_thresh)
+    if not soft_nms_enabled:
+        keep = batched_nms_rotated(boxes, scores, filter_inds[:, 1], nms_thresh)
+    else:
+        keep = batched_soft_nms_rotated(
+            boxes, scores, filter_inds[:, 1], soft_nms_method, soft_nms_sigma, nms_thresh
+        )
     if topk_per_image >= 0:
         keep = keep[:topk_per_image]
     boxes, scores, filter_inds = boxes[keep], scores[keep], filter_inds[keep]

--- a/detectron2/modeling/test_time_augmentation.py
+++ b/detectron2/modeling/test_time_augmentation.py
@@ -250,6 +250,9 @@ class GeneralizedRCNNWithTTA(nn.Module):
             shape_hw,
             1e-8,
             self.cfg.MODEL.ROI_HEADS.NMS_THRESH_TEST,
+            self.cfg.MODEL.ROI_HEADS.SOFT_NMS_ENABLED,
+            self.cfg.MODEL.ROI_HEADS.SOFT_NMS_METHOD,
+            self.cfg.MODEL.ROI_HEADS.SOFT_NMS_SIGMA,
             self.cfg.TEST.DETECTIONS_PER_IMAGE,
         )
 

--- a/tests/test_soft_nms.py
+++ b/tests/test_soft_nms.py
@@ -1,0 +1,267 @@
+import unittest
+import torch
+
+from detectron2.layers.soft_nms import (
+    batched_soft_nms,
+    batched_soft_nms_rotated,
+    soft_nms,
+    soft_nms_rotated,
+)
+
+
+def keeps_are_equal(keep1, keep2, tolerance):
+    """ Due to floating point precision, sometimes the positions of two kept boxes are reversed
+    """
+
+    equality_matrix = keep1[:, None] == keep2[None, :]
+    equality_indices = equality_matrix.nonzero()
+    difference = equality_indices[0] - equality_indices[0]
+    max_abs_dif = difference.abs().max()
+    return max_abs_dif < tolerance
+
+
+class TestSoftNMS(unittest.TestCase):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    methods = ["gaussian", "linear", "hard"]
+
+    def test_single_box(self):
+        boxes = torch.tensor([[10, 10, 15, 15]], dtype=torch.float, device=self.device)
+        scores = torch.tensor([1.0], device=self.device)
+        for method in self.methods:
+            keep = soft_nms(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0])
+            ), "Single box not kept for soft nms method {}.".format(method)
+
+    def test_two_separate_boxes(self):
+        boxes = torch.tensor([[10, 10, 15, 15], [20, 20, 25, 25]], dtype=torch.float)
+        scores = torch.tensor([1.0, 0.99])
+        for method in self.methods:
+            keep = soft_nms(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1])
+            ), "Separate boxes not kept for soft nms method {}".format(method)
+
+    def test_two_full_overlap(self):
+        boxes = torch.tensor([[10, 10, 15, 15], [10, 10, 15, 15]], dtype=torch.float)
+        scores = torch.tensor(([1.0, 0.4]))
+        for method in self.methods:
+            keep = soft_nms(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0])
+            ), "Box not suppressed properly for soft nms method {}.".format(method)
+
+    def test_no_boxes(self):
+        boxes = torch.tensor([], dtype=torch.float).reshape(0, 4)
+        scores = torch.tensor(([]))
+        for method in self.methods:
+            keep = soft_nms(boxes, scores, method, 0.5, 0.3)
+            assert keep.size()[0] == 0, "Soft nms failed for method {}".format(method)
+
+    def test_batched_single_box(self):
+        boxes = torch.tensor([[10, 10, 15, 15], [10, 10, 15, 15]], dtype=torch.float)
+        scores = torch.tensor([1.0, 0.4])
+        category_idxs = torch.tensor([0, 1])
+        for method in self.methods:
+            keep = batched_soft_nms(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1])
+            ), "Single box not kept for soft nms method {}.".format(method)
+
+    def test_bached_two_separate_boxes(self):
+        boxes = torch.tensor(
+            [[10, 10, 15, 15], [20, 20, 25, 25], [10, 10, 15, 15], [20, 20, 25, 25]],
+            dtype=torch.float,
+        )
+        scores = torch.tensor([1.0, 0.99, 0.98, 0.97])
+        category_idxs = torch.tensor([0, 0, 1, 1])
+        for method in self.methods:
+            keep = batched_soft_nms(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1, 2, 3])
+            ), "Separate boxes not kept for soft nms method {}".format(method)
+
+    def test_batched_two_full_overlap(self):
+        boxes = torch.tensor(
+            [[10, 10, 15, 15], [10, 10, 15, 15], [10, 10, 15, 15], [10, 10, 15, 15]],
+            dtype=torch.float,
+        )
+        scores = torch.tensor(([1.0, 0.4, 0.99, 0.4]))
+        category_idxs = torch.tensor([0, 0, 1, 1])
+        for method in self.methods:
+            keep = batched_soft_nms(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 2])
+            ), "Box not suppressed properly for soft nms method {}.".format(method)
+
+
+class TestSoftNMSRotated(unittest.TestCase):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    methods = ["gaussian", "linear", "hard"]
+
+    def _create_tensors(self, N):
+        boxes = torch.rand(N, 4, device=self.device) * 100
+        # Note: the implementation of this function in torchvision is:
+        # boxes[:, 2:] += torch.rand(N, 2) * 100
+        # but it does not guarantee non-negative widths/heights constraints:
+        # boxes[:, 2] >= boxes[:, 0] and boxes[:, 3] >= boxes[:, 1]:
+        boxes[:, 2:] += boxes[:, :2]
+        scores = torch.rand(N, device=self.device)
+        return boxes, scores
+
+    def test_single_box(self):
+        boxes = torch.tensor([[10, 10, 5, 5, 0]], dtype=torch.float)
+        scores = torch.tensor([1.0])
+        for method in self.methods:
+            keep = soft_nms_rotated(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0])
+            ), "Single box not kept for soft nms method {}.".format(method)
+
+    def test_two_separate_boxes(self):
+        boxes = torch.tensor(
+            [[10, 10, 5, 5, 0], [20, 20, 5, 5, 0]], dtype=torch.float, device=self.device
+        )
+        scores = torch.tensor([1.0, 0.99], device=self.device)
+        for method in self.methods:
+            keep = soft_nms_rotated(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1])
+            ), "Separate boxes not kept for soft nms method {}".format(method)
+
+    def test_two_full_overlap(self):
+        boxes = torch.tensor(
+            [[10, 10, 5, 5, 0], [10, 10, 5, 5, 0]], dtype=torch.float, device=self.device
+        )
+        scores = torch.tensor([1.0, 0.4], device=self.device)
+        for method in self.methods:
+            keep = soft_nms_rotated(boxes, scores, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0])
+            ), "Box not suppressed properly for soft nms method {}.".format(method)
+
+    def test_batched_single_box(self):
+        boxes = torch.tensor(
+            [[10, 10, 5, 5, 0], [10, 10, 5, 5, 0]], dtype=torch.float, device=self.device
+        )
+        scores = torch.tensor([1.0, 0.4], device=self.device)
+        category_idxs = torch.tensor([0, 1], device=self.device)
+        for method in self.methods:
+            keep = batched_soft_nms_rotated(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1])
+            ), "Single box not kept for soft nms method {}.".format(method)
+
+    def test_bached_two_separate_boxes(self):
+        boxes = torch.tensor(
+            [[10, 10, 5, 5, 0], [20, 20, 5, 5, 0], [10, 10, 5, 5, 0], [20, 20, 5, 5, 0]],
+            dtype=torch.float,
+            device=self.device,
+        )
+        scores = torch.tensor([1.0, 0.99, 0.98, 0.97], device=self.device)
+        category_idxs = torch.tensor([0, 0, 1, 1], device=self.device)
+        for method in self.methods:
+            keep = batched_soft_nms_rotated(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 1, 2, 3])
+            ), "Separate boxes not kept for soft nms method {}".format(method)
+
+    def test_batched_two_full_overlap(self):
+        boxes = torch.tensor(
+            [[10, 10, 5, 5, 0], [10, 10, 5, 5, 0], [10, 10, 5, 5, 0], [10, 10, 5, 5, 0]],
+            dtype=torch.float,
+            device=self.device,
+        )
+        scores = torch.tensor([1.0, 0.4, 0.99, 0.4], device=self.device)
+        category_idxs = torch.tensor([0, 0, 1, 1], device=self.device)
+        for method in self.methods:
+            keep = batched_soft_nms_rotated(boxes, scores, category_idxs, method, 0.5, 0.3)
+            assert torch.equal(
+                keep, torch.tensor([0, 2])
+            ), "Box not suppressed properly for soft nms method {}.".format(method)
+
+    def test_batched_nms_rotated_0_degree(self):
+        # torch.manual_seed(0)
+        N = 2000
+        num_classes = 50
+        boxes, scores = self._create_tensors(N)
+        idxs = torch.randint(0, num_classes, (N,))
+        rotated_boxes = torch.zeros(N, 5, device=self.device)
+        rotated_boxes[:, 0] = (boxes[:, 0] + boxes[:, 2]) / 2.0
+        rotated_boxes[:, 1] = (boxes[:, 1] + boxes[:, 3]) / 2.0
+        rotated_boxes[:, 2] = boxes[:, 2] - boxes[:, 0]
+        rotated_boxes[:, 3] = boxes[:, 3] - boxes[:, 1]
+        err_msg = (
+            "Rotated Soft NMS with 0 degree is incompatible with horizontal Soft NMS "
+            "for method={}, sigma={}, discard_threshold={}"
+        )
+        for method in self.methods:
+            for sigma in [0.5, 1.0, 2.0]:
+                for discard_threshold in [0.2, 0.5, 0.8]:
+                    backup = boxes.clone()
+                    keep_ref = batched_soft_nms(
+                        boxes, scores, idxs, method, sigma, discard_threshold
+                    )
+                    assert torch.allclose(boxes, backup), "boxes modified by batched_soft_nms"
+                    backup = rotated_boxes.clone()
+                    keep = batched_soft_nms_rotated(
+                        rotated_boxes, scores, idxs, method, sigma, discard_threshold
+                    )
+                    assert torch.allclose(
+                        rotated_boxes, backup
+                    ), "rotated_boxes modified by batched_soft_nms_rotated"
+                    assert keeps_are_equal(keep, keep_ref, 1), err_msg.format(
+                        method, sigma, discard_threshold
+                    )
+
+    def test_soft_nms_rotated_90_degrees(self):
+        N = 1000
+        boxes, scores = self._create_tensors(N)
+        rotated_boxes = torch.zeros(N, 5, device=self.device)
+        rotated_boxes[:, 0] = (boxes[:, 0] + boxes[:, 2]) / 2.0
+        rotated_boxes[:, 1] = (boxes[:, 1] + boxes[:, 3]) / 2.0
+        # Note for rotated_boxes[:, 2] and rotated_boxes[:, 3]:
+        # widths and heights are intentionally swapped here for 90 degrees case
+        # so that the reference horizontal nms could be used
+        rotated_boxes[:, 2] = boxes[:, 3] - boxes[:, 1]
+        rotated_boxes[:, 3] = boxes[:, 2] - boxes[:, 0]
+
+        rotated_boxes[:, 4] = torch.ones(N) * 90
+        err_msg = (
+            "Rotated Soft NMS with 90 degree is incompatible with horizontal Soft NMS "
+            "for method={}, sigma={}, discard_threshold={}"
+        )
+        for method in self.methods:
+            for sigma in [0.5, 1.0, 2.0]:
+                for discard_threshold in [0.2, 0.5, 0.8]:
+                    keep_ref = soft_nms(boxes, scores, method, sigma, discard_threshold)
+                    keep = soft_nms_rotated(rotated_boxes, scores, method, sigma, discard_threshold)
+                    assert keeps_are_equal(keep, keep_ref, 1), err_msg.format(
+                        method, sigma, discard_threshold
+                    )
+
+    def test_soft_nms_rotated_180_degrees(self):
+        N = 1000
+        boxes, scores = self._create_tensors(N)
+        rotated_boxes = torch.zeros(N, 5, device=self.device)
+        rotated_boxes[:, 0] = (boxes[:, 0] + boxes[:, 2]) / 2.0
+        rotated_boxes[:, 1] = (boxes[:, 1] + boxes[:, 3]) / 2.0
+        rotated_boxes[:, 2] = boxes[:, 2] - boxes[:, 0]
+        rotated_boxes[:, 3] = boxes[:, 3] - boxes[:, 1]
+        rotated_boxes[:, 4] = torch.ones(N) * 180
+        err_msg = (
+            "Rotated Soft NMS with 180 degree is incompatible with horizontal Soft NMS "
+            "for method={}, sigma={}, discard_threshold={}"
+        )
+        for method in self.methods:
+            for sigma in [0.5, 1.0, 2.0]:
+                for discard_threshold in [0.2, 0.5, 0.8]:
+                    keep_ref = soft_nms(boxes, scores, method, sigma, discard_threshold)
+                    keep = soft_nms_rotated(rotated_boxes, scores, method, sigma, discard_threshold)
+                    assert keeps_are_equal(keep, keep_ref, 1), err_msg.format(
+                        method, sigma, discard_threshold
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #980 

A pytorch implementation of Soft NMS for both Boxes and RotatedBoxes.

I have a cyclical dependency problem if I try to import soft_nms into layers. This is driven by the fact that `pairwise_iou` expected Boxes even though it only cares about tensors. In this way soft_nms needs access to structures to get Boxes. Open to suggestions for structural changes.

I have not run eval yet on pre-trained models to verify.

Unit tests pass except `test_model_e2e.py::MaskRCNNE2ETest::test_rpn_inf_nan_data` which I think isn't my fault?