### PR TITLE
fix(layers): fix logic of shape check in deformalbe

### DIFF
--- a/detectron2/layers/csrc/deformable/deform_conv_cuda.cu
+++ b/detectron2/layers/csrc/deformable/deform_conv_cuda.cu
@@ -234,7 +234,7 @@ void shape_check(
       input.size(1));
 
   TORCH_CHECK(
-      (inputHeight >= kH && inputWidth >= kW),
+      (inputHeight + 2 * padH >= kH && inputWidth + 2 * padW >= kW),
       "input image is smaller than kernel");
 
   TORCH_CHECK(

--- a/tests/layers/test_deformable.py
+++ b/tests/layers/test_deformable.py
@@ -7,7 +7,6 @@ from detectron2.layers import DeformConv, ModulatedDeformConv
 
 
 class DeformableTest(unittest.TestCase):
-
     @unittest.skipIf(not torch.cuda.is_available(), "Deformable not supported for cpu")
     def test_forward_output(self):
         device = torch.device("cuda")
@@ -31,21 +30,23 @@ class DeformableTest(unittest.TestCase):
         deform.weight = torch.nn.Parameter(torch.ones_like(deform.weight))
         output = deform(inputs, offset)
         output = output.detach().cpu().numpy()
-        deform_results = np.array([
-            [30, 41.25, 48.75, 45, 28.75],
-            [62.25, 81, 90, 80.25, 50.25],
-            [99.75, 126, 135, 117.75, 72.75],
-            [105, 131.25, 138.75, 120, 73.75],
-            [71.75, 89.25, 93.75, 80.75, 49.5],
-        ])
+        deform_results = np.array(
+            [
+                [30, 41.25, 48.75, 45, 28.75],
+                [62.25, 81, 90, 80.25, 50.25],
+                [99.75, 126, 135, 117.75, 72.75],
+                [105, 131.25, 138.75, 120, 73.75],
+                [71.75, 89.25, 93.75, 80.75, 49.5],
+            ]
+        )
         self.assertTrue(np.allclose(output.flatten(), deform_results.flatten()))
 
         # Test DCN v2
         mask_channels = kernel_size * kernel_size
         mask = torch.full((N, mask_channels, H, W), 0.5, dtype=torch.float32).to(device)
-        modulate_deform = ModulatedDeformConv(
-            C, C, kernel_size, padding=padding, bias=False
-        ).to(device)
+        modulate_deform = ModulatedDeformConv(C, C, kernel_size, padding=padding, bias=False).to(
+            device
+        )
         modulate_deform.weight = deform.weight
         output = modulate_deform(inputs, offset, mask)
         output = output.detach().cpu().numpy()
@@ -91,9 +92,9 @@ class DeformableTest(unittest.TestCase):
         offset = torch.randn((N, offset_channels, H, W), dtype=torch.float32).to(device)
         mask_channels = kernel_size * kernel_size * 2  # This is wrong channels for mask
         mask = torch.ones((N, mask_channels, H, W), dtype=torch.float32).to(device)
-        modulate_deform = ModulatedDeformConv(
-            C, C, kernel_size, padding=padding, bias=False
-        ).to(device)
+        modulate_deform = ModulatedDeformConv(C, C, kernel_size, padding=padding, bias=False).to(
+            device
+        )
         self.assertRaises(RuntimeError, modulate_deform, inputs, offset, mask)
 
     def test_repr(self):

--- a/tests/layers/test_deformable.py
+++ b/tests/layers/test_deformable.py
@@ -1,0 +1,117 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import numpy as np
+import unittest
+import torch
+
+from detectron2.layers import DeformConv, ModulatedDeformConv
+
+
+class DeformableTest(unittest.TestCase):
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Deformable not supported for cpu")
+    def test_forward_output(self):
+        device = torch.device("cuda")
+        N, C, H, W = shape = 1, 1, 5, 5
+        kernel_size = 3
+        padding = 1
+
+        inputs = torch.arange(np.prod(shape), dtype=torch.float32).reshape(*shape).to(device)
+        """
+        0  1  2   3 4
+        5  6  7   8 9
+        10 11 12 13 14
+        15 16 17 18 19
+        20 21 22 23 24
+        """
+        offset_channels = kernel_size * kernel_size * 2
+        offset = torch.full((N, offset_channels, H, W), 0.5, dtype=torch.float32).to(device)
+
+        # Test DCN v1
+        deform = DeformConv(C, C, kernel_size=kernel_size, padding=padding).to(device)
+        deform.weight = torch.nn.Parameter(torch.ones_like(deform.weight))
+        output = deform(inputs, offset)
+        output = output.detach().cpu().numpy()
+        deform_results = np.array([
+            [30, 41.25, 48.75, 45, 28.75],
+            [62.25, 81, 90, 80.25, 50.25],
+            [99.75, 126, 135, 117.75, 72.75],
+            [105, 131.25, 138.75, 120, 73.75],
+            [71.75, 89.25, 93.75, 80.75, 49.5],
+        ])
+        self.assertTrue(np.allclose(output.flatten(), deform_results.flatten()))
+
+        # Test DCN v2
+        mask_channels = kernel_size * kernel_size
+        mask = torch.full((N, mask_channels, H, W), 0.5, dtype=torch.float32).to(device)
+        modulate_deform = ModulatedDeformConv(
+            C, C, kernel_size, padding=padding, bias=False
+        ).to(device)
+        modulate_deform.weight = deform.weight
+        output = modulate_deform(inputs, offset, mask)
+        output = output.detach().cpu().numpy()
+        self.assertTrue(np.allclose(output.flatten(), deform_results.flatten() * 0.5))
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Deformable not supported for cpu")
+    def test_small_input(self):
+        device = torch.device("cuda")
+        for kernel_size in [3, 5]:
+            padding = kernel_size // 2
+            N, C, H, W = shape = (1, 1, kernel_size - 1, kernel_size - 1)
+
+            inputs = torch.rand(shape).to(device)  # input size is smaller than kernel size
+
+            offset_channels = kernel_size * kernel_size * 2
+            offset = torch.randn((N, offset_channels, H, W), dtype=torch.float32).to(device)
+            deform = DeformConv(C, C, kernel_size=kernel_size, padding=padding).to(device)
+            output = deform(inputs, offset)
+            self.assertTrue(output.shape == inputs.shape)
+
+            mask_channels = kernel_size * kernel_size
+            mask = torch.ones((N, mask_channels, H, W), dtype=torch.float32).to(device)
+            modulate_deform = ModulatedDeformConv(
+                C, C, kernel_size, padding=padding, bias=False
+            ).to(device)
+            output = modulate_deform(inputs, offset, mask)
+            self.assertTrue(output.shape == inputs.shape)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Deformable not supported for cpu")
+    def test_raise_exception(self):
+        device = torch.device("cuda")
+        N, C, H, W = shape = 1, 1, 3, 3
+        kernel_size = 3
+        padding = 1
+
+        inputs = torch.rand(shape, dtype=torch.float32).to(device)
+        offset_channels = kernel_size * kernel_size  # This is wrong channels for offset
+        offset = torch.randn((N, offset_channels, H, W), dtype=torch.float32).to(device)
+        deform = DeformConv(C, C, kernel_size=kernel_size, padding=padding).to(device)
+        self.assertRaises(RuntimeError, deform, inputs, offset)
+
+        offset_channels = kernel_size * kernel_size * 2
+        offset = torch.randn((N, offset_channels, H, W), dtype=torch.float32).to(device)
+        mask_channels = kernel_size * kernel_size * 2  # This is wrong channels for mask
+        mask = torch.ones((N, mask_channels, H, W), dtype=torch.float32).to(device)
+        modulate_deform = ModulatedDeformConv(
+            C, C, kernel_size, padding=padding, bias=False
+        ).to(device)
+        self.assertRaises(RuntimeError, modulate_deform, inputs, offset, mask)
+
+    def test_repr(self):
+        module = DeformConv(3, 10, kernel_size=3, padding=1, deformable_groups=2)
+        correct_string = (
+            "DeformConv(in_channels=3, out_channels=10, kernel_size=(3, 3), "
+            "stride=(1, 1), padding=(1, 1), dilation=(1, 1), "
+            "groups=1, deformable_groups=2, bias=False)"
+        )
+        self.assertEqual(repr(module), correct_string)
+
+        module = ModulatedDeformConv(3, 10, kernel_size=3, padding=1, deformable_groups=2)
+        correct_string = (
+            "ModulatedDeformConv(in_channels=3, out_channels=10, kernel_size=(3, 3), "
+            "stride=1, padding=1, dilation=1, groups=1, deformable_groups=2, bias=True)"
+        )
+        self.assertEqual(repr(module), correct_string)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Code [here](https://github.com/facebookresearch/detectron2/blob/master/detectron2/layers/csrc/deformable/deform_conv_cuda.cu#L237) in deformable check the input shape without padding, which is incorrect,  especially for a model using P7 level feature(stride=128). While using 2017_coco_test dataset, such a model with deformable conv leads to crashing.

Or, You might try this code to implement the same crashing.
```Python3
import torch
from torch import nn

from detectron2.layers import DeformConv

x = torch.randn(2, 3, 2, 2).cuda()  # height and width are both 2, which is smaller than kernel_size
offset_conv = nn.Conv2d(3, 18, kernel_size=3, padding=1).cuda()

offset = offset_conv(x)
deform = DeformConv(3, 10, kernel_size=3, padding=1).cuda()

y = deform(x, offset)
``` 

This PR fixes logic of shape checking in dcn. Please kindly review, thanks.