### PR TITLE
implement pairwise_ioa by pairwise_iou and add corresponding test case

### DIFF
--- a/detectron2/structures/__init__.py
+++ b/detectron2/structures/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .boxes import Boxes, BoxMode, pairwise_iou
+from .boxes import Boxes, BoxMode, pairwise_iou, pairwise_ioa
 from .image_list import ImageList
 
 from .instances import Instances

--- a/tests/structures/test_boxes.py
+++ b/tests/structures/test_boxes.py
@@ -5,7 +5,7 @@ import numpy as np
 import unittest
 import torch
 
-from detectron2.structures import Boxes, BoxMode, pairwise_iou
+from detectron2.structures import Boxes, BoxMode, pairwise_ioa, pairwise_iou
 from detectron2.utils.env import TORCH_VERSION
 
 
@@ -147,7 +147,7 @@ class TestBoxMode(unittest.TestCase):
 
 
 class TestBoxIOU(unittest.TestCase):
-    def test_pairwise_iou(self):
+    def create_boxes(self):
         boxes1 = torch.tensor([[0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0]])
 
         boxes2 = torch.tensor(
@@ -160,7 +160,10 @@ class TestBoxIOU(unittest.TestCase):
                 [0.5, 0.5, 1.5, 1.5],
             ]
         )
+        return boxes1, boxes2
 
+    def test_pairwise_iou(self):
+        boxes1, boxes2 = self.create_boxes()
         expected_ious = torch.tensor(
             [
                 [1.0, 0.5, 0.5, 0.25, 0.25, 0.25 / (2 - 0.25)],
@@ -169,8 +172,15 @@ class TestBoxIOU(unittest.TestCase):
         )
 
         ious = pairwise_iou(Boxes(boxes1), Boxes(boxes2))
-
         self.assertTrue(torch.allclose(ious, expected_ious))
+
+    def test_pairwise_ioa(self):
+        boxes1, boxes2 = self.create_boxes()
+        expected_ioas = torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0, 1.0, 0.25], [1.0, 1.0, 1.0, 1.0, 1.0, 0.25]]
+        )
+        ioas = pairwise_ioa(Boxes(boxes1), Boxes(boxes2))
+        self.assertTrue(torch.allclose(ioas, expected_ioas))
 
 
 class TestBoxes(unittest.TestCase):


### PR DESCRIPTION
ref to issues in #1909 and pr in #1910 

The matcher ignore area strategy split into 3 parts:

1. pump the extra data into the model
2. **utility functions IoA**
3. ignore strategy for RPN

here is the second implementation, 

I extract intersection calculation from pairwise_iou function,  
and implement pairwise_ioa based on this, also add relevant testcase for IoA.