### PR TITLE
Adding the input device to the new tensor

### DIFF
--- a/detectron2/modeling/roi_heads/roi_heads.py
+++ b/detectron2/modeling/roi_heads/roi_heads.py
@@ -206,7 +206,7 @@ class ROIHeads(torch.nn.Module):
             # Label ignore proposals (-1 label)
             gt_classes[matched_labels == -1] = -1
         else:
-            gt_classes = torch.zeros_like(matched_idxs) + self.num_classes
+            gt_classes = torch.zeros_like(matched_idxs, device=gt_classes.device) + self.num_classes
 
         sampled_fg_idxs, sampled_bg_idxs = subsample_labels(
             gt_classes, self.batch_size_per_image, self.positive_fraction, self.num_classes


### PR DESCRIPTION
In case `gt_classes.numel()==0`, an all background tensor will be created by running:
`gt_classes = torch.zeros_like(matched_idxs) + self.num_classes`

This line creates a tensor on the CPU rather than on the GPU. It causes an issue later when trying to concatenate all gt_classes from all proposals. 

I modified it to the following by adding the gt_classes input device:
`gt_classes = torch.zeros_like(matched_idxs, device=gt_classes.device) + self.num_classes
`