### PR TITLE
Replace copy_ op in Box2BoxTransform.apply_deltas

### DIFF
--- a/detectron2/modeling/box_regression.py
+++ b/detectron2/modeling/box_regression.py
@@ -107,12 +107,12 @@ class Box2BoxTransform(object):
         pred_w = torch.exp(dw) * widths[:, None]
         pred_h = torch.exp(dh) * heights[:, None]
 
-        pred_boxes = torch.zeros_like(deltas)
-        pred_boxes[:, 0::4] = pred_ctr_x - 0.5 * pred_w  # x1
-        pred_boxes[:, 1::4] = pred_ctr_y - 0.5 * pred_h  # y1
-        pred_boxes[:, 2::4] = pred_ctr_x + 0.5 * pred_w  # x2
-        pred_boxes[:, 3::4] = pred_ctr_y + 0.5 * pred_h  # y2
-        return pred_boxes
+        x1 = pred_ctr_x - 0.5 * pred_w
+        y1 = pred_ctr_y - 0.5 * pred_h
+        x2 = pred_ctr_x + 0.5 * pred_w
+        y2 = pred_ctr_y + 0.5 * pred_h
+        pred_boxes = torch.stack((x1, y1, x2, y2), dim=-1)
+        return pred_boxes.reshape(deltas.shape)
 
 
 @torch.jit.script


### PR DESCRIPTION
The goal of this PR is to remove dead-end branches from the graph caused by in-place operators (such as `copy_`). The improvement in the graph structure is needed to make it easier to use the model with 3rd party inference frameworks (e.g. TVM, ONNX, etc).

Related discussions:
- https://github.com/facebookresearch/detectron2/discussions/2678

@ppwwyyxx 
