### PR TITLE
Make augmentation configurable

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -71,7 +71,14 @@ _C.INPUT.CROP.TYPE = "relative_range"
 # Size of crop in range (0, 1] if CROP.TYPE is "relative" or "relative_range" and in number of
 # pixels if CROP.TYPE is "absolute"
 _C.INPUT.CROP.SIZE = [0.9, 0.9]
-
+_C.INPUT.AUGMENTATION = [
+    {
+        "name": "RandomFlip",
+        "prob": 0.5,
+        "horizontal": True,
+        "vertical": False,
+    }
+]
 
 # Whether the model needs RGB, YUV, HSV etc.
 # Should be one of the modes defined here, as we use PIL to read the image:

--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -71,15 +71,8 @@ _C.INPUT.CROP.TYPE = "relative_range"
 # Size of crop in range (0, 1] if CROP.TYPE is "relative" or "relative_range" and in number of
 # pixels if CROP.TYPE is "absolute"
 _C.INPUT.CROP.SIZE = [0.9, 0.9]
-_C.INPUT.AUGMENTATION = [
-    {
-        "name": "RandomFlip",
-        "prob": 0.5,
-        "horizontal": True,
-        "vertical": False,
-    }
-]
-
+# Augmentations are executed sequentially in the order of this list
+_C.INPUT.AUGMENTATION = [{"name": "RandomFlip", "prob": 0.5, "horizontal": True, "vertical": False}]
 # Whether the model needs RGB, YUV, HSV etc.
 # Should be one of the modes defined here, as we use PIL to read the image:
 # https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -5,6 +5,7 @@
 Common data processing utilities that are used in a
 typical object detection data pipeline.
 """
+import copy
 import logging
 import numpy as np
 import pycocotools.mask as mask_util
@@ -25,6 +26,7 @@ from detectron2.structures import (
 
 from . import transforms as T
 from .catalog import MetadataCatalog
+from .transforms import AUGMENTATION_REGISTRY
 
 __all__ = [
     "SizeMismatchError",
@@ -576,7 +578,11 @@ def build_augmentation(cfg, is_train):
         sample_style = "choice"
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
     if is_train:
-        augmentation.append(T.RandomFlip())
+        for aug in cfg.INPUT.AUGMENTATION:
+            name = aug["name"]
+            kwargs = copy.copy(aug)
+            kwargs.pop("name", None)
+            augmentation.append(AUGMENTATION_REGISTRY.get(aug["name"])(**kwargs))
     return augmentation
 
 

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -581,7 +581,6 @@ def build_augmentation(cfg, is_train):
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
     if is_train:
         for aug in cfg.INPUT.AUGMENTATION:
-            name = aug["name"]
             kwargs = copy.copy(aug)
             kwargs.pop("name", None)
             augmentation.append(AUGMENTATION_REGISTRY.get(aug["name"])(**kwargs))

--- a/detectron2/data/transforms/augmentation_impl.py
+++ b/detectron2/data/transforms/augmentation_impl.py
@@ -15,10 +15,10 @@ from fvcore.transforms.transform import (
 )
 from PIL import Image
 
+from detectron2.utils.registry import Registry
+
 from .augmentation import Augmentation
 from .transform import ExtentTransform, ResizeTransform, RotationTransform
-
-from detectron2.utils.registry import Registry
 
 AUGMENTATION_REGISTRY = Registry("AUGMENTATION")
 AUGMENTATION_REGISTRY.__doc__ = """

--- a/detectron2/data/transforms/augmentation_impl.py
+++ b/detectron2/data/transforms/augmentation_impl.py
@@ -18,7 +18,16 @@ from PIL import Image
 from .augmentation import Augmentation
 from .transform import ExtentTransform, ResizeTransform, RotationTransform
 
+from detectron2.utils.registry import Registry
+
+AUGMENTATION_REGISTRY = Registry("AUGMENTATION")
+AUGMENTATION_REGISTRY.__doc__ = """
+Registry for augmentation.
+"""
+
+
 __all__ = [
+    "AUGMENTATION_REGISTRY",
     "RandomApply",
     "RandomBrightness",
     "RandomContrast",
@@ -70,6 +79,7 @@ class RandomApply(Augmentation):
             return NoOpTransform()
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomFlip(Augmentation):
     """
     Flip the image horizontally or vertically with the given probability.
@@ -102,6 +112,7 @@ class RandomFlip(Augmentation):
             return NoOpTransform()
 
 
+@AUGMENTATION_REGISTRY.register()
 class Resize(Augmentation):
     """ Resize image to a fixed target size"""
 
@@ -175,6 +186,7 @@ class ResizeShortestEdge(Augmentation):
         return ResizeTransform(h, w, newh, neww, self.interp)
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomRotation(Augmentation):
     """
     This method returns a copy of this image, rotated the given
@@ -229,6 +241,7 @@ class RandomRotation(Augmentation):
         return RotationTransform(h, w, angle, expand=self.expand, center=center, interp=self.interp)
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomCrop(Augmentation):
     """
     Randomly crop a subimage out of an image.
@@ -400,6 +413,7 @@ class RandomContrast(Augmentation):
         return BlendTransform(src_image=img.mean(), src_weight=1 - w, dst_weight=w)
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomBrightness(Augmentation):
     """
     Randomly transforms image brightness.
@@ -426,6 +440,7 @@ class RandomBrightness(Augmentation):
         return BlendTransform(src_image=0, src_weight=1 - w, dst_weight=w)
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomSaturation(Augmentation):
     """
     Randomly transforms saturation of an RGB image.
@@ -455,6 +470,7 @@ class RandomSaturation(Augmentation):
         return BlendTransform(src_image=grayscale, src_weight=1 - w, dst_weight=w)
 
 
+@AUGMENTATION_REGISTRY.register()
 class RandomLighting(Augmentation):
     """
     The "lighting" augmentation described in AlexNet, using fixed PCA over ImageNet.


### PR DESCRIPTION
Default behavior of the framework is not changed (i.e. only apply RandomFlip with prob 0.5)
Related issues:
[https://github.com/facebookresearch/detectron2/issues/1763](url)
[https://github.com/facebookresearch/detectron2/issues/1513](url)

How to use:
expand the list in config:
cfg.INPUT.AUGMENTATION = [
    {
        "name": "RandomFlip",
        "prob": 0.5,
        "horizontal": True,
        "vertical": False,
    }
]

and if user want to add new type of augmentations, use registry AUGMENTATION_REGISTRY (defined in detectron2/data/transforms/augmentation_impl.py) to register their customized augmentation.

initialization parameters are passed as kwargs except 'name'.
