### PR TITLE
Filter out a UserWarning in torch-1.9

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -96,7 +96,7 @@ class ImageList(object):
         if size_divisibility > 1:
             stride = size_divisibility
             # the last two dims are H,W, both subject to divisibility requirement
-            max_size = (max_size + (stride - 1)) // stride * stride
+            max_size = (max_size + (stride - 1)).div(stride, rounding_mode="floor") * stride
 
         # handle weirdness of scripting and tracing ...
         if torch.jit.is_scripting():


### PR DESCRIPTION
Filter out the following `UserWarning` triggered by the floor division in the original code when using pytorch-1.9.0. Replace with the [torch.div()](https://pytorch.org/docs/stable/generated/torch.div.html#torch.div) API as suggested.

```
UserWarning: floor_divide is deprecated, and will be removed in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values.
To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor'). (Triggered internally at  /opt/conda/conda-bld/pytorch_1623448224956/work/aten/src/ATen/na
tive/BinaryOps.cpp:467.)
```

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

