### PR TITLE
ade20k dataset missing ignore_label

### DIFF
--- a/detectron2/data/datasets/builtin.py
+++ b/detectron2/data/datasets/builtin.py
@@ -247,6 +247,7 @@ def register_all_ade20k(root):
             image_root=image_dir,
             sem_seg_root=gt_dir,
             evaluator_type="sem_seg",
+            ignore_label=255,
         )
 
 


### PR DESCRIPTION
Add `ignore_label` to ade20k dataset metadata.

