### PR TITLE
fix: URL to install DensePose thorugh pip

### DIFF
--- a/projects/DensePose/doc/GETTING_STARTED.md
+++ b/projects/DensePose/doc/GETTING_STARTED.md
@@ -70,7 +70,7 @@ The following dependencies are needed:
 DensePose can then be installed from this repository with:
 
 ```
-pip install git+https://github.com/facebookresearch/detectron2@master#subdirectory=projects/DensePose
+pip install git+https://github.com/facebookresearch/detectron2@main#subdirectory=projects/DensePose
 ```
 
 After installation, the package will be importable as `densepose`.


### PR DESCRIPTION
DensePose Pip install URL points to  master branch which no longer exists. Fix url to install from main branch instead