### PR TITLE
Allow empty annotations for repeat_factors_from_category_frequency

### DIFF
--- a/detectron2/data/samplers/distributed_sampler.py
+++ b/detectron2/data/samplers/distributed_sampler.py
@@ -124,7 +124,11 @@ class RepeatFactorTrainingSampler(Sampler):
         rep_factors = []
         for dataset_dict in dataset_dicts:
             cat_ids = {ann["category_id"] for ann in dataset_dict["annotations"]}
-            rep_factor = max({category_rep[cat_id] for cat_id in cat_ids})
+
+            if len(cat_ids) > 0:
+                rep_factor = max({category_rep[cat_id] for cat_id in cat_ids})
+            else:
+                rep_factor = 1.0
             rep_factors.append(rep_factor)
 
         return torch.tensor(rep_factors, dtype=torch.float32)

--- a/detectron2/data/samplers/distributed_sampler.py
+++ b/detectron2/data/samplers/distributed_sampler.py
@@ -124,11 +124,7 @@ class RepeatFactorTrainingSampler(Sampler):
         rep_factors = []
         for dataset_dict in dataset_dicts:
             cat_ids = {ann["category_id"] for ann in dataset_dict["annotations"]}
-
-            if len(cat_ids) > 0:
-                rep_factor = max({category_rep[cat_id] for cat_id in cat_ids})
-            else:
-                rep_factor = 1.0
+            rep_factor = max({category_rep[cat_id] for cat_id in cat_ids}, default=1.0)
             rep_factors.append(rep_factor)
 
         return torch.tensor(rep_factors, dtype=torch.float32)


### PR DESCRIPTION
This PR enables the use of empty annotations for repeat_factors_from_category_frequency.

Related to issue: https://github.com/facebookresearch/detectron2/issues/2139