### PR TITLE
fix a typo and a bug in ImageList.from_tensors

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -73,7 +73,7 @@ class ImageList(object):
     ) -> "ImageList":
         """
         Args:
-            tensors: a tuple or list of `torch.Tensors`, each of shape (Hi, Wi) or
+            tensors: a tuple or list of `torch.Tensor`, each of shape (Hi, Wi) or
                 (C_1, ..., C_K, Hi, Wi) where K >= 1. The Tensors will be padded
                 to the same shape with `pad_value`.
             size_divisibility (int): If `size_divisibility > 0`, add padding to ensure
@@ -88,7 +88,7 @@ class ImageList(object):
         assert isinstance(tensors, (tuple, list))
         for t in tensors:
             assert isinstance(t, torch.Tensor), type(t)
-            assert t.shape[1:-2] == tensors[0].shape[1:-2], t.shape
+            assert t.shape[:-2] == tensors[0].shape[:-2], t.shape
 
         image_sizes = [(im.shape[-2], im.shape[-1]) for im in tensors]
         image_sizes_tensor = [_as_tensor(x) for x in image_sizes]


### PR DESCRIPTION
In `ImageList.from_tensors`, shape of each item in `tensors` is (Hi, Wi) or (C_1, ..., C_K, Hi, Wi) where K >= 1 according to the docstring, and from the following code, we can conclude that each item in `tensors` must have the same shape besides width and height (i.e. the last two dimension).

https://github.com/facebookresearch/detectron2/blob/f7b394e059702341c5eb8db2b9a0534779826b4c/detectron2/structures/image_list.py#L117-L121

Accordingly, 
https://github.com/facebookresearch/detectron2/blob/f7b394e059702341c5eb8db2b9a0534779826b4c/detectron2/structures/image_list.py#L89-L91

should be 
```python
for t in tensors:
    assert isinstance(t, torch.Tensor), type(t)
    assert t.shape[:-2] == tensors[0].shape[:-2], t.shape
```
In addition, there is a typo in docstring in `ImageList.from_tensors`, and this PR fix it.

For your information.