### PR TITLE
filter_empty_instances with box threshold

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -325,7 +325,7 @@ def annotations_to_instances_rotated(annos, image_size):
     return target
 
 
-def filter_empty_instances(instances, by_box=True, by_mask=True):
+def filter_empty_instances(instances, by_box=True, by_mask=True, box_threshold=1e-5):
     """
     Filter out empty instances in an `Instances` object.
 
@@ -333,6 +333,7 @@ def filter_empty_instances(instances, by_box=True, by_mask=True):
         instances (Instances):
         by_box (bool): whether to filter out instances with empty boxes
         by_mask (bool): whether to filter out instances with empty masks
+        box_threshold (float): minimum width and height to be considered non-empty
 
     Returns:
         Instances: the filtered instances.
@@ -340,7 +341,7 @@ def filter_empty_instances(instances, by_box=True, by_mask=True):
     assert by_box or by_mask
     r = []
     if by_box:
-        r.append(instances.gt_boxes.nonempty())
+        r.append(instances.gt_boxes.nonempty(threshold=box_threshold))
     if instances.has("gt_masks") and by_mask:
         r.append(instances.gt_masks.nonempty())
 

--- a/detectron2/structures/boxes.py
+++ b/detectron2/structures/boxes.py
@@ -187,7 +187,7 @@ class Boxes:
         self.tensor[:, 2].clamp_(min=0, max=w)
         self.tensor[:, 3].clamp_(min=0, max=h)
 
-    def nonempty(self, threshold: int = 0) -> torch.Tensor:
+    def nonempty(self, threshold: float = 0.0) -> torch.Tensor:
         """
         Find boxes that are non-empty.
         A box is considered empty, if either of its side is no larger than threshold.

--- a/detectron2/structures/rotated_boxes.py
+++ b/detectron2/structures/rotated_boxes.py
@@ -298,7 +298,7 @@ class RotatedBoxes(Boxes):
         self.tensor[idx, 2] = torch.min(self.tensor[idx, 2], x2 - x1)
         self.tensor[idx, 3] = torch.min(self.tensor[idx, 3], y2 - y1)
 
-    def nonempty(self, threshold: int = 0) -> torch.Tensor:
+    def nonempty(self, threshold: float = 0.0) -> torch.Tensor:
         """
         Find boxes that are non-empty.
         A box is considered empty, if either of its side is no larger than threshold.


### PR DESCRIPTION
Minor change to enable passing a threshold through filter_empty_instances.
Due to floating point issues I had boxes with width 1e-14 that passed the 0 threshold but blew up later.
Also fixed the type hinting to float. These are floats.