### PR TITLE
Make padding shape tracable.

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -70,16 +70,21 @@ class ImageList(object):
             assert isinstance(t, torch.Tensor), type(t)
             assert t.shape[1:-2] == tensors[0].shape[1:-2], t.shape
         # per dimension maximum (H, W) or (C_1, ..., C_K, H, W) where K >= 1 among all tensors
-        max_size = tuple(max(s) for s in zip(*[img.shape for img in tensors]))
+        max_size = (
+            torch.stack(
+                [
+                    # Keep original tensor for tracing.
+                    torch.stack(size) if torch.is_tensor(size[0]) else torch.tensor(size)
+                    for size in [tuple(img.shape) for img in tensors]
+                ]
+            )
+            .max(0)
+            .values
+        )
 
         if size_divisibility > 0:
-            import math
-
             stride = size_divisibility
-            max_size = list(max_size)  # type: ignore
-            max_size[-2] = int(math.ceil(max_size[-2] / stride) * stride)  # type: ignore
-            max_size[-1] = int(math.ceil(max_size[-1] / stride) * stride)  # type: ignore
-            max_size = tuple(max_size)
+            max_size = torch.cat([max_size[:-2], (max_size[-2:] + (stride - 1)) // stride * stride])
 
         image_sizes = [tuple(im.shape[-2:]) for im in tensors]
 
@@ -94,8 +99,10 @@ class ImageList(object):
                 padded = F.pad(tensors[0], padding_size, value=pad_value)
                 batched_imgs = padded.unsqueeze_(0)
         else:
-            batch_shape = (len(tensors),) + max_size
-            batched_imgs = tensors[0].new_full(batch_shape, pad_value)
+            # Keep original tensor for tracing.
+            num_imgs = len(tensors) if torch.is_tensor(len(tensors)) else torch.tensor(len(tensors))
+            batch_shape = torch.cat([num_imgs[None], max_size])
+            batched_imgs = tensors[0].new_full(tuple(batch_shape), pad_value)
             for img, pad_img in zip(tensors, batched_imgs):
                 pad_img[..., : img.shape[-2], : img.shape[-1]].copy_(img)
 

--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -74,7 +74,7 @@ class ImageList(object):
             torch.stack(
                 [
                     # Keep original tensor for tracing.
-                    torch.stack(size) if torch.is_tensor(size[0]) else torch.tensor(size)
+                    torch.stack([torch.as_tensor(dim) for dim in size])
                     for size in [tuple(img.shape) for img in tensors]
                 ]
             )
@@ -100,8 +100,7 @@ class ImageList(object):
                 batched_imgs = padded.unsqueeze_(0)
         else:
             # Keep original tensor for tracing.
-            num_imgs = len(tensors) if torch.is_tensor(len(tensors)) else torch.tensor(len(tensors))
-            batch_shape = torch.cat([num_imgs[None], max_size])
+            batch_shape = torch.cat([torch.as_tensor(len(tensors))[None], max_size])
             batched_imgs = tensors[0].new_full(tuple(batch_shape), pad_value)
             for img, pad_img in zip(tensors, batched_imgs):
                 pad_img[..., : img.shape[-2], : img.shape[-1]].copy_(img)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -7,7 +7,9 @@ import pycocotools.mask as mask_util
 
 from detectron2.data import detection_utils
 from detectron2.data import transforms as T
-from detectron2.structures import BitMasks, BoxMode
+from detectron2.structures import BitMasks, BoxMode, ImageList
+
+import torch
 
 
 class TestTransformAnnotations(unittest.TestCase):
@@ -114,3 +116,10 @@ class TestTransformAnnotations(unittest.TestCase):
         instance = {"bbox": [10, 10, 100, 100], "bbox_mode": BoxMode.XYXY_ABS}
         with self.assertRaises(AssertionError):
             detection_utils.gen_crop_transform_with_instance((10, 10), (15, 15), instance)
+
+    def test_imagelist_padding_shape(self):
+        class TensorToImageList(torch.nn.Module):
+            def forward(self, tensor: torch.Tensor):
+                return ImageList.from_tensors([torch.ones((3, 10, 10))], 4).tensor
+        func = torch.jit.trace(TensorToImageList(), torch.ones((3, 10, 10), dtype=torch.float32))
+        func(torch.ones((3, 15, 20), dtype=torch.float32))

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -117,18 +117,21 @@ class TestTransformAnnotations(unittest.TestCase):
         with self.assertRaises(AssertionError):
             detection_utils.gen_crop_transform_with_instance((10, 10), (15, 15), instance)
 
-    def test_imagelist_padding_shape(self):
-        class TensorToImageList(torch.nn.Module):
-            def forward(self, tensors: Sequence[torch.Tensor]):
-                return ImageList.from_tensors(tensors, 4).tensor
 
+class TestInputShapeInferencing(unittest.TestCase):
+    class TensorsToImageList(torch.nn.Module):
+        def forward(self, tensors: Sequence[torch.Tensor]):
+            return ImageList.from_tensors(tensors, 4).tensor
+
+    def test_imagelist_single_padding_shape(self):
         func = torch.jit.trace(
-            TensorToImageList(), ([torch.ones((3, 10, 10), dtype=torch.float32)],)
+            self.TensorsToImageList(), ([torch.ones((3, 10, 10), dtype=torch.float32)],)
         )
         func([torch.ones((3, 15, 20), dtype=torch.float32)])
 
+    def test_imagelist_multi_padding_shape(self):
         func = torch.jit.trace(
-            TensorToImageList(),
+            self.TensorsToImageList(),
             (
                 [
                     torch.ones((3, 16, 10), dtype=torch.float32),

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -3,6 +3,7 @@
 import copy
 import numpy as np
 import unittest
+from typing import Sequence
 import pycocotools.mask as mask_util
 import torch
 
@@ -118,8 +119,26 @@ class TestTransformAnnotations(unittest.TestCase):
 
     def test_imagelist_padding_shape(self):
         class TensorToImageList(torch.nn.Module):
-            def forward(self, tensor: torch.Tensor):
-                return ImageList.from_tensors([torch.ones((3, 10, 10))], 4).tensor
+            def forward(self, tensors: Sequence[torch.Tensor]):
+                return ImageList.from_tensors(tensors, 4).tensor
 
-        func = torch.jit.trace(TensorToImageList(), torch.ones((3, 10, 10), dtype=torch.float32))
-        func(torch.ones((3, 15, 20), dtype=torch.float32))
+        func = torch.jit.trace(
+            TensorToImageList(), ([torch.ones((3, 10, 10), dtype=torch.float32)],)
+        )
+        func([torch.ones((3, 15, 20), dtype=torch.float32)])
+
+        func = torch.jit.trace(
+            TensorToImageList(),
+            (
+                [
+                    torch.ones((3, 16, 10), dtype=torch.float32),
+                    torch.ones((3, 13, 11), dtype=torch.float32),
+                ],
+            ),
+        )
+        func(
+            [
+                torch.ones((3, 25, 20), dtype=torch.float32),
+                torch.ones((3, 10, 10), dtype=torch.float32),
+            ]
+        )

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -4,12 +4,11 @@ import copy
 import numpy as np
 import unittest
 import pycocotools.mask as mask_util
+import torch
 
 from detectron2.data import detection_utils
 from detectron2.data import transforms as T
 from detectron2.structures import BitMasks, BoxMode, ImageList
-
-import torch
 
 
 class TestTransformAnnotations(unittest.TestCase):
@@ -121,5 +120,6 @@ class TestTransformAnnotations(unittest.TestCase):
         class TensorToImageList(torch.nn.Module):
             def forward(self, tensor: torch.Tensor):
                 return ImageList.from_tensors([torch.ones((3, 10, 10))], 4).tensor
+
         func = torch.jit.trace(TensorToImageList(), torch.ones((3, 10, 10), dtype=torch.float32))
         func(torch.ones((3, 15, 20), dtype=torch.float32))


### PR DESCRIPTION
Previously `max_size` will be hardcoded in traced ONNX model since some dataflow/computation is outside PyTorch.

The entire chunk between `[Sub, Div]`(whitening) and `Pad` shows how this shape inferencing works, with `size_divisibility==32` for this backbone.
`ceil()` is replaced with `[Add, Div, Mul]` in the middle, i.e. `(n + (m - 1)) // m * m` with constant folding for `m-1`.
<img width="479" alt="image" src="https://user-images.githubusercontent.com/5203025/79173373-e9d48780-7e29-11ea-880b-dc8612e027e2.png">
