### PR TITLE
Handle pillow exif orientation flag more correctly

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -42,13 +42,8 @@ def apply_exif_orientation(image):
     if exif is None:
         return image
 
-    exif = {
-        ExifTags.TAGS[k]: v
-        for k, v in exif.items()
-        if k in ExifTags.TAGS
-    }
-
-    orientation = exif.get('Orientation', None)
+    exif = {ExifTags.TAGS[k]: v for k, v in exif.items() if k in ExifTags.TAGS}
+    orientation = exif.get("Orientation", None)
     if orientation == 1:
         # do nothing
         return image

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -35,8 +35,8 @@ class SizeMismatchError(ValueError):
 
 def apply_exif_orientation(image):
     """
-    Handle pillow EXIF Orientation flag, see discussion at:https://stackoverflow.com/a/6218425/4999289
-    This function is copied from: https://github.com/wkentaro/labelme/blob/master/labelme/utils/image.py#L46
+    Handle pillow EXIF Orientation flag, see: https://stackoverflow.com/a/6218425/4999289
+    Grab from: https://github.com/wkentaro/labelme/blob/master/labelme/utils/image.py#L46
     """
     exif = image._getexif()
     if exif is None:


### PR DESCRIPTION
This pr solves `SizeMismatchError` caused by pillow exif orientation flag when the image is rotated 90/270 degrees(It also handles other orientation which will not raise an error).  See [discussion at stackoverflow](https://stackoverflow.com/questions/4228530/pil-thumbnail-is-rotating-my-image/6218425#6218425)