### PR TITLE
Add ARCHFLAGS to macOS installation command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ git clone https://github.com/facebookresearch/detectron2.git
 python -m pip install -e detectron2
 
 # Or if you are on macOS
-CC=clang CXX=clang++ python -m pip install ......
+CC=clang CXX=clang++ ARCHFLAGS="-arch x86_64" python -m pip install ......
 ```
 
 To __rebuild__ detectron2 that's built from a local clone, use `rm -rf build/ **/*.so` to clean the


### PR DESCRIPTION
This PR solves the installation error `Unsupported architecture` on macOS.

Related Issues:
https://github.com/facebookresearch/detectron2/issues/2288

https://github.com/facebookresearch/detectron2/issues/2285