### PR TITLE
Add PyTorch 1.6 to CI, fix errors related to new release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,10 +157,10 @@ workflows:
     jobs:
       - cpu_tests
       - gpu_tests:
-          name: gpu_tests_pytorch1.4
-          pytorch_version: '1.4'
-          torchvision_version: '0.5'
-      - gpu_tests:
           name: gpu_tests_pytorch1.5
           pytorch_version: '1.5'
           torchvision_version: '0.6'
+      - gpu_tests:
+          name: gpu_tests_pytorch1.6
+          pytorch_version: '1.6'
+          torchvision_version: '0.7'

--- a/detectron2/modeling/postprocessing.py
+++ b/detectron2/modeling/postprocessing.py
@@ -41,8 +41,8 @@ def detector_postprocess(results, output_height, output_width, mask_threshold=0.
         output_height_tmp = output_height
 
     scale_x, scale_y = (
-        output_width_tmp / results.image_size[1],
-        output_height_tmp / results.image_size[0],
+        output_width_tmp.true_divide(results.image_size[1]),
+        output_height_tmp.true_divide(results.image_size[0]),
     )
     results = Instances((output_height, output_width), **results.get_fields())
 

--- a/detectron2/modeling/postprocessing.py
+++ b/detectron2/modeling/postprocessing.py
@@ -32,11 +32,15 @@ def detector_postprocess(results, output_height, output_width, mask_threshold=0.
     #   computing scale_x and scale_y.
     if isinstance(output_width, torch.Tensor):
         output_width_tmp = output_width.float()
+    elif isinstance(output_width, int):
+        output_width_tmp = float(output_width)
     else:
         output_width_tmp = output_width
 
     if isinstance(output_height, torch.Tensor):
         output_height_tmp = output_height.float()
+    elif isinstance(output_height, int):
+        output_height_tmp = float(output_height)
     else:
         output_height_tmp = output_height
 

--- a/docker/Dockerfile-circleci
+++ b/docker/Dockerfile-circleci
@@ -14,4 +14,4 @@ RUN wget -q https://bootstrap.pypa.io/get-pip.py && \
 RUN pip install tensorboard opencv-python-headless
 ARG PYTORCH_VERSION
 ARG TORCHVISION_VERSION
-RUN pip install torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f https://download.pytorch.org/whl/cu101/torch_stable.html
+RUN pip install torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f https://download.pytorch.org/whl/cu101/torch_stable.html -f https://download.pytorch.org/whl/test/cu101/torch_test.html


### PR DESCRIPTION
Results from the integration tests that were ran can be found here: https://app.circleci.com/pipelines/github/pytorch/pytorch-integration-testing/28/workflows/80c9c991-949b-4928-a89b-a26c5f023f8f/jobs/149

Ran into an error message when running tests that use this function for
the PyTorch 1.6 release:

> Integer division of tensors using div or / is no longer supported

Replaced the regular divide with a floor divide
