### PR TITLE
pump extra data in Instances for passing other annotation and add ignore annotation implement

### DIFF
--- a/detectron2/data/dataset_mapper.py
+++ b/detectron2/data/dataset_mapper.py
@@ -181,5 +181,7 @@ class DatasetMapper:
             # the intersection of original bounding box and the cropping box.
             if self.recompute_boxes:
                 instances.gt_boxes = instances.gt_masks.get_bounding_boxes()
+            instances.apply_func_to_extra_data(utils.filter_empty_instances)
             dataset_dict["instances"] = utils.filter_empty_instances(instances)
+
         return dataset_dict

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -521,6 +521,7 @@ class Visualizer:
             boxes = [BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) for x in annos]
 
             labels = [x["category_id"] for x in annos]
+            ignore_list = [x.get("ignore", 0) for x in annos]
             colors = None
             if self._instance_mode == ColorMode.SEGMENTATION and self.metadata.get("thing_colors"):
                 colors = [
@@ -528,7 +529,9 @@ class Visualizer:
                 ]
             names = self.metadata.get("thing_classes", None)
             if names:
-                labels = [names[i] for i in labels]
+                labels = [
+                    names[i] if flag == 0 else "ignore" for flag, i in zip(ignore_list, labels)
+                ]
             labels = [
                 "{}".format(i) + ("|crowd" if a.get("iscrowd", 0) else "")
                 for i, a in zip(labels, annos)


### PR DESCRIPTION
ref to issues in #1909 and pr in #1910 

The matcher ignore area strategy split into 3 parts:

1. **pump the extra data into the model**
2. utility functions IoA
3. ignore strategy for RPN

here is the first implementation, 

assume we have a per-instance annotation 'ignore', after augmentation.
in annotations_to_instances(), we could filter gt_instance and ignore_instance.
for passing two or more instances to model, I put self ._extract_instance for store more instances in one instance.
we could init an Instance by a name, and then add it to self._extract_instance by store_extra_data(),.
also, we could use obtain_extra_data() and apply_func_to_extra_data() to obtain or modify stored instances.

Because Instance has a fixed length of each filed requirement, so I use this method to pass annotation to model.

The visualizer function also updates for showing 'ignore' annotation on the image.

