### PR TITLE
add color field in instances and visualize based on preset colors

### DIFF
--- a/detectron2/utils/video_visualizer.py
+++ b/detectron2/utils/video_visualizer.py
@@ -72,6 +72,7 @@ class VideoVisualizer:
         scores = predictions.scores if predictions.has("scores") else None
         classes = predictions.pred_classes.numpy() if predictions.has("pred_classes") else None
         keypoints = predictions.pred_keypoints if predictions.has("pred_keypoints") else None
+        colors = predictions.COLOR if predictions.has("COLOR") else [None] * len(predictions)
 
         if predictions.has("pred_masks"):
             masks = predictions.pred_masks
@@ -82,10 +83,11 @@ class VideoVisualizer:
             masks = None
 
         detected = [
-            _DetectedInstance(classes[i], boxes[i], mask_rle=None, color=None, ttl=8)
+            _DetectedInstance(classes[i], boxes[i], mask_rle=None, color=colors[i], ttl=8)
             for i in range(num_instances)
         ]
-        colors = self._assign_colors(detected)
+        if not predictions.has("COLOR"):
+            colors = self._assign_colors(detected)
 
         labels = _create_text_labels(classes, scores, self.metadata.get("thing_classes", None))
 


### PR DESCRIPTION
Summary: Currently D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f) and D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f)GO uses a box IoU based method to assign id and color for each instance. It is useful but not flexible. This diff allows user to define their own preset colors for each instance. By doing this, some advanced tracking method can be applied before get into the Visualizer.

Differential Revision: D31366663

