### PR TITLE
Allow stem feature map extraction

### DIFF
--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -608,6 +608,11 @@ def build_resnet_backbone(cfg, input_shape):
 
     stages = []
 
+    rem_feat = []
+    if "stem" in out_features:
+        out_features.remove("stem")
+        rem_feat.append("stem")
+
     # Avoid creating variables without gradients
     # It consumes extra memory and may cause allreduce to fail
     out_stage_idx = [{"res2": 2, "res3": 3, "res4": 4, "res5": 5}[f] for f in out_features]
@@ -641,4 +646,6 @@ def build_resnet_backbone(cfg, input_shape):
         out_channels *= 2
         bottleneck_channels *= 2
         stages.append(blocks)
+    if rem_feat:
+        out_features = out_features + rem_feat
     return ResNet(stem, stages, out_features=out_features).freeze(freeze_at)

--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -608,14 +608,11 @@ def build_resnet_backbone(cfg, input_shape):
 
     stages = []
 
-    rem_feat = []
-    if "stem" in out_features:
-        out_features.remove("stem")
-        rem_feat.append("stem")
-
     # Avoid creating variables without gradients
     # It consumes extra memory and may cause allreduce to fail
-    out_stage_idx = [{"res2": 2, "res3": 3, "res4": 4, "res5": 5}[f] for f in out_features]
+    out_stage_idx = [
+        {"res2": 2, "res3": 3, "res4": 4, "res5": 5}[f] for f in out_features if f != "stem"
+    ]
     max_stage_idx = max(out_stage_idx)
     for idx, stage_idx in enumerate(range(2, max_stage_idx + 1)):
         dilation = res5_dilation if stage_idx == 5 else 1
@@ -646,6 +643,4 @@ def build_resnet_backbone(cfg, input_shape):
         out_channels *= 2
         bottleneck_channels *= 2
         stages.append(blocks)
-    if rem_feat:
-        out_features = out_features + rem_feat
     return ResNet(stem, stages, out_features=out_features).freeze(freeze_at)


### PR DESCRIPTION
From #2099, a fix like this could allow users to extract the 'stem' feature map for downstream tasks by simply specifying `stem` in the `MODELS.RESNETS.OUT_FEATURES`. As mentioned in reference issue, detectron2 seems to support this. It's just that it hits an error while making the res block/stages ([here](https://github.com/facebookresearch/detectron2/blob/0dd2b6579a4ba8d6bdddd3f5d010e9c1b620870d/detectron2/modeling/backbone/resnet.py#L613)).

Example usage
```
BACKBONE:
    NAME: "build_resnet_backbone"
  WEIGHTS: "detectron2://ImageNetPretrained/MSRA/R-50.pkl"
  RESNETS:
    DEPTH: 50
    OUT_FEATURES: ["stem", "res2", "res3", "res4", "res5"]
```

The alternative would be to create a new backbone and implement it there. Personally, I feel its a minor addition that detectron2 could support. However, if it's against its design philosophy, feel free to reject this.

Thanks 