### PR TITLE
Enable visualization of rotated bounding-boxes

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -528,7 +528,9 @@ class Visualizer:
                 keypts = None
 
             boxes = [
-                BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) if len(x["bbox"]) == 4 else x["bbox"]
+                BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS)
+                if len(x["bbox"]) == 4
+                else x["bbox"]
                 for x in annos
             ]
 

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -527,7 +527,10 @@ class Visualizer:
             else:
                 keypts = None
 
-            boxes = [BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) for x in annos]
+            boxes = [
+                BoxMode.convert(x["bbox"], x["bbox_mode"], BoxMode.XYXY_ABS) if len(x["bbox"]) == 4 else x["bbox"]
+                for x in annos
+            ]
 
             labels = [x["category_id"] for x in annos]
             colors = None

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -63,6 +63,30 @@ class TestVisualizer(unittest.TestCase):
         v = Visualizer(img, self.metadata)
         v.draw_dataset_dict(dic)
 
+    def test_draw_rotated_dataset_dict(self):
+        img = np.random.rand(512, 512, 3) * 255
+        dic = {
+            "annotations": [
+                {
+                    "bbox": [
+                        368.9946492271106,
+                        330.891438763377,
+                        13.148537455410235,
+                        13.644708680142685,
+                        45.0
+                    ],
+                    "bbox_mode": BoxMode.XYWHA_ABS,
+                    "category_id": 0,
+                    "iscrowd": 1
+                }
+            ],
+            "height": 512,
+            "image_id": 1,
+            "width": 512,
+        }
+        v = Visualizer(img, self.metadata)
+        v.draw_dataset_dict(dic)
+
     def test_overlay_instances(self):
         img, boxes, labels, polygons, masks = self._random_data()
 

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -73,11 +73,11 @@ class TestVisualizer(unittest.TestCase):
                         330.891438763377,
                         13.148537455410235,
                         13.644708680142685,
-                        45.0
+                        45.0,
                     ],
                     "bbox_mode": BoxMode.XYWHA_ABS,
                     "category_id": 0,
-                    "iscrowd": 1
+                    "iscrowd": 1,
                 }
             ],
             "height": 512,


### PR DESCRIPTION
Enable rotated boxes to be visualized through the Visualizer class; related to the issue https://github.com/facebookresearch/detectron2/issues/572

Below is an example to verify the change visually:

```python
import torch
import cv2
from detectron2 import model_zoo
from detectron2.engine import DefaultPredictor
from detectron2.config import get_cfg
from detectron2.utils.visualizer import Visualizer
from detectron2.data import MetadataCatalog
from detectron2.structures import Boxes, RotatedBoxes

# wget http://images.cocodataset.org/val2017/000000439715.jpg -q -O input.jpg
im = cv2.imread("./input.jpg")

cfg = get_cfg()
cfg.merge_from_file(model_zoo.get_config_file("COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml"))
cfg.MODEL.WEIGHTS = model_zoo.get_checkpoint_url("COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml")
cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = 0.5
predictor = DefaultPredictor(cfg)
outputs = predictor(im)

show_rotated = True

if show_rotated:
    pred_boxes = outputs["instances"].pred_boxes.tensor
    temp_pred_boxes = pred_boxes.clone()

    # Converting from XYXY to CXCYWHA
    pred_boxes[:, 0] = (temp_pred_boxes[:, 0] + temp_pred_boxes[:, 2]) / 2
    pred_boxes[:, 1] = (temp_pred_boxes[:, 1] + temp_pred_boxes[:, 3]) / 2
    pred_boxes[:, 2] = (temp_pred_boxes[:, 2] - temp_pred_boxes[:, 0])
    pred_boxes[:, 3] = (temp_pred_boxes[:, 3] - temp_pred_boxes[:, 1])

    # Adding rotation of 45 degrees
    pred_boxes = torch.cat((pred_boxes, 45 * torch.ones((len(pred_boxes), 1), device="cuda")), dim=1)
    outputs["instances"].pred_boxes = RotatedBoxes(pred_boxes)


v = Visualizer(im[:, :, ::-1], MetadataCatalog.get(cfg.DATASETS.TRAIN[0]), scale=1.2)
out = v.draw_instance_predictions(outputs["instances"].to("cpu"))
cv2.imshow("pred", out.get_image()[:, :, ::-1])
cv2.waitKey(0)
```