### PR TITLE
Fix UserWarning: 'This overload of nonzero is deprecated'

### DIFF
--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -222,5 +222,5 @@ def nonzero_tuple(x):
     because of https://github.com/pytorch/pytorch/issues/38718
     """
     if x.dim() == 0:
-        return x.unsqueeze(0).nonzero().unbind(1)
-    return x.nonzero().unbind(1)
+        return x.unsqueeze(0).nonzero(as_tuple=False).unbind(1)
+    return x.nonzero(as_tuple=False).unbind(1)

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -201,13 +201,13 @@ class FastRCNNOutputs:
         bg_class_ind = self.pred_class_logits.shape[1] - 1
 
         fg_inds = (self.gt_classes >= 0) & (self.gt_classes < bg_class_ind)
-        num_fg = fg_inds.nonzero().numel()
+        num_fg = fg_inds.nonzero(as_tuple=False).numel()
         fg_gt_classes = self.gt_classes[fg_inds]
         fg_pred_classes = pred_classes[fg_inds]
 
-        num_false_negative = (fg_pred_classes == bg_class_ind).nonzero().numel()
-        num_accurate = (pred_classes == self.gt_classes).nonzero().numel()
-        fg_num_accurate = (fg_pred_classes == fg_gt_classes).nonzero().numel()
+        num_false_negative = (fg_pred_classes == bg_class_ind).nonzero(as_tuple=False).numel()
+        num_accurate = (pred_classes == self.gt_classes).nonzero(as_tuple=False).numel()
+        fg_num_accurate = (fg_pred_classes == fg_gt_classes).nonzero(as_tuple=False).numel()
 
         storage = get_event_storage()
         if num_instances > 0:


### PR DESCRIPTION
Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

