### PR TITLE
Enabling more flexible feature shapes for FPN

### DIFF
--- a/detectron2/modeling/backbone/fpn.py
+++ b/detectron2/modeling/backbone/fpn.py
@@ -128,8 +128,9 @@ class FPN(Backbone):
         for features, lateral_conv, output_conv in zip(
             x[1:], self.lateral_convs[1:], self.output_convs[1:]
         ):
-            top_down_features = F.interpolate(prev_features, scale_factor=2, mode="nearest")
             lateral_features = lateral_conv(features)
+            top_down_size = lateral_features.shape[-2:]  # (height, width)
+            top_down_features = F.interpolate(prev_features, size=top_down_size, mode="nearest")
             prev_features = lateral_features + top_down_features
             if self._fuse_type == "avg":
                 prev_features /= 2


### PR DESCRIPTION
In certain cases, the current implementation of `FPN` doesn't allow for certain image shapes, and raises errors that look like the following:
```python
RuntimeError: The size of tensor a (17) must match the size of tensor b (18) at non-singleton dimension 2
```
This seems to be coming from the fact that features are interpolated with a scale factor of 2, which in some cases must round down the feature size. This PR addresses this issue by explicitly providing the target top-down feature shape for interpolation.