### PR TITLE
Fix numerical instability of rotated IoU (issue 2154 & issue 2167)

### DIFF
--- a/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h
+++ b/detectron2/layers/csrc/box_iou_rotated/box_iou_rotated_utils.h
@@ -88,6 +88,13 @@ HOST_DEVICE_INLINE int get_intersection_points(
     vec2[i] = pts2[(i + 1) % 4] - pts2[i];
   }
 
+  // When computing the intersection area, it doesn't hurt if we have
+  // more (duplicated/approximate) intersections/vertices than needed,
+  // while it can cause drastic difference if we miss an intersection/vertex.
+  // Therefore, we add an epsilon to relax the comparisons between
+  // the float point numbers that decide the intersection points.
+  double EPS = 1e-5;
+
   // Line test - test all line combos for intersection
   int num = 0; // number of intersections
   for (int i = 0; i < 4; i++) {
@@ -105,7 +112,7 @@ HOST_DEVICE_INLINE int get_intersection_points(
       T t1 = cross_2d<T>(vec2[j], vec12) / det;
       T t2 = cross_2d<T>(vec1[i], vec12) / det;
 
-      if (t1 >= 0.0f && t1 <= 1.0f && t2 >= 0.0f && t2 <= 1.0f) {
+      if (t1 > -EPS && t1 < 1.0f + EPS && t2 > -EPS && t2 < 1.0f + EPS) {
         intersections[num++] = pts1[i] + vec1[i] * t1;
       }
     }
@@ -127,8 +134,8 @@ HOST_DEVICE_INLINE int get_intersection_points(
       auto APdotAB = dot_2d<T>(AP, AB);
       auto APdotAD = -dot_2d<T>(AP, DA);
 
-      if ((APdotAB >= 0) && (APdotAD >= 0) && (APdotAB <= ABdotAB) &&
-          (APdotAD <= ADdotAD)) {
+      if ((APdotAB > -EPS) && (APdotAD > -EPS) && (APdotAB < ABdotAB + EPS) &&
+          (APdotAD < ADdotAD + EPS)) {
         intersections[num++] = pts1[i];
       }
     }
@@ -146,8 +153,8 @@ HOST_DEVICE_INLINE int get_intersection_points(
       auto APdotAB = dot_2d<T>(AP, AB);
       auto APdotAD = -dot_2d<T>(AP, DA);
 
-      if ((APdotAB >= 0) && (APdotAD >= 0) && (APdotAB <= ABdotAB) &&
-          (APdotAD <= ADdotAD)) {
+      if ((APdotAB > -EPS) && (APdotAD > -EPS) && (APdotAB < ABdotAB + EPS) &&
+          (APdotAD < ADdotAD + EPS)) {
         intersections[num++] = pts2[i];
       }
     }


### PR DESCRIPTION
Summary:
https://github.com/facebookresearch/detectron2/issues/2154

- Fixed numerical instability of rotated IoU and added two more unit tests covering the two examples reported.

When computing the intersection area, it doesn't hurt if we have more (duplicated/approximate) intersections/vertices than needed, while it can cause drastic difference if we miss an intersection/vertex. Therefore, we add an epsilon to make relaxed comparisons between the float point numbers that decides the intersection points.

- Fixed unit tests coverage by changing
```
["cpu"] + ["cuda"] if torch.cuda.is_available() else []
```
to
```
["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
```
since otherwise the result would be [] instead of ["cpu"] on cpu machines.

Differential Revision: D24498800

