### PR TITLE
fix a bug in voc_eval()

### DIFF
--- a/detectron2/evaluation/pascal_voc_evaluation.py
+++ b/detectron2/evaluation/pascal_voc_evaluation.py
@@ -245,7 +245,7 @@ def voc_eval(detpath, annopath, imagesetfile, classname, ovthresh=0.5, use_07_me
     tp = np.zeros(nd)
     fp = np.zeros(nd)
     for d in range(nd):
-        R = class_recs[image_ids[d]]
+        R = class_recs[imagenames[int(image_ids[d])]]
         bb = BB[d, :].astype(float)
         ovmax = -np.inf
         BBGT = R["bbox"].astype(float)


### PR DESCRIPTION
# fix a KeyError bug in the function voc_eval()

Based on the definition in line 226, the key of `class_recs` should be `imagename`, instead of `image_id`. 

Actually, `image_id` should be the index of `imagename` in `imagenames` , but it can be seen from line 231~234 that the type of `image_id` is string, and need to be converted into int. 