### PR TITLE
Added the mapping from config to model checkpoint for the new baselines

### DIFF
--- a/detectron2/model_zoo/model_zoo.py
+++ b/detectron2/model_zoo/model_zoo.py
@@ -48,6 +48,19 @@ class _ModelZooUrls(object):
         "COCO-InstanceSegmentation/mask_rcnn_R_101_DC5_3x": "138363294/model_final_0464b7.pkl",
         "COCO-InstanceSegmentation/mask_rcnn_R_101_FPN_3x": "138205316/model_final_a3ec72.pkl",
         "COCO-InstanceSegmentation/mask_rcnn_X_101_32x8d_FPN_3x": "139653917/model_final_2d9806.pkl",  # noqa
+        # New baselines using Large-Scale Jitter and Longer Training Schedule
+        "new_baselines/mask_rcnn_R_50_FPN_100ep_LSJ": "42047764/model_final_bb69de.pkl",
+        "new_baselines/mask_rcnn_R_50_FPN_200ep_LSJ": "42047638/model_final_89a8d3.pkl",
+        "new_baselines/mask_rcnn_R_50_FPN_400ep_LSJ": "42019571/model_final_14d201.pkl",
+        "new_baselines/mask_rcnn_R_101_FPN_100ep_LSJ": "42025812/model_final_4f7b58.pkl",
+        "new_baselines/mask_rcnn_R_101_FPN_200ep_LSJ": "42131867/model_final_0bb7ae.pkl",
+        "new_baselines/mask_rcnn_R_101_FPN_400ep_LSJ": "42073830/model_final_f96b26.pkl",
+        "new_baselines/mask_rcnn_regnetx_4gf_dds_FPN_100ep_LSJ": "42047771/model_final_b7fbab.pkl",  # noqa
+        "new_baselines/mask_rcnn_regnetx_4gf_dds_FPN_200ep_LSJ": "42132721/model_final_5d87c1.pkl",  # noqa
+        "new_baselines/mask_rcnn_regnetx_4gf_dds_FPN_400ep_LSJ": "42025447/model_final_f1362d.pkl",  # noqa
+        "new_baselines/mask_rcnn_regnety_4gf_dds_FPN_100ep_LSJ": "42047784/model_final_6ba57e.pkl",  # noqa
+        "new_baselines/mask_rcnn_regnety_4gf_dds_FPN_200ep_LSJ": "42047642/model_final_27b9c1.pkl",  # noqa
+        "new_baselines/mask_rcnn_regnety_4gf_dds_FPN_400ep_LSJ": "42045954/model_final_ef3a80.pkl",  # noqa
         # COCO Person Keypoint Detection Baselines with Keypoint R-CNN
         "COCO-Keypoints/keypoint_rcnn_R_50_FPN_1x": "137261548/model_final_04e291.pkl",
         "COCO-Keypoints/keypoint_rcnn_R_50_FPN_3x": "137849621/model_final_a6e10b.pkl",


### PR DESCRIPTION
Related to #3225, but does **not** solve it. 

# Overview of changes
FAIR recently published new [Mask R-CNN baselines](https://ai.facebook.com/blog/advancing-computer-vision-research-with-new-detectron2-mask-r-cnn-baselines/). The new config files have not yet been mapped to the corresponding model checkpoint files in the `model_zoo._ModelZooUrls` class. This was a relatively easy fix that simply follows the table given in the [MODEL_ZOO table](https://github.com/facebookresearch/detectron2/blob/master/MODEL_ZOO.md#new-baselines-using-large-scale-jitter-and-longer-training-schedule). If we run the following code snippet below:
```python
from detectron2 import model_zoo
model = model_zoo.get("new_baselines/mask_rcnn_regnetx_4gf_dds_FPN_400ep_LSJ.py", trained=True)
```

This used to give: 
```
RuntimeError: new_baselines/mask_rcnn_regnetx_4gf_dds_FPN_400ep_LSJ not available in Model Zoo!
``` 

With these new changes, we get what we would expect and actually download and load the model: 
```
model_final_f1362d.pkl: 173MB [01:13, 2.37MB/s]                                                                                                                                                                                                                                
The checkpoint state_dict contains keys that are not used by the model:
  proposal_generator.anchor_generator.cell_anchors.{0, 1, 2, 3, 4}
```

I am not entirely sure whether the warning is expected or something that requires fixing.

# Additional proposal
I personally am not a big fan of the naming. "new_baslines" seems too general to me and deviates from the already established naming conventions. This makes it less intuitive and not very robust to future updates. I would suggest moving the configs to `configs/COCO-InstanceSegmentation`. Similarly, I would then also move the checkpoint files accordingly to `https://dl.fbaipublicfiles.com/detectron2/COCO-InstanceSegmentation/`. I did not implement these changes yet because I cannot change where the model files are stored and because I can imagine there to be an internal motivation not to change the naming anymore. 