### PR TITLE
Issue: 1916 UserWarning: This overload of nonzero is deprecated: (Solved)

### DIFF
--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -223,4 +223,4 @@ def nonzero_tuple(x):
     """
     if x.dim() == 0:
         return x.unsqueeze(0).nonzero().unbind(1)
-    return x.nonzero().unbind(1)
+    return torch.nonzero(x, as_tuple=True)

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -108,7 +108,7 @@ def fast_rcnn_inference_single_image(
     filter_mask = scores > score_thresh  # R x K
     # R' x 2. First column contains indices of the R predictions;
     # Second column contains indices of classes.
-    filter_inds = filter_mask.nonzero()
+    filter_inds=torch.nonzero(filter_mask, as_tuple=False)
     if num_bbox_reg_classes == 1:
         boxes = boxes[filter_inds[:, 0], 0]
     else:

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -108,7 +108,7 @@ def fast_rcnn_inference_single_image(
     filter_mask = scores > score_thresh  # R x K
     # R' x 2. First column contains indices of the R predictions;
     # Second column contains indices of classes.
-    filter_inds=torch.nonzero(filter_mask, as_tuple=False)
+    filter_inds = torch.nonzero(filter_mask, as_tuple=False)
     if num_bbox_reg_classes == 1:
         boxes = boxes[filter_inds[:, 0], 0]
     else:


### PR DESCRIPTION
The warning was because of the PyTorch function nonzero. This warning can be removed by adding the as_tuple argument in the function. 

In the Detectron2/layers/wrappers.py:

"return x.nonzero().unbind(1)"                             needs to be **replaced** by 
"return torch.nonzero(x, as_tuple=True)"

And in the file Detectron2/modeling/roi_heads/fast_rcnn.py:

"filter_inds = filter_mask.nonzero()"                    needs to be **replaced** by  
"filter_inds=torch.nonzero(filter_mask, as_tuple=False)"
