### PR TITLE
Adding histograms to tensorboard

### DIFF
--- a/detectron2/utils/events.py
+++ b/detectron2/utils/events.py
@@ -304,7 +304,8 @@ class EventStorage:
 
     def put_histogram(self, hist_name, hist_tensor, bins=1000):
         """
-        Create an histogram of a numpy array, calculate its parameters and add them to `_histograms`.
+        Create an histogram of a numpy array, calculate its parameters and add them
+        to self `_histograms`.
 
         Args:
             hist_name (str): The name of the histogram to put into tensorboard.

--- a/detectron2/utils/events.py
+++ b/detectron2/utils/events.py
@@ -2,7 +2,6 @@
 import datetime
 import json
 import logging
-import numpy as np
 import os
 import time
 from collections import defaultdict
@@ -187,7 +186,7 @@ class CommonMetricPrinter(EventWriter):
             # estimate eta on our own - more noisy
             if self._last_write is not None:
                 estimate_iter_time = (time.perf_counter() - self._last_write[1]) / (
-                        iteration - self._last_write[0]
+                    iteration - self._last_write[0]
                 )
                 eta_seconds = estimate_iter_time * (self._max_iter - iteration)
                 eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
@@ -286,7 +285,7 @@ class EventStorage:
         existing_hint = self._smoothing_hints.get(name)
         if existing_hint is not None:
             assert (
-                    existing_hint == smoothing_hint
+                existing_hint == smoothing_hint
             ), "Scalar {} was put with a different smoothing_hint!".format(name)
         else:
             self._smoothing_hints[name] = smoothing_hint
@@ -314,22 +313,17 @@ class EventStorage:
             bins (int): Number of histogram bins.
         """
 
-        val_min, val_max = hist_tensor.min().item(), hist_tensor.max().item()
+        ht_min, ht_max = hist_tensor.min().item(), hist_tensor.max().item()
 
         # Create a histogram with PyTorch
         hist_counts = torch.histc(hist_tensor, bins=bins)
-        hist_edges = torch.linspace(
-            start=val_min,
-            end=val_max,
-            steps=bins + 1,
-            dtype=torch.float32
-        )
+        hist_edges = torch.linspace(start=ht_min, end=ht_max, steps=bins + 1, dtype=torch.float32)
 
         # Parameter for the add_histogram_raw function of the PyTorch SummaryWriter
         hist_params = dict(
             tag=hist_name,
-            min=val_min,
-            max=val_max,
+            min=ht_min,
+            max=ht_max,
             num=len(hist_tensor),
             sum=float(hist_tensor.sum()),
             sum_squares=float(torch.sum(hist_tensor ** 2)),

--- a/detectron2/utils/events.py
+++ b/detectron2/utils/events.py
@@ -2,12 +2,12 @@
 import datetime
 import json
 import logging
+import numpy as np
 import os
 import time
 from collections import defaultdict
 from contextlib import contextmanager
 import torch
-import numpy as np
 from fvcore.common.file_io import PathManager
 from fvcore.common.history_buffer import HistoryBuffer
 
@@ -187,7 +187,7 @@ class CommonMetricPrinter(EventWriter):
             # estimate eta on our own - more noisy
             if self._last_write is not None:
                 estimate_iter_time = (time.perf_counter() - self._last_write[1]) / (
-                        iteration - self._last_write[0]
+                    iteration - self._last_write[0]
                 )
                 eta_seconds = estimate_iter_time * (self._max_iter - iteration)
                 eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
@@ -286,7 +286,7 @@ class EventStorage:
         existing_hint = self._smoothing_hints.get(name)
         if existing_hint is not None:
             assert (
-                    existing_hint == smoothing_hint
+                existing_hint == smoothing_hint
             ), "Scalar {} was put with a different smoothing_hint!".format(name)
         else:
             self._smoothing_hints[name] = smoothing_hint
@@ -325,7 +325,7 @@ class EventStorage:
             sum_squares=float(np.sum(hist_tensor ** 2)),
             bucket_limits=limits[1:].tolist(),
             bucket_counts=counts.tolist(),
-            global_step=self._iter
+            global_step=self._iter,
         )
 
         self._histograms.append(hist_params)


### PR DESCRIPTION
Hey, 

as this is a small PR and I already implemented this feature for myself I did not open an issue.

Description:
I changed EventStorage and TensorboardXWriter such that histograms (for monitoring weights or gradients) can be saved to tensorboard.

To make this implementation as efficient as possible I calculate the histogram statistics for the add_histogram_raw function of the PyTorch SummaryWriter (instead of saving weight matrices). In general, I tried to match the information flow to that of the put_image function.

In my personal implementation I extended the EventStorage and TensorboardXWriter, but I thought that this might be a feature that Detectron could offer out of the box.

A possible example usage could be a Hook:
```
class HistogramHook(HookBase):
    def after_step(self):
        storage = self.trainer.storage
        hist_period = self.trainer.cfg.HIST_PERIOD

        if hist_period > 0 and storage.iter % hist_period == 0:
            self.add_histogram(self.trainer.model, storage)

    def add_histogram(self, model, storage):
        for i, (tag, value) in enumerate(model.named_parameters()):
            # E.g. add histograms for parameters of the Mask R-CNN mask head
            if tag.split(".")[1] == "mask_head":
                storage.put_histogram(tag, value.data.cpu().numpy())
```
Feedback is very much appreciated! :)

Best,
David 