### PR TITLE
fix deprecation warning with torch.nonzero

### DIFF
--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -151,7 +151,7 @@ def fast_rcnn_inference_single_image(
     filter_mask = scores > score_thresh  # R x K
     # R' x 2. First column contains indices of the R predictions;
     # Second column contains indices of classes.
-    filter_inds = filter_mask.nonzero()
+    filter_inds = torch.nonzero(filter_mask, as_tuple=False)
     if num_bbox_reg_classes == 1:
         boxes = boxes[filter_inds[:, 0], 0]
     else:


### PR DESCRIPTION
The original overload of nonzero is deprecated, switching to `nonzero(Tensor input, *, bool as_tuple)` signature.