### PR TITLE
Correct typo

### DIFF
--- a/docs/tutorials/augmentation.md
+++ b/docs/tutorials/augmentation.md
@@ -111,7 +111,7 @@ We use keypoints data as an example.
 Keypoints are (x, y) coordinates, but they are not so trivial to augment due to the semantic meaning they carry.
 Such meaning is only known to the users, therefore users may want to augment them manually
 by looking at the returned `transform`.
-For example, when an image is horizontally flipped, we'd like to to swap the keypoint annotations for "left eye" and "right eye".
+For example, when an image is horizontally flipped, we'd like to swap the keypoint annotations for "left eye" and "right eye".
 This can be done like this (included by default in detectron2's default data loader):
 ```python
 # augs, input are defined as in previous examples


### PR DESCRIPTION
Correct typo
to to swap -> to swap
Regarding issue #3458 

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

