### PR TITLE
Assertion bugfix for apply_deltas in Box2BoxTransformRotated

### DIFF
--- a/detectron2/modeling/box_regression.py
+++ b/detectron2/modeling/box_regression.py
@@ -183,7 +183,7 @@ class Box2BoxTransformRotated(object):
                 deltas[i] represents box transformation for the single box boxes[i].
             boxes (Tensor): boxes to transform, of shape (N, 5)
         """
-        assert deltas.shape[1] == 5 and boxes.shape[1] == 5
+        assert deltas.shape[1] % 5 == 0 and boxes.shape[1] == 5
 
         boxes = boxes.to(deltas.dtype).unsqueeze(2)
 


### PR DESCRIPTION
As of facebookresearch/detectron2@bf11a9b5bbc8e80cfe713c547203576a77a09065, deltas have shape `(N, k*5)` but assertion hasn't been updated to reflect this.

