### PR TITLE
Implement RandomApply which applies a transformation with a given probability

### DIFF
--- a/detectron2/data/transforms/transform_gen.py
+++ b/detectron2/data/transforms/transform_gen.py
@@ -21,6 +21,7 @@ from PIL import Image
 from .transform import ExtentTransform, ResizeTransform, RotationTransform
 
 __all__ = [
+    "RandomApply",
     "RandomBrightness",
     "RandomContrast",
     "RandomCrop",
@@ -111,6 +112,40 @@ class TransformGen(metaclass=ABCMeta):
             return super().__repr__()
 
     __str__ = __repr__
+
+
+class RandomApply(TransformGen):
+    """
+    Randomly apply the wrapper transformation with a given probability.
+    """
+
+    def __init__(self, transform, prob=0.5):
+        """
+        Args:
+            transform (Transform, TransformGen): the transform to be wrapped
+                by the `RandomApply`. The `transform` can either be a
+                `Transform` or `TransformGen` instance.
+            prob (float): probability between 0.0 and 1.0 that
+                the wrapper transformation is applied
+        """
+        super().__init__()
+        assert isinstance(transform, (Transform, TransformGen)), (
+            f"The given transform must either be a Transform or TransformGen instance. "
+            f"Not {type(transform)}"
+        )
+        assert 0.0 <= prob <= 1.0, f"Probablity must be between 0.0 and 1.0 (given: {prob})"
+        self.prob = prob
+        self.transform = transform
+
+    def get_transform(self, img):
+        do = self._rand_range() < self.prob
+        if do:
+            if isinstance(self.transform, TransformGen):
+                return self.transform.get_transform(img)
+            else:
+                return self.transform
+        else:
+            return NoOpTransform()
 
 
 class RandomFlip(TransformGen):

--- a/tests/data/test_transforms.py
+++ b/tests/data/test_transforms.py
@@ -4,6 +4,7 @@
 import logging
 import numpy as np
 import unittest
+from unittest import mock
 
 from detectron2.config import get_cfg
 from detectron2.data import detection_utils
@@ -78,3 +79,56 @@ class TestTransforms(unittest.TestCase):
 
         t = T.RandomFlip()
         self.assertTrue(str(t) == "RandomFlip()")
+
+    def test_random_apply_prob_out_of_range_check(self):
+        # GIVEN
+        test_probabilities = {0.0: True, 0.5: True, 1.0: True, -0.01: False, 1.01: False}
+
+        # WHEN
+        for given_probability, is_valid in test_probabilities.items():
+            # THEN
+            if not is_valid:
+                self.assertRaises(AssertionError, T.RandomApply, None, prob=given_probability)
+            else:
+                T.RandomApply(T.NoOpTransform(), prob=given_probability)
+
+    def test_random_apply_wrapping_transform_gen_probability_occured_evaluation(self):
+        # GIVEN
+        transform_mock = mock.MagicMock(name="MockTransform", spec=T.TransformGen)
+        image_mock = mock.MagicMock(name="MockImage")
+        random_apply = T.RandomApply(transform_mock, prob=0.001)
+
+        # WHEN
+        with mock.patch.object(random_apply, "_rand_range", return_value=0.0001):
+            transform = random_apply.get_transform(image_mock)
+
+        # THEN
+        transform_mock.get_transform.assert_called_once_with(image_mock)
+        self.assertIsNot(transform, transform_mock)
+
+    def test_random_apply_wrapping_std_transform_probability_occured_evaluation(self):
+        # GIVEN
+        transform_mock = mock.MagicMock(name="MockTransform", spec=T.Transform)
+        image_mock = mock.MagicMock(name="MockImage")
+        random_apply = T.RandomApply(transform_mock, prob=0.001)
+
+        # WHEN
+        with mock.patch.object(random_apply, "_rand_range", return_value=0.0001):
+            transform = random_apply.get_transform(image_mock)
+
+        # THEN
+        self.assertIs(transform, transform_mock)
+
+    def test_random_apply_probability_not_occured_evaluation(self):
+        # GIVEN
+        transform_mock = mock.MagicMock(name="MockTransform", spec=T.TransformGen)
+        image_mock = mock.MagicMock(name="MockImage")
+        random_apply = T.RandomApply(transform_mock, prob=0.001)
+
+        # WHEN
+        with mock.patch.object(random_apply, "_rand_range", return_value=0.9):
+            transform = random_apply.get_transform(image_mock)
+
+        # THEN
+        transform_mock.get_transform.assert_not_called()
+        self.assertIsInstance(transform, T.NoOpTransform)


### PR DESCRIPTION
As discussed in #1251 this change implements a `RandomApply` transformation generator which can be used to only apply a given transformation with a certain probability.

`RandomApply` supports wrapping of `T.Transform` and `T.TransformGen`.