### PR TITLE
Replace in-place clamp_ with out-place one

### DIFF
--- a/detectron2/structures/boxes.py
+++ b/detectron2/structures/boxes.py
@@ -202,10 +202,11 @@ class Boxes:
         """
         assert torch.isfinite(self.tensor).all(), "Box tensor contains infinite or NaN!"
         h, w = box_size
-        self.tensor[:, 0].clamp_(min=0, max=w)
-        self.tensor[:, 1].clamp_(min=0, max=h)
-        self.tensor[:, 2].clamp_(min=0, max=w)
-        self.tensor[:, 3].clamp_(min=0, max=h)
+        x1 = self.tensor[:, 0].clamp(min=0, max=w)
+        y1 = self.tensor[:, 1].clamp(min=0, max=h)
+        x2 = self.tensor[:, 2].clamp(min=0, max=w)
+        y2 = self.tensor[:, 3].clamp(min=0, max=h)
+        self.tensor = torch.stack((x1, y1, x2, y2), dim=-1)
 
     def nonempty(self, threshold: float = 0.0) -> torch.Tensor:
         """


### PR DESCRIPTION
This PR continues the initiative to replace in-place operators (such as clamp_ , copy_, etc) with out-place version of them. The modification of the graph structure is needed to make it easier to use the model with 3rd party inference frameworks (e.g. TVM, ONNX, etc).

Related discussions:

#2678
@ppwwyyxx