### PR TITLE
Use copy.deepcopy() instead of .clone() to allow other cfg types other than CfgNode

### DIFF
--- a/detectron2/solver/build.py
+++ b/detectron2/solver/build.py
@@ -25,7 +25,7 @@ def _create_gradient_clipper(cfg: CfgNode) -> _GradientClipper:
     Creates gradient clipping closure to clip by value or by norm,
     according to the provided config.
     """
-    cfg = cfg.clone()
+    cfg = copy.deepcopy(cfg)
 
     def clip_grad_norm(p: _GradientClipperInput):
         torch.nn.utils.clip_grad_norm_(p, cfg.CLIP_VALUE, cfg.NORM_TYPE)


### PR DESCRIPTION
Make this function more generalizable so that other projects can use it with customized cfg types as they may not have .clone() method.


