### PR TITLE
fix: throw KeyError when there are custom attributes in proposals

### DIFF
--- a/detectron2/modeling/proposal_generator/proposal_utils.py
+++ b/detectron2/modeling/proposal_generator/proposal_utils.py
@@ -129,14 +129,13 @@ def find_top_rpn_proposals(
         results.append(res)
     return results
 
-
-def add_ground_truth_to_proposals(gt_boxes, proposals):
+def add_ground_truth_to_proposals(gt: List[Instances], proposals: List[Instances]):
     """
     Call `add_ground_truth_to_proposals_single_image` for all images.
 
     Args:
-        gt_boxes(list[Boxes]): list of N elements. Element i is a Boxes
-            representing the gound-truth for image i.
+        gt(list[Instances]): list of N elements. Element i is a Instances
+            representing the ground-truth for image i.
         proposals (list[Instances]): list of N elements. Element i is a Instances
             representing the proposals for image i.
 
@@ -144,21 +143,21 @@ def add_ground_truth_to_proposals(gt_boxes, proposals):
         list[Instances]: list of N Instances. Each is the proposals for the image,
             with field "proposal_boxes" and "objectness_logits".
     """
-    assert gt_boxes is not None
+    assert gt is not None
 
-    assert len(proposals) == len(gt_boxes)
+    assert len(proposals) == len(gt)
     if len(proposals) == 0:
         return proposals
 
     return [
-        add_ground_truth_to_proposals_single_image(gt_boxes_i, proposals_i)
-        for gt_boxes_i, proposals_i in zip(gt_boxes, proposals)
+        add_ground_truth_to_proposals_single_image(gt_i, proposals_i)
+        for gt_i, proposals_i in zip(gt, proposals)
     ]
 
 
-def add_ground_truth_to_proposals_single_image(gt_boxes, proposals):
+def add_ground_truth_to_proposals_single_image(gt, proposals):
     """
-    Augment `proposals` with ground-truth boxes from `gt_boxes`.
+    Augment `proposals` with `gt`.
 
     Args:
         Same as `add_ground_truth_to_proposals`, but with gt_boxes and proposals
@@ -167,6 +166,7 @@ def add_ground_truth_to_proposals_single_image(gt_boxes, proposals):
     Returns:
         Same as `add_ground_truth_to_proposals`, but for only one image.
     """
+    gt_boxes = gt.gt_boxes
     device = proposals.objectness_logits.device
     # Assign all ground-truth boxes an objectness logit corresponding to
     # P(object) = sigmoid(logit) =~ 1.
@@ -174,7 +174,7 @@ def add_ground_truth_to_proposals_single_image(gt_boxes, proposals):
     gt_logits = gt_logit_value * torch.ones(len(gt_boxes), device=device)
 
     # Concatenating gt_boxes with proposals requires them to have the same fields
-    gt_proposal = Instances(proposals.image_size)
+    gt_proposal = Instances(proposals.image_size, **gt.get_fields())
     gt_proposal.proposal_boxes = gt_boxes
     gt_proposal.objectness_logits = gt_logits
     new_proposals = Instances.cat([proposals, gt_proposal])

--- a/detectron2/modeling/roi_heads/roi_heads.py
+++ b/detectron2/modeling/roi_heads/roi_heads.py
@@ -243,7 +243,6 @@ class ROIHeads(torch.nn.Module):
 
                 Other fields such as "gt_classes", "gt_masks", that's included in `targets`.
         """
-        gt_boxes = [x.gt_boxes for x in targets]
         # Augment proposals with ground-truth boxes.
         # In the case of learned proposals (e.g., RPN), when training starts
         # the proposals will be low quality due to random initialization.
@@ -256,7 +255,7 @@ class ROIHeads(torch.nn.Module):
         # convergence and empirically improves box AP on COCO by about 0.5
         # points (under one tested configuration).
         if self.proposal_append_gt:
-            proposals = add_ground_truth_to_proposals(gt_boxes, proposals)
+            proposals = add_ground_truth_to_proposals(targets, proposals)
 
         proposals_with_gt = []
 

--- a/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
@@ -234,9 +234,8 @@ class RROIHeads(StandardROIHeads):
                    then the ground-truth box is random)
                 - gt_classes: the ground-truth classification lable for each proposal
         """
-        gt_boxes = [x.gt_boxes for x in targets]
         if self.proposal_append_gt:
-            proposals = add_ground_truth_to_proposals(gt_boxes, proposals)
+            proposals = add_ground_truth_to_proposals(targets, proposals)
 
         proposals_with_gt = []
 

--- a/tests/modeling/test_rpn.py
+++ b/tests/modeling/test_rpn.py
@@ -9,7 +9,7 @@ from detectron2.export import scripting_with_instances
 from detectron2.layers import ShapeSpec
 from detectron2.modeling.backbone import build_backbone
 from detectron2.modeling.proposal_generator import RPN, build_proposal_generator
-from detectron2.modeling.proposal_generator.proposal_utils import find_top_rpn_proposals
+from detectron2.modeling.proposal_generator.proposal_utils import find_top_rpn_proposals, add_ground_truth_to_proposals
 from detectron2.structures import Boxes, ImageList, Instances, RotatedBoxes
 from detectron2.utils.env import TORCH_VERSION
 from detectron2.utils.events import EventStorage
@@ -232,6 +232,29 @@ class RPNTest(unittest.TestCase):
         torch.jit.trace(
             func, (proposal, pred_logit, torch.tensor([100, 100])), check_inputs=other_inputs
         )
+
+    def test_append_gt_to_proposal(self):
+        proposals = Instances((10, 10), **{
+            'proposal_boxes': Boxes(torch.empty((0, 4))),
+            'objectness_logits': torch.tensor([]),
+            'custom_attribute': torch.tensor([])
+        })
+        gt_boxes = Boxes(torch.tensor([[0, 0, 1, 1]]))
+
+        self.assertRaises(AssertionError, add_ground_truth_to_proposals, [gt_boxes], [proposals])
+
+        gt_instances = Instances((10, 10))
+        gt_instances.gt_boxes = gt_boxes
+
+        self.assertRaises(AssertionError, add_ground_truth_to_proposals, [gt_instances], [proposals])
+
+        gt_instances.custom_attribute = torch.tensor([1])
+        gt_instances.custom_attribute2 = torch.tensor([])
+        new_proposals = add_ground_truth_to_proposals([gt_instances], [proposals])[0]
+
+        self.assertEqual(new_proposals.custom_attribute[0], 1)
+        # new proposals should only include the attributes in proposals
+        self.assertRaises(KeyError, lambda: new_proposals.custom_attribute2)
 
 
 if __name__ == "__main__":

--- a/tests/modeling/test_rpn.py
+++ b/tests/modeling/test_rpn.py
@@ -249,12 +249,12 @@ class RPNTest(unittest.TestCase):
         self.assertRaises(AssertionError, add_ground_truth_to_proposals, [gt_instances], [proposals])
 
         gt_instances.custom_attribute = torch.tensor([1])
-        gt_instances.custom_attribute2 = torch.tensor([])
+        gt_instances.custom_attribute2 = torch.tensor([1])
         new_proposals = add_ground_truth_to_proposals([gt_instances], [proposals])[0]
 
         self.assertEqual(new_proposals.custom_attribute[0], 1)
         # new proposals should only include the attributes in proposals
-        self.assertRaises(KeyError, lambda: new_proposals.custom_attribute2)
+        self.assertRaises(AttributeError, lambda: new_proposals.custom_attribute2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix: throw KeyError when there are custom attributes in proposals