### PR TITLE
Make vis module importable, remove required torch and torchvision

### DIFF
--- a/projects/DensePose/doc/GETTING_STARTED.md
+++ b/projects/DensePose/doc/GETTING_STARTED.md
@@ -64,7 +64,8 @@ DensePose can also be installed as a Python package for integration with other s
 
 The following dependencies are needed:
 - Python >= 3.6
-- [PyTorch](https://pytorch.org/get-started/locally/#start-locally)
+- [PyTorch](https://pytorch.org/get-started/locally/#start-locally) >= 1.7 (to match [detectron2 requirements](https://detectron2.readthedocs.io/en/latest/tutorials/install.html#requirements))
+- [torchvision](https://pytorch.org/vision/stable/) version [compatible with your version of PyTorch](https://github.com/pytorch/vision#installation)
 
 DensePose can then be installed from this repository with:
 

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -38,7 +38,5 @@ setup(
         "detectron2@git+https://github.com/facebookresearch/detectron2.git",
         "opencv-python-headless>=4.5.3.56",
         "scipy>=1.5.4",
-        "torch>=1.9.0",
-        "torchvision>=0.10.0",
     ],
 )


### PR DESCRIPTION
In PR #3311 we made densepose a pip-installable Python package. However, we forgot to include an `__init__.py` so that the `vis` module is importable. This PR adds that `__init__.py`.

It was also mentioned in that PR that there is a preference not to require torch and torchvision requirements versions:
https://github.com/facebookresearch/detectron2/pull/3311#issuecomment-892513481

This PR also removes those requirements from the `setup.py` and lists them instead in the prerequisites in the documentation.