### PR TITLE
Fixed small issue with color-format conversion

### DIFF
--- a/demo/predictor.py
+++ b/demo/predictor.py
@@ -87,7 +87,7 @@ class VisualizationDemo(object):
         video_visualizer = VideoVisualizer(self.metadata, self.instance_mode)
 
         def process_predictions(frame, predictions):
-            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             if "panoptic_seg" in predictions:
                 panoptic_seg, segments_info = predictions["panoptic_seg"]
                 vis_frame = video_visualizer.draw_panoptic_seg_predictions(


### PR DESCRIPTION
The draw_instance_predictions (in video_visualizer.py) expects color format of RGB. Also, we get BGR from Opencv (cv2.VideoCapture). However we convert RGB2BGR, but it should be BGR2RGB (Opencv video input to format that draw_instance_predictions expects). Functionally,  RGB2BGR and BGR2RGB yields the same results, but it is a bit confusing.

https://github.com/facebookresearch/detectron2/blob/c152862a18182544b9f41dac0519e87c5ff8ac6c/detectron2/utils/video_visualizer.py#L53