### PR TITLE
Add config option for automatic subdir creation

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -602,6 +602,8 @@ _C.TEST.PRECISE_BN.NUM_ITER = 200
 # ---------------------------------------------------------------------------- #
 # Directory where output files are written
 _C.OUTPUT_DIR = "./output"
+# If true, a new subdir is created based on current timestamp and config file name
+_C.WRITE_OUTPUT_TO_SUBDIR = False
 # Set seed to negative to fully randomize everything.
 # Set seed to positive to use a fixed seed. Note that a fixed seed increases
 # reproducibility but does not guarantee fully deterministic behavior.

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -19,6 +19,7 @@ You may want to write your own script with your datasets and other customization
 import logging
 import os
 from collections import OrderedDict
+from datetime import datetime
 import torch
 
 import detectron2.utils.comm as comm
@@ -121,6 +122,11 @@ def setup(args):
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts)
+    if cfg.WRITE_OUTPUT_TO_SUBDIR:
+        config_file_name = args.config_file.split("/")[-1].replace(".yaml", "")
+        cfg.OUTPUT_DIR = os.path.join(
+            cfg.OUTPUT_DIR, datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + "_" + config_file_name
+        )
     cfg.freeze()
     default_setup(cfg, args)
     return cfg


### PR DESCRIPTION
I added a config option WRITE_OUTPUT_TO_SUBDIR, which creates a sub-directory in the set OUTPUT_DIR based on the current date-time and config file name.
This is handy when running multiple train runs without having to specify a different OUTPUT_DIR for each run.
The default behavior is unchanged, since the config option is disabled by default. 