### PR TITLE
Adds config options for randomly flipping images  

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -58,9 +58,7 @@ _C.INPUT.MIN_SIZE_TEST = 800
 # Maximum size of the side of the image during testing
 _C.INPUT.MAX_SIZE_TEST = 1333
 # `True` if flipping is used for data augmentation during training
-_C.INPUT.RANDOM_FLIP = CN({"ENABLED": True})
-_C.INPUT.RANDOM_FLIP.HORIZONTAL = True
-_C.INPUT.RANDOM_FLIP.VERTICAL = False
+_C.INPUT.RANDOM_FLIP = "horizontal/vertical/none"
 
 # `True` if cropping is used for data augmentation during training
 _C.INPUT.CROP = CN({"ENABLED": False})

--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -57,8 +57,9 @@ _C.INPUT.MAX_SIZE_TRAIN = 1333
 _C.INPUT.MIN_SIZE_TEST = 800
 # Maximum size of the side of the image during testing
 _C.INPUT.MAX_SIZE_TEST = 1333
-# `True` if flipping is used for data augmentation during training
-_C.INPUT.RANDOM_FLIP = "horizontal/vertical/none"
+# Mode for flipping images used in data augmentation during training
+# choose one of ["horizontal, "vertical", "none"]
+_C.INPUT.RANDOM_FLIP = "horizontal"
 
 # `True` if cropping is used for data augmentation during training
 _C.INPUT.CROP = CN({"ENABLED": False})

--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -57,6 +57,10 @@ _C.INPUT.MAX_SIZE_TRAIN = 1333
 _C.INPUT.MIN_SIZE_TEST = 800
 # Maximum size of the side of the image during testing
 _C.INPUT.MAX_SIZE_TEST = 1333
+# `True` if flipping is used for data augmentation during training
+_C.INPUT.RANDOM_FLIP = CN({"ENABLED": True})
+_C.INPUT.RANDOM_FLIP.HORIZONTAL = True
+_C.INPUT.RANDOM_FLIP.VERTICAL = False
 
 # `True` if cropping is used for data augmentation during training
 _C.INPUT.CROP = CN({"ENABLED": False})

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -579,8 +579,12 @@ def build_augmentation(cfg, is_train):
         max_size = cfg.INPUT.MAX_SIZE_TEST
         sample_style = "choice"
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
-    if is_train:
-        augmentation.append(T.RandomFlip())
+    if is_train and cfg.INPUT.RANDOM_FLIP.ENABLED:
+        augmentation.append(
+            T.RandomFlip(
+                horizontal=cfg.INPUT.RANDOM_FLIP.HORIZONTAL, vertical=cfg.INPUT.RANDOM_FLIP.VERTICAL
+            )
+        )
     return augmentation
 
 

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -579,11 +579,11 @@ def build_augmentation(cfg, is_train):
         max_size = cfg.INPUT.MAX_SIZE_TEST
         sample_style = "choice"
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
-    if is_train and 'none' not in cfg.INPUT.RANDOM_FLIP:
+    if is_train and "none" not in cfg.INPUT.RANDOM_FLIP:
         augmentation.append(
             T.RandomFlip(
-                horizontal=True if 'horizontal' in cfg.INPUT.RANDOM_FLIP else False,
-                vertical=True if 'vertical' in cfg.INPUT.RANDOM_FLIP else False,
+                horizontal=True if "horizontal" in cfg.INPUT.RANDOM_FLIP else False,
+                vertical=True if "vertical" in cfg.INPUT.RANDOM_FLIP else False,
             )
         )
     return augmentation

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -579,10 +579,11 @@ def build_augmentation(cfg, is_train):
         max_size = cfg.INPUT.MAX_SIZE_TEST
         sample_style = "choice"
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
-    if is_train and cfg.INPUT.RANDOM_FLIP.ENABLED:
+    if is_train and 'none' not in cfg.INPUT.RANDOM_FLIP:
         augmentation.append(
             T.RandomFlip(
-                horizontal=cfg.INPUT.RANDOM_FLIP.HORIZONTAL, vertical=cfg.INPUT.RANDOM_FLIP.VERTICAL
+                horizontal=True if 'horizontal' in cfg.INPUT.RANDOM_FLIP else False,
+                vertical=True if 'vertical' in cfg.INPUT.RANDOM_FLIP else False,
             )
         )
     return augmentation

--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -579,11 +579,11 @@ def build_augmentation(cfg, is_train):
         max_size = cfg.INPUT.MAX_SIZE_TEST
         sample_style = "choice"
     augmentation = [T.ResizeShortestEdge(min_size, max_size, sample_style)]
-    if is_train and "none" not in cfg.INPUT.RANDOM_FLIP:
+    if is_train and cfg.INPUT.RANDOM_FLIP != "none":
         augmentation.append(
             T.RandomFlip(
-                horizontal=True if "horizontal" in cfg.INPUT.RANDOM_FLIP else False,
-                vertical=True if "vertical" in cfg.INPUT.RANDOM_FLIP else False,
+                horizontal=cfg.INPUT.RANDOM_FLIP == "horizontal",
+                vertical=cfg.INPUT.RANDOM_FLIP == "vertical",
             )
         )
     return augmentation

--- a/tests/data/test_transforms.py
+++ b/tests/data/test_transforms.py
@@ -23,6 +23,7 @@ class TestTransforms(unittest.TestCase):
         np.random.seed(125)
         cfg = get_cfg()
         is_train = True
+        cfg.INPUT.RANDOM_FLIP = 'horizontal'
         augs = detection_utils.build_augmentation(cfg, is_train)
         image = np.random.rand(200, 300)
         image, transforms = T.apply_augmentations(augs, image)

--- a/tests/data/test_transforms.py
+++ b/tests/data/test_transforms.py
@@ -23,7 +23,6 @@ class TestTransforms(unittest.TestCase):
         np.random.seed(125)
         cfg = get_cfg()
         is_train = True
-        cfg.INPUT.RANDOM_FLIP = 'horizontal'
         augs = detection_utils.build_augmentation(cfg, is_train)
         image = np.random.rand(200, 300)
         image, transforms = T.apply_augmentations(augs, image)


### PR DESCRIPTION
Adds options to config in order to enable/disable random horizontal/vertical flipping for image augmentation.

Feature labeled as _enhancement_ and requested by [1513](https://github.com/facebookresearch/detectron2/issues/1513)