### PR TITLE
Update README.md by adding the external project link for BCNet in CVPR2021

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -40,4 +40,5 @@ External projects in the community that use detectron2:
 + [VoVNet backbones](https://github.com/youngwanLEE/vovnet-detectron2)
 + [FsDet](https://github.com/ucbdrive/few-shot-object-detection), Few-Shot Object Detection.
 + [Sparse R-CNN](https://github.com/PeizeSun/SparseR-CNN)
++ [BCNet](https://github.com/lkeab/BCNet), a bilayer decoupling instance segmentation method.
 


### PR DESCRIPTION
Add the external project link for BCNet in CVPR2021, which supasses centermask, blendmask, htc etc.

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

