### PR TITLE
Fixed an RuntimeError with interference

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -1177,7 +1177,7 @@ class Visualizer:
         Convert different format of boxes to an NxB array, where B = 4 or 5 is the box dimension.
         """
         if isinstance(boxes, Boxes) or isinstance(boxes, RotatedBoxes):
-            return boxes.tensor.numpy()
+            return boxes.tensor.detach().numpy()
         else:
             return np.asarray(boxes)
 


### PR DESCRIPTION
Thanks for your contribution!.
Fixed the following runtime Error : numpy() fails when visualizing an output element of a input batch during inference
