### PR TITLE
Better handling empty proposals in FastRCNNOutputs

### DIFF
--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -185,7 +185,7 @@ class FastRCNNOutputs(object):
                 self.gt_classes = cat([p.gt_classes for p in proposals], dim=0)
         else:
             self.proposals = Boxes(torch.zeros(0, 4, device=self.pred_proposal_deltas.device))
-        self._no_instances = len(proposals) == 0  # no instances found
+        self._no_instances = self.proposals.shape[0] == 0  # no instances found
 
     def _log_accuracy(self):
         """


### PR DESCRIPTION
Fixes issue encountered when training CascadeMaskRCNN - empty proposals are generated for all the images in the batch, causing errors in loss calculation
