### PR TITLE
Fix spelling of skipTest()

### DIFF
--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -49,7 +49,7 @@ class TestCaffe2Export(unittest.TestCase):
             file_name = DatasetCatalog.get("coco_2017_train")[0]["file_name"]
             assert PathManager.exists(file_name)
         except Exception:
-            self.SkipTest("COCO dataset not available.")
+            self.skipTest("COCO dataset not available.")
 
         with PathManager.open(file_name, "rb") as f:
             buf = f.read()


### PR DESCRIPTION
The unittest module's exception for skipping tests is capitalized
("SkipTest") but the TestCase class's method for skipping is not
("skipTest"). Fix the spelling in TestCaffe2Export._get_test_image()
to avoid:

AttributeError: 'TestCaffe2Export' object has no attribute 'SkipTest'