### PR TITLE
Fix a bug about small mask without polygon

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -644,6 +644,10 @@ class Visualizer:
                     text_pos = (x0, y0)  # if drawing boxes, put text on the box corner.
                     horiz_align = "left"
                 elif masks is not None:
+                    # skip small mask without polygon
+                    if len(masks[i].polygons) == 0:
+                        continue
+
                     x0, y0, x1, y1 = masks[i].bbox()
 
                     # draw text in the center (defined by median) when box is not drawn


### PR DESCRIPTION
Command line:
```
python demo.py --config-file ../configs/COCO-PanopticSegmentation/panoptic_fpn_R_50_3x.yaml --input "$HOME/Datasets/COCO/2014/train2014/*.jpg" --opts MODEL.WEIGHTS detectron2://COCO-PanopticSegmentation/panoptic_fpn_R_50_3x/139514569/model_final_c10459.pkl
```

When processing the image `COCO_train2014_000000374538.jpg`, `labes=['person 55%', 'person 100%', 'skis 53%']`，the mask of `skis` is too small (two pixels only), which results in no polygon, and then `masks[i].bbox()` raises an exception `IndexError: list index out of range`.

This commit fixed this bug.
