### PR TITLE
Adds native PyTorch's automatic mixed precision (AMP) support

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -26,6 +26,7 @@ _C.MODEL.LOAD_PROPOSALS = False
 _C.MODEL.MASK_ON = False
 _C.MODEL.KEYPOINT_ON = False
 _C.MODEL.DEVICE = "cuda"
+_C.MODEL.AMP = False
 _C.MODEL.META_ARCHITECTURE = "GeneralizedRCNN"
 
 # Path (a file path, or URL like detectron2://.., https://..) to a checkpoint file

--- a/detectron2/layers/nms.py
+++ b/detectron2/layers/nms.py
@@ -3,10 +3,12 @@
 
 from typing import List
 import torch
+from torch.cuda.amp import custom_fwd
 from torchvision.ops import boxes as box_ops
 from torchvision.ops import nms  # BC-compat
 
 
+@custom_fwd(cast_inputs=torch.float32)
 def batched_nms(
     boxes: torch.Tensor, scores: torch.Tensor, idxs: torch.Tensor, iou_threshold: float
 ):
@@ -31,6 +33,7 @@ def batched_nms(
 
 # Note: this function (nms_rotated) might be moved into
 # torchvision/ops/boxes.py in the future
+@custom_fwd(cast_inputs=torch.float32)
 def nms_rotated(boxes, scores, iou_threshold):
     """
     Performs non-maximum suppression (NMS) on the rotated boxes according

--- a/tests/layers/test_nms.py
+++ b/tests/layers/test_nms.py
@@ -24,7 +24,11 @@ class TestNMS(unittest.TestCase):
         num_classes = 50
         boxes, scores = self._create_tensors(N)
         idxs = torch.randint(0, num_classes, (N,))
-        scripted_batched_nms = torch.jit.script(batched_nms)
+        # As of PyTorch 1.6.0 JIT scripting/tracing interaction
+        # with AMP's autocasting is still a WIP
+        # see: https://github.com/pytorch/pytorch/issues/38958#issuecomment-635472379
+        # for now, we skip @custom_fwd by using __wrapped__ property
+        scripted_batched_nms = torch.jit.script(batched_nms.__wrapped__)
         err_msg = "NMS is incompatible with jit-scripted NMS for IoU={}"
 
         for iou in [0.2, 0.5, 0.8]:

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -110,7 +110,7 @@ def benchmark_train(args):
             yield from data
 
     max_iter = 400
-    trainer = SimpleTrainer(model, f(), optimizer)
+    trainer = SimpleTrainer(cfg, model, f(), optimizer)
     trainer.register_hooks(
         [hooks.IterationTimer(), hooks.PeriodicWriter([CommonMetricPrinter(max_iter)])]
     )


### PR DESCRIPTION
This is my shot at adding PyTorch's native AMP support. I followed the official examples as close as possible and feedback gathered from https://github.com/facebookresearch/detectron2/issues/2104 and https://github.com/facebookresearch/detectron2/pull/925

Few notes though:
* This probably breaks compatibility with PyTorch 1.5.x
* We should double check modules in `detectron2/layers` for their fp16 and fp32 computational safety. I primarily followed NVIDIA's Apex [whitelist/blacklist of ops](https://github.com/NVIDIA/apex/blob/master/apex/amp/lists/functional_overrides.py) and ones mentioned in #776 but it's possible that I missed some.
* Interaction between JIT tracking/scripting and AMP's autocasting is still work in progress. AFAIK this is only reflected in `test_nms_scriptability` test.
* Most importantly, someone needs to run the benchmarks (it would take ages on my single RTX Titan)