### PR TITLE
Remove redundant dequant/quant between backbone and proposal generator and roi heads

### DIFF
--- a/detectron2/layers/roi_align.py
+++ b/detectron2/layers/roi_align.py
@@ -53,6 +53,8 @@ class ROIAlign(nn.Module):
             rois: Bx5 boxes. First column is the index into N. The other 4 columns are xyxy.
         """
         assert rois.dim() == 2 and rois.size(1) == 5
+        if input.is_quantized:
+            input = input.dequantize()
         return roi_align(
             input,
             rois.to(dtype=input.dtype),


### PR DESCRIPTION
Summary:
Actually only the one between backbone and proposal generator is redundant unless
we implement a quantized version for roi_align (currently roi align is expecting
a float32 input, so we have to dequantize it in the code)

Reviewed By: vkuzo, ppwwyyxx

Differential Revision: D27837648

