### PR TITLE
docker-compose gpu access updated, since 1.28.0 version

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,9 +14,9 @@ docker run --gpus all -it \
 xhost +local:`docker inspect --format='{{ .Config.Hostname }}' detectron2`
 ```
 
-## Use the container (with docker < 19.03)
+## Use the container (with docker-compose ≥ 1.28.0)
 
-Install docker-compose and nvidia-docker2, then run:
+Install docker-compose and nvidia-docker-toolkit, then run:
 ```
 cd docker && USER_ID=$UID docker-compose run detectron2
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,3 +21,6 @@ services:
     environment:
       - DISPLAY=$DISPLAY
       - NVIDIA_VISIBLE_DEVICES=all
+    # Uncomment with proper source to access webcam from docker
+    # devices: 
+    #   - /dev/video0:/dev/video0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,12 @@ services:
       dockerfile: Dockerfile
       args:
         USER_ID: ${USER_ID:-1000}
-    runtime: nvidia  # TODO: Exchange with "gpu: all" in the future (see https://github.com/facebookresearch/detectron2/pull/197/commits/00545e1f376918db4a8ce264d427a07c1e896c5a).
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities:
+              - gpu
     shm_size: "8gb"
     ulimits:
       memlock: -1


### PR DESCRIPTION
Updating gpu access from docker-compose, pointed by this comment:

https://github.com/facebookresearch/detectron2/blob/45a8bfb64053d71d9d7f136fb25a6abe841dc91f/docker/docker-compose.yml#L9

The solution comes from this [pull request](https://github.com/docker/compose/issues/6691), and working since 1.28.0 [release](https://github.com/docker/compose/releases). It's the [official](https://github.com/docker/compose/pull/7929) replace of `runtime: nvidia`

In this way, we don't need to install nvidia-docker (less prerequisites :tada:), but nvidia-container-toolkit seems to be needed yet.
