### PR TITLE
fixed issue with _eval_predictions in rotated-coco

### DIFF
--- a/detectron2/evaluation/rotated_coco_evaluation.py
+++ b/detectron2/evaluation/rotated_coco_evaluation.py
@@ -145,7 +145,7 @@ class RotatedCOCOEvaluator(COCOEvaluator):
             results.append(result)
         return results
 
-    def _eval_predictions(self, predictions):
+    def _eval_predictions(self, predictions, **kwargs):
         """
         Evaluate predictions on the given tasks.
         Fill self._results with the metrics of the tasks.


### PR DESCRIPTION
At the moment RotatedCOCOEvaluator is not working.
The issue is that it is derived from COCOEvaluator, which call the method _eval_predictions with parameter img_ids  https://github.com/facebookresearch/detectron2/blob/cd60faf1427f95d357ba30365a415d0309a8618f/detectron2/evaluation/coco_evaluation.py#L173.

However, RotatedCOCOEvaluator's _eval_predictions doesn't have that parameter https://github.com/facebookresearch/detectron2/blob/cd60faf1427f95d357ba30365a415d0309a8618f/detectron2/evaluation/rotated_coco_evaluation.py#L148.

One could add the img_ids=None (which will be unused) aswell.