### PR TITLE
make flexible for wrapping model with ddp

### DIFF
--- a/detectron2/engine/defaults.py
+++ b/detectron2/engine/defaults.py
@@ -274,10 +274,7 @@ class DefaultTrainer(SimpleTrainer):
         data_loader = self.build_train_loader(cfg)
 
         # For training, wrap with DDP. But don't need this for inference.
-        if comm.get_world_size() > 1:
-            model = DistributedDataParallel(
-                model, device_ids=[comm.get_local_rank()], broadcast_buffers=False
-            )
+        model = self.wrap_model_with_ddp(cfg, model)
         super().__init__(model, data_loader, optimizer)
 
         self.scheduler = self.build_lr_scheduler(cfg, optimizer)
@@ -402,6 +399,21 @@ class DefaultTrainer(SimpleTrainer):
             ), "No evaluation results obtained during training!"
             verify_results(self.cfg, self._last_eval_results)
             return self._last_eval_results
+
+    @classmethod
+    def wrap_model_with_ddp(self, cfg, model):
+        """
+        Returns:
+            torch.nn.Module:
+
+        Overwrite this function if you'd like to implement more with `torch.nn.parallel.DistributedDataParallel`,
+        such as adding `find_unused_parameters=True`.
+        """
+        if comm.get_world_size() > 1:
+            model = DistributedDataParallel(
+                model, device_ids=[comm.get_local_rank()], broadcast_buffers=False
+            )
+        return model
 
     @classmethod
     def build_model(cls, cfg):

--- a/detectron2/engine/defaults.py
+++ b/detectron2/engine/defaults.py
@@ -400,7 +400,6 @@ class DefaultTrainer(SimpleTrainer):
             verify_results(self.cfg, self._last_eval_results)
             return self._last_eval_results
 
-    @classmethod
     def wrap_model_with_ddp(self, cfg, model):
         """
         Returns:


### PR DESCRIPTION
Run `dev/linter.sh` to lint the code.

```bash
Linter requires 'black @ git+https://github.com/psf/black@673327449f86fce558adde153bb6cbe54bfebad2' !
```

### Notes

This PR will make wrapping model with DDP more flexible. If users would like to implement more with DDP out of the `__init__` in `detectron2/engine/defaults.py` for Trainer, such as adding `find_unused_parameters=True`, this change can offer this function to implement their own wrap methods in project.