### PR TITLE
Fix: _get_args_from_config

### DIFF
--- a/detectron2/config/config.py
+++ b/detectron2/config/config.py
@@ -217,8 +217,12 @@ def _get_args_from_config(from_config_func, *args, **kwargs):
     """
     signature = inspect.signature(from_config_func)
     if list(signature.parameters.keys())[0] != "cfg":
+        if inspect.isfunction(from_config_func):
+            name = from_config_func.__name__
+        else:
+            name = f"{from_config_func.__self__}.from_config"
         raise TypeError(
-            f"{from_config_func.__self__}.from_config must take 'cfg' as the first argument!"
+            f"{name} must take 'cfg' as the first argument!"
         )
     support_var_arg = any(
         param.kind in [param.VAR_POSITIONAL, param.VAR_KEYWORD]

--- a/detectron2/config/config.py
+++ b/detectron2/config/config.py
@@ -221,9 +221,7 @@ def _get_args_from_config(from_config_func, *args, **kwargs):
             name = from_config_func.__name__
         else:
             name = f"{from_config_func.__self__}.from_config"
-        raise TypeError(
-            f"{name} must take 'cfg' as the first argument!"
-        )
+        raise TypeError(f"{name} must take 'cfg' as the first argument!")
     support_var_arg = any(
         param.kind in [param.VAR_POSITIONAL, param.VAR_KEYWORD]
         for param in signature.parameters.values()


### PR DESCRIPTION
Hi,

For the following code snippet: 

```
from detectron2.config import CfgNode, configurable

def from_config_func(a):
    return {}

@configurable(from_config=from_config_func)
def func():
    pass

func(CfgNode())
```

It will raise following error:

```AttributeError: 'function' object has no attribute '__self__'```

Which is not worked as our expected.

That we need to identify the `from_config_func` is a `function` or a `method`.