### PR TITLE
add flag `do_postprocess` to forward function of GeneralisedRCNN, to disable postprecessing

### DIFF
--- a/detectron2/modeling/meta_arch/rcnn.py
+++ b/detectron2/modeling/meta_arch/rcnn.py
@@ -7,7 +7,6 @@ from torch import nn
 from detectron2.structures import ImageList
 from detectron2.utils.events import get_event_storage
 from detectron2.utils.logger import log_first_n
-from detectron2.utils.memory import retry_if_cuda_oom
 
 from ..backbone import build_backbone
 from ..postprocessing import detector_postprocess
@@ -199,7 +198,7 @@ class GeneralizedRCNN(nn.Module):
         ):
             height = input_per_image.get("height", image_size[0])
             width = input_per_image.get("width", image_size[1])
-            r = retry_if_cuda_oom(detector_postprocess)(results_per_image, height, width)
+            r = detector_postprocess(results_per_image, height, width)
             processed_results.append({"instances": r})
         return processed_results
 

--- a/detectron2/modeling/meta_arch/rcnn.py
+++ b/detectron2/modeling/meta_arch/rcnn.py
@@ -7,6 +7,7 @@ from torch import nn
 from detectron2.structures import ImageList
 from detectron2.utils.events import get_event_storage
 from detectron2.utils.logger import log_first_n
+from detectron2.utils.memory import retry_if_cuda_oom
 
 from ..backbone import build_backbone
 from ..postprocessing import detector_postprocess
@@ -198,7 +199,7 @@ class GeneralizedRCNN(nn.Module):
         ):
             height = input_per_image.get("height", image_size[0])
             width = input_per_image.get("width", image_size[1])
-            r = detector_postprocess(results_per_image, height, width)
+            r = retry_if_cuda_oom(detector_postprocess)(results_per_image, height, width)
             processed_results.append({"instances": r})
         return processed_results
 

--- a/detectron2/modeling/meta_arch/rcnn.py
+++ b/detectron2/modeling/meta_arch/rcnn.py
@@ -81,7 +81,7 @@ class GeneralizedRCNN(nn.Module):
             storage.put_image(vis_name, vis_img)
             break  # only visualize one image in a batch
 
-    def forward(self, batched_inputs):
+    def forward(self, batched_inputs, do_postprocess=True):
         """
         Args:
             batched_inputs: a list, batched outputs of :class:`DatasetMapper` .
@@ -105,7 +105,7 @@ class GeneralizedRCNN(nn.Module):
                 "pred_boxes", "pred_classes", "scores", "pred_masks", "pred_keypoints"
         """
         if not self.training:
-            return self.inference(batched_inputs)
+            return self.inference(batched_inputs, do_postprocess=do_postprocess)
 
         images = self.preprocess_image(batched_inputs)
         if "instances" in batched_inputs[0]:

--- a/detectron2/modeling/meta_arch/rcnn.py
+++ b/detectron2/modeling/meta_arch/rcnn.py
@@ -81,7 +81,7 @@ class GeneralizedRCNN(nn.Module):
             storage.put_image(vis_name, vis_img)
             break  # only visualize one image in a batch
 
-    def forward(self, batched_inputs, do_postprocess=True):
+    def forward(self, batched_inputs):
         """
         Args:
             batched_inputs: a list, batched outputs of :class:`DatasetMapper` .
@@ -105,7 +105,7 @@ class GeneralizedRCNN(nn.Module):
                 "pred_boxes", "pred_classes", "scores", "pred_masks", "pred_keypoints"
         """
         if not self.training:
-            return self.inference(batched_inputs, do_postprocess=do_postprocess)
+            return self.inference(batched_inputs)
 
         images = self.preprocess_image(batched_inputs)
         if "instances" in batched_inputs[0]:

--- a/detectron2/modeling/postprocessing.py
+++ b/detectron2/modeling/postprocessing.py
@@ -3,6 +3,7 @@ from torch.nn import functional as F
 
 from detectron2.layers import paste_masks_in_image
 from detectron2.structures import Instances
+from detectron2.utils.memory import retry_if_cuda_oom
 
 
 def detector_postprocess(results, output_height, output_width, mask_threshold=0.5):
@@ -38,7 +39,7 @@ def detector_postprocess(results, output_height, output_width, mask_threshold=0.
     results = results[output_boxes.nonempty()]
 
     if results.has("pred_masks"):
-        results.pred_masks = paste_masks_in_image(
+        results.pred_masks = retry_if_cuda_oom(paste_masks_in_image)(
             results.pred_masks[:, 0, :, :],  # N, 1, M, M
             results.pred_boxes,
             results.image_size,


### PR DESCRIPTION
Hello, 

As described in this old issue [comment](https://github.com/facebookresearch/detectron2/issues/321#issuecomment-568343346), storing a few large masks in the GPU can easily lead to an OOM error, and it happens during the postprocessing phase of the inference/eval, my original idea was to add a `postprocessing_device` kwarg to the `forward` function to define which device to use for the postprocessing but it seems like it can lead to a mess and needed more thinking, 

Instead, I propose this simple change to allow users to disable the default `postprocessing` and apply their own afterward in another device if they chose to.
