### PR TITLE
RandomRotation: random center selection

### DIFF
--- a/detectron2/data/transforms/augmentation_impl.py
+++ b/detectron2/data/transforms/augmentation_impl.py
@@ -288,7 +288,10 @@ class RandomRotation(Augmentation):
         else:
             angle = np.random.choice(self.angle)
             if self.center is not None:
-                center = np.random.choice(self.center)
+                center = (
+                    np.random.choice(self.center[0]),
+                    np.random.choice(self.center[1]),
+                )
 
         if center is not None:
             center = (w * center[0], h * center[1])  # Convert to absolute coordinates


### PR DESCRIPTION
Inside the class RandomRotation, random center selection with sample_style="choice" generates an error because np.random.choice() was applied to a list of lists and not to a list of floats.

Regards

