### PR TITLE
Make matcher JIT-capable.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # Keep in sync with setup.cfg which is used for source packages.
 
 [flake8]
-ignore = W503, E203, E221, C901, C408, E741
+ignore = W503, E203, E221, C901, C408, E741, C407
 max-line-length = 100
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/detectron2/layers/__init__.py
+++ b/detectron2/layers/__init__.py
@@ -6,7 +6,7 @@ from .nms import batched_nms, batched_nms_rotated, nms, nms_rotated
 from .roi_align import ROIAlign, roi_align
 from .roi_align_rotated import ROIAlignRotated, roi_align_rotated
 from .shape_spec import ShapeSpec
-from .wrappers import BatchNorm2d, Conv2d, ConvTranspose2d, cat, interpolate, Linear
+from .wrappers import BatchNorm2d, Conv2d, ConvTranspose2d, cat, interpolate, Linear, nonzero_tuple
 from .blocks import CNNBlockBase
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -214,3 +214,13 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     output_shape = tuple(_output_size(2))
     output_shape = input.shape[:-2] + output_shape
     return _NewEmptyTensorOp.apply(input, output_shape)
+
+
+def nonzero_tuple(x):
+    """
+    A 'as_tuple=True' version of torch.nonzero to support torchscript.
+    because of https://github.com/pytorch/pytorch/issues/38718
+    """
+    if x.dim() == 0:
+        return x.unsqueeze(0).nonzero().unbind(1)
+    return x.nonzero().unbind(1)

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -52,8 +52,8 @@ class Matcher(object):
         thresholds.insert(0, -float("inf"))
         thresholds.append(float("inf"))
         # Currently torchscript does not support all + generator
-        assert all(
-            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]  # noqa: C407
+        assert all(  # noqa: C407
+            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]
         )
         assert all([l in [-1, 0, 1] for l in labels])  # noqa: C407
         assert len(labels) == len(thresholds) - 1

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -96,6 +96,8 @@ class Matcher(object):
 
         for (l, low, high) in zip(self.labels, self.thresholds[:-1], self.thresholds[1:]):
             low_high = (matched_vals >= low) & (matched_vals < high)
+            # directly assign l to match_labels[low_high] is not supported by torch.jit.
+            # https://github.com/pytorch/pytorch/issues/38962
             match_labels.masked_fill_(low_high, l)
 
         if self.allow_low_quality_matches:

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -5,7 +5,6 @@ import torch
 from detectron2.layers import nonzero_tuple
 
 
-@torch.jit.script
 class Matcher(object):
     """
     This class assigns to each predicted "element" (e.g., a box) a ground-truth

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -52,10 +52,8 @@ class Matcher(object):
         thresholds.insert(0, -float("inf"))
         thresholds.append(float("inf"))
         # Currently torchscript does not support all + generator
-        assert all(  # noqa: C407
-            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]
-        )
-        assert all([l in [-1, 0, 1] for l in labels])  # noqa: C407
+        assert all([low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])])
+        assert all([l in [-1, 0, 1] for l in labels])
         assert len(labels) == len(thresholds) - 1
         self.thresholds = thresholds
         self.labels = labels

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -53,8 +53,8 @@ class Matcher(object):
         thresholds.append(float("inf"))
         # Currently torchscript does not support all + generator
         assert all(
-            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]
-        )  # noqa: C407
+            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]  # noqa: C407
+        )
         assert all([l in [-1, 0, 1] for l in labels])  # noqa: C407
         assert len(labels) == len(thresholds) - 1
         self.thresholds = thresholds

--- a/detectron2/modeling/matcher.py
+++ b/detectron2/modeling/matcher.py
@@ -51,8 +51,11 @@ class Matcher(object):
         assert thresholds[0] > 0
         thresholds.insert(0, -float("inf"))
         thresholds.append(float("inf"))
-        assert all([low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])])
-        assert all([l in [-1, 0, 1] for l in labels])
+        # Currently torchscript does not support all + generator
+        assert all(
+            [low <= high for (low, high) in zip(thresholds[:-1], thresholds[1:])]
+        )  # noqa: C407
+        assert all([l in [-1, 0, 1] for l in labels])  # noqa: C407
         assert len(labels) == len(thresholds) - 1
         self.thresholds = thresholds
         self.labels = labels

--- a/detectron2/modeling/poolers.py
+++ b/detectron2/modeling/poolers.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 from torchvision.ops import RoIPool
 
-from detectron2.layers import ROIAlign, ROIAlignRotated, cat
+from detectron2.layers import ROIAlign, ROIAlignRotated, cat, nonzero_tuple
 
 __all__ = ["ROIPooler"]
 
@@ -227,7 +227,7 @@ class ROIPooler(nn.Module):
         )
 
         for level, (x_level, pooler) in enumerate(zip(x, self.level_poolers)):
-            inds = torch.nonzero(level_assignments == level, as_tuple=True)[0]
+            inds = nonzero_tuple(level_assignments == level)[0]
             pooler_fmt_boxes_level = pooler_fmt_boxes[inds]
             output[inds] = pooler(x_level, pooler_fmt_boxes_level)
 

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -6,7 +6,7 @@ from torch import nn
 from torch.nn import functional as F
 
 from detectron2.config import configurable
-from detectron2.layers import Linear, ShapeSpec, batched_nms, cat
+from detectron2.layers import Linear, ShapeSpec, batched_nms, cat, nonzero_tuple
 from detectron2.modeling.box_regression import Box2BoxTransform
 from detectron2.structures import Boxes, Instances
 from detectron2.utils.events import get_event_storage
@@ -248,9 +248,7 @@ class FastRCNNOutputs(object):
         # Empty fg_inds produces a valid loss of zero as long as the size_average
         # arg to smooth_l1_loss is False (otherwise it uses torch.mean internally
         # and would produce a nan loss).
-        fg_inds = torch.nonzero(
-            (self.gt_classes >= 0) & (self.gt_classes < bg_class_ind), as_tuple=True
-        )[0]
+        fg_inds = nonzero_tuple((self.gt_classes >= 0) & (self.gt_classes < bg_class_ind))[0]
         if cls_agnostic_bbox_reg:
             # pred_proposal_deltas only corresponds to foreground class for agnostic
             gt_class_cols = torch.arange(box_dim, device=device)

--- a/detectron2/modeling/roi_heads/roi_heads.py
+++ b/detectron2/modeling/roi_heads/roi_heads.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 
 from detectron2.config import configurable
-from detectron2.layers import ShapeSpec
+from detectron2.layers import ShapeSpec, nonzero_tuple
 from detectron2.structures import Boxes, ImageList, Instances, pairwise_iou
 from detectron2.utils.events import get_event_storage
 from detectron2.utils.registry import Registry
@@ -111,7 +111,7 @@ def select_proposals_with_visible_keypoints(proposals: List[Instances]) -> List[
             & (ys <= proposal_boxes[:, :, 3])
         )
         selection = (kp_in_box & vis_mask).any(dim=1)
-        selection_idxs = torch.nonzero(selection, as_tuple=True)[0]
+        selection_idxs = nonzero_tuple(selection)[0]
         all_num_fg.append(selection_idxs.numel())
         ret.append(proposals_per_image[selection_idxs])
 

--- a/detectron2/modeling/sampling.py
+++ b/detectron2/modeling/sampling.py
@@ -1,6 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import torch
 
+from detectron2.layers import nonzero_tuple
+
 __all__ = ["subsample_labels"]
 
 
@@ -33,8 +35,8 @@ def subsample_labels(
         pos_idx, neg_idx (Tensor):
             1D vector of indices. The total length of both is `num_samples` or fewer.
     """
-    positive = torch.nonzero((labels != -1) & (labels != bg_label), as_tuple=True)[0]
-    negative = torch.nonzero(labels == bg_label, as_tuple=True)[0]
+    positive = nonzero_tuple((labels != -1) & (labels != bg_label))[0]
+    negative = nonzero_tuple(labels == bg_label)[0]
 
     num_pos = int(num_samples * positive_fraction)
     # protect against not enough positive examples

--- a/tests/modeling/test_matcher.py
+++ b/tests/modeling/test_matcher.py
@@ -29,11 +29,11 @@ class TestMatcher(unittest.TestCase):
         # https://github.com/pytorch/pytorch/issues/38964
         from detectron2.layers import nonzero_tuple  # noqa F401
 
-        scrpted_matcher = torch.jit.script(Matcher)
-        scrpted_anchor_matcher = scrpted_matcher(
+        scripted_matcher = torch.jit.script(Matcher)
+        scripted_anchor_matcher = scripted_matcher(
             cfg.MODEL.RPN.IOU_THRESHOLDS, cfg.MODEL.RPN.IOU_LABELS, allow_low_quality_matches=True
         )
-        matches, match_labels = scrpted_anchor_matcher(match_quality_matrix)
+        matches, match_labels = scripted_anchor_matcher(match_quality_matrix)
         assert torch.allclose(matches, expected_matches)
         assert torch.allclose(match_labels, expected_match_labels)
 


### PR DESCRIPTION
One point that needs further discussion is how to handle `torch.nonzero`. As discussed in [here](https://github.com/pytorch/pytorch/issues/38718), currently torchscript does not support `torch.nonzero` when `as_tuple` is explicitly set. I write a `as_tuple=True` version of torch.nonzero to replace that in this pr.