### PR TITLE
Minimal setup.py for DensePose project

### DIFF
--- a/projects/DensePose/doc/GETTING_STARTED.md
+++ b/projects/DensePose/doc/GETTING_STARTED.md
@@ -56,3 +56,20 @@ Please refer to [Query DB](TOOL_QUERY_DB.md) for more details on this tool
 
 `apply_net` is a tool to print or visualize DensePose results.
 Please refer to [Apply Net](TOOL_APPLY_NET.md) for more details on this tool
+
+
+## Installation as a package
+
+DensePose can also be installed as a Python package for integration with other software.
+
+Prerequisites that must be installed prior to installing DensePose are:
+ - Python >= 3.6
+ - [PyTorch](https://pytorch.org/get-started/locally/#start-locally)
+
+DensePose can then be installed from this GitHub repository by running:
+
+```
+pip install git+https://github.com/drivendataorg/detectron2@master#subdirectory=projects/DensePose
+```
+
+After installing the package it is available with `import densepose`.

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -1,0 +1,29 @@
+
+from setuptools import setup, find_packages
+
+try:
+    import torch
+except ImportError:
+    raise Exception("""
+You must install PyTorch prior to installing DensePose:
+pip install torch
+
+For more information:
+    https://pytorch.org/get-started/locally/
+    """)
+
+setup(
+    name='DensePose',
+    author='FAIR',
+    url="https://github.com/facebookresearch/detectron2/tree/master/projects/DensePose",
+    packages=find_packages(),
+    python_requires=">=3.6",
+    install_requires=[
+        'av >= 8.0.3',
+        'detectron2@git+https://github.com/facebookresearch/detectron2.git',
+        'opencv-python-headless >= 4.5.3.56',
+        'scipy >= 1.5.4',
+        'torch >= 1.9.0',
+        'torchvision >= 0.10.0',
+    ],
+)

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -22,7 +22,7 @@ def get_detectron2_current_version():
     file with a regex."""
     # get version info from detectron2 __init__.py
     version_source = (Path(__file__).parents[2] / "detectron2" / "__init__.py").read_text()
-    version_number = re.findall('__version__ = "([0-9\.]+)"', version_source)[0]
+    version_number = re.findall(r'__version__ = "([0-9\.]+)"', version_source)[0]
     return version_number
 
 

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -1,29 +1,30 @@
-
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 try:
-    import torch
+    import torch  # noqa: F401
 except ImportError:
-    raise Exception("""
+    raise Exception(
+        """
 You must install PyTorch prior to installing DensePose:
 pip install torch
 
 For more information:
     https://pytorch.org/get-started/locally/
-    """)
+    """
+    )
 
 setup(
-    name='DensePose',
-    author='FAIR',
+    name="DensePose",
+    author="FAIR",
     url="https://github.com/facebookresearch/detectron2/tree/master/projects/DensePose",
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'av >= 8.0.3',
-        'detectron2@git+https://github.com/facebookresearch/detectron2.git',
-        'opencv-python-headless >= 4.5.3.56',
-        'scipy >= 1.5.4',
-        'torch >= 1.9.0',
-        'torchvision >= 0.10.0',
+        "av >= 8.0.3",
+        "detectron2@git+https://github.com/facebookresearch/detectron2.git",
+        "opencv-python-headless >= 4.5.3.56",
+        "scipy >= 1.5.4",
+        "torch >= 1.9.0",
+        "torchvision >= 0.10.0",
     ],
 )

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -1,3 +1,5 @@
+import re
+from pathlib import Path
 from setuptools import find_packages, setup
 
 try:
@@ -13,9 +15,21 @@ For more information:
     """
     )
 
+
+def get_detectron2_current_version():
+    """Version is not available for import through Python since it is
+    above the top level of the packge. Instead, we parse it from the
+    file with a regex."""
+    # get version info from detectron2 __init__.py
+    version_source = (Path(__file__).parents[2] / "detectron2" / "__init__.py").read_text()
+    version_number = re.findall('__version__ = "([0-9\.]+)"', version_source)[0]
+    return version_number
+
+
 setup(
-    name="DensePose",
+    name="detectron2-densepose",
     author="FAIR",
+    version=get_detectron2_current_version(),
     url="https://github.com/facebookresearch/detectron2/tree/master/projects/DensePose",
     packages=find_packages(),
     python_requires=">=3.6",


### PR DESCRIPTION
## Summary

Currently DensePose cannot be installed and referenced in other code bases as a Python package. It would be useful to be able to install densepose as a package. 

This PR adds a minimal `setup.py` file that allows outside developers to include densepose as a dependency by running:
```
pip install git+https://github.com/drivendataorg/detectron2@master#subdirectory=projects/DensePose
```

It includes the extra dependencies that are not part of detectron2 as requirements and also installs `detectron2`. It also adds an `__init__.py` to the utils folder so that is importable when installed with pip.

## Open questions:
 1. Should we provide a version number? We currently do not so pip interprets the version as `0.0.0`.
 2. Currently the [package name is `DensePose`](https://github.com/facebookresearch/detectron2/pull/3311/files#diff-8ada752fb4e04a934789193ff59b1e77491221bfdb46f99638f7a0b00e29f2d2R17) to match the name of the project folder, but I think its more conventional to match the actual module and use `densepose` as the name. Is there a preference?
 3. Should we add these install instructions to the README?

-------------

## Example usage

Here is the full output log of a successful `pip install` from our branch into a new environment that only had `torch` installed:

```
❯ pip install git+https://github.com/drivendataorg/detectron2@densepose-add-setup-py#subdirectory=projects/DensePose

 ... // clipped install logs

Successfully installed Pillow-8.3.1 absl-py-0.13.0 antlr4-python3-runtime-4.8 appdirs-1.4.4 av-8.0.3 black-21.4b2 cachetools-4.2.2 charset-normalizer-2.0.4 click-8.0.1 cloudpickle-1.6.0 cycler-0.10.0 cython-0.29.24 detectron2-0.5 detectron2-densepose-0.5 future-0.18.2 fvcore-0.1.5.post20210730 google-auth-1.34.0 google-auth-oauthlib-0.4.5 grpcio-1.39.0 hydra-core-1.1.0 idna-3.2 importlib-metadata-4.6.3 importlib-resources-5.2.2 iopath-0.1.9 kiwisolver-1.3.1 markdown-3.3.4 matplotlib-3.3.4 mypy-extensions-0.4.3 numpy-1.19.5 oauthlib-3.1.1 omegaconf-2.1.0 opencv-python-headless-4.5.3.56 pathspec-0.9.0 portalocker-2.3.0 protobuf-3.17.3 pyasn1-0.4.8 pyasn1-modules-0.2.8 pycocotools-2.0.2 pydot-1.4.2 pyparsing-2.4.7 python-dateutil-2.8.2 pyyaml-5.4.1 regex-2021.7.6 requests-2.26.0 requests-oauthlib-1.3.0 rsa-4.7.2 scipy-1.5.4 six-1.16.0 tabulate-0.8.9 tensorboard-2.5.0 tensorboard-data-server-0.6.1 tensorboard-plugin-wit-1.8.0 termcolor-1.1.0 toml-0.10.2 torchvision-0.10.0 tqdm-4.62.0 typed-ast-1.4.3 urllib3-1.26.6 werkzeug-2.0.1 yacs-0.1.8 zipp-3.5.0

❯ python
Python 3.6.13 |Anaconda, Inc.| (default, Feb 23 2021, 12:58:59)
[GCC Clang 10.0.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import densepose
>>> # successful import!
```

