### PR TITLE
made `BestCheckpointer` log message more readable

### DIFF
--- a/detectron2/engine/hooks.py
+++ b/detectron2/engine/hooks.py
@@ -276,7 +276,7 @@ class BestCheckpointer(HookBase):
             additional_state = {"iteration": metric_iter}
             self._checkpointer.save(f"{self._file_prefix}", **additional_state)
             self._logger.info(
-                f"Saved best model as latest eval score for {self._val_metric} is"
+                f"Saved best model as latest eval score for {self._val_metric} is "
                 f"{latest_metric:0.5f}, better than last best score "
                 f"{self.best_metric:0.5f} @ iteration {self.best_iter}."
             )


### PR DESCRIPTION
This PR makes the log message more readable in `BestCheckpointer`
The current version doesn't have space between `is` and the `metric value`. 

![image](https://user-images.githubusercontent.com/52319020/140401818-5a825ef4-9857-4856-a43f-c864cc5ec6a9.png)

This PR just adds a space between `is` and the `metric value`