### PR TITLE
Fix RLE segmentation to json for coco annotation.

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -336,7 +336,7 @@ def convert_to_coco_dict(dataset_name):
                     polygons = PolygonMasks([segmentation])
                     area = polygons.area()[0].item()
                 elif isinstance(segmentation, dict):  # RLE
-                    area = mask_util.area(segmentation)
+                    area = mask_util.area(segmentation).item()
                 else:
                     raise TypeError(f"Unknown segmentation type {type(segmentation)}!")
             else:
@@ -375,6 +375,10 @@ def convert_to_coco_dict(dataset_name):
 
             if "segmentation" in annotation:
                 coco_annotation["segmentation"] = annotation["segmentation"]
+                if isinstance(coco_annotation["segmentation"], dict):  # RLE
+                    coco_annotation["segmentation"]["counts"] = coco_annotation["segmentation"][
+                        "counts"
+                    ].decode("ascii")
 
             coco_annotations.append(coco_annotation)
 

--- a/tests/data/test_coco.py
+++ b/tests/data/test_coco.py
@@ -1,0 +1,76 @@
+import json
+import numpy as np
+import os
+import tempfile
+import unittest
+import pycocotools
+
+from detectron2.data import DatasetCatalog, MetadataCatalog
+from detectron2.data.datasets.coco import convert_to_coco_dict, load_coco_json
+from detectron2.structures import BoxMode
+
+
+def make_mask():
+    """
+    Makes a donut shaped binary mask.
+    """
+    H = 100
+    W = 100
+    mask = np.zeros([H, W], dtype=np.uint8)
+    for x in range(W):
+        for y in range(H):
+            d = np.linalg.norm(np.array([W, H]) / 2 - np.array([x, y]))
+            if d > 10 and d < 20:
+                mask[y, x] = 1
+    return mask
+
+
+def make_dataset_dicts(mask):
+    """
+    Returns a list of dicts that represents a single COCO data point for
+    object detection. The single instance given by `mask` is represented by
+    RLE.
+    """
+    record = {}
+    record["file_name"] = "test"
+    record["image_id"] = 0
+    record["height"] = mask.shape[0]
+    record["width"] = mask.shape[1]
+
+    y, x = np.nonzero(mask)
+    segmentation = pycocotools.mask.encode(np.asarray(mask, order="F"))
+    min_x = np.min(x)
+    max_x = np.max(x)
+    min_y = np.min(y)
+    max_y = np.max(y)
+    obj = {
+        "bbox": [min_x, min_y, max_x, max_y],
+        "bbox_mode": BoxMode.XYXY_ABS,
+        "category_id": 0,
+        "iscrowd": 0,
+        "segmentation": segmentation,
+    }
+    record["annotations"] = [obj]
+    return [record]
+
+
+class TestRLEToJson(unittest.TestCase):
+    def test(self):
+        # Make a dummy dataset.
+        mask = make_mask()
+        DatasetCatalog.register("test_dataset", lambda: make_dataset_dicts(mask))
+        MetadataCatalog.get("test_dataset").set(thing_classes=["test_label"])
+
+        # Dump to json.
+        json_dict = convert_to_coco_dict("test_dataset")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            json_file_name = os.path.join(tmpdir, "test.json")
+            with open(os.path.join(tmpdir, "test.json"), "w") as f:
+                json.dump(json_dict, f)
+            # Load from json.
+            dicts = load_coco_json(json_file_name, "")
+
+        # Check the loaded mask matches the original.
+        anno = dicts[0]["annotations"][0]
+        loaded_mask = pycocotools.mask.decode(anno["segmentation"])
+        self.assertTrue(np.array_equal(loaded_mask, mask))

--- a/tests/data/test_coco.py
+++ b/tests/data/test_coco.py
@@ -65,7 +65,7 @@ class TestRLEToJson(unittest.TestCase):
         json_dict = convert_to_coco_dict("test_dataset")
         with tempfile.TemporaryDirectory() as tmpdir:
             json_file_name = os.path.join(tmpdir, "test.json")
-            with open(os.path.join(tmpdir, "test.json"), "w") as f:
+            with open(json_file_name, "w") as f:
                 json.dump(json_dict, f)
             # Load from json.
             dicts = load_coco_json(json_file_name, "")


### PR DESCRIPTION
I got `TypeError: Object of type 'uint32' is not JSON serializable` for `area`, and `TypeError: Object of type 'bytes' is not JSON serializable` for `segmentation["counts"]`during json dump. 

Relates to #200 