### PR TITLE
correct error messages in TracingAdapter(allow_non_tensor=True)

### DIFF
--- a/detectron2/export/flatten.py
+++ b/detectron2/export/flatten.py
@@ -280,7 +280,9 @@ class TracingAdapter(nn.Module):
             if self.inputs_schema is not None:
                 inputs_orig_format = self.inputs_schema(args)
             else:
-                if args != self.flattened_inputs:
+                if len(args) != len(self.flattened_inputs) or any(
+                    x is not y for x, y in zip(args, self.flattened_inputs)
+                ):
                     raise ValueError(
                         "TracingAdapter does not contain valid inputs_schema."
                         " So it cannot generalize to other inputs and must be"


### PR DESCRIPTION
Summary:
tuple comparison using "!=" does not work when (1) tuple contains tensors AND (2) the tensors are not the same object

change to compare each element.

This prevents the error message in https://github.com/facebookresearch/detectron2/issues/3234

Differential Revision: D29626855

