### PR TITLE
avoid warnings of NCCL

### DIFF
--- a/detectron2/engine/defaults.py
+++ b/detectron2/engine/defaults.py
@@ -572,6 +572,9 @@ Alternatively, you can call evaluation functions yourself (see Colab balloon tut
     @classmethod
     def test(cls, cfg, model, evaluators=None):
         """
+        Evaluate the given model. The given model is expected to already contain
+        weights to evaluate.
+
         Args:
             cfg (CfgNode):
             model (nn.Module):

--- a/detectron2/utils/comm.py
+++ b/detectron2/utils/comm.py
@@ -43,7 +43,9 @@ def get_local_rank() -> int:
         return 0
     if not dist.is_initialized():
         return 0
-    assert _LOCAL_PROCESS_GROUP is not None
+    assert (
+        _LOCAL_PROCESS_GROUP is not None
+    ), "Local process group is not created! Please use launch() to spawn processes!"
     return dist.get_rank(group=_LOCAL_PROCESS_GROUP)
 
 
@@ -76,7 +78,10 @@ def synchronize():
     world_size = dist.get_world_size()
     if world_size == 1:
         return
-    dist.barrier()
+    if dist.get_backend() == dist.Backend.NCCL:
+        dist.barrier(device_ids=[get_local_rank()])
+    else:
+        dist.barrier()
 
 
 @functools.lru_cache()


### PR DESCRIPTION
Summary:
avoid warnings like the following:
```
[W ProcessGroupNCCL.cpp:1569] Rank 0 using best-guess GPU 0 to perform barrier as devices used by
this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is
incorrect. Specify device_ids in barrier() to force use of a particular device.
```

maybe can fix the hang in https://github.com/facebookresearch/detectron2/issues/3319

Differential Revision: D30077957

