### PR TITLE
enable stable sort in BoxWithNMSLimit op

### DIFF
--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -121,6 +121,8 @@ def assert_instances_allclose(input, other, *, rtol=1e-5, msg="", size_as_tensor
                     msg + f"Field {f} differs too much!"
                 )
             else:
+                if not torch.equal(val1, val2):
+                    import pdb; pdb.set_trace()
                 assert torch.equal(val1, val2), msg + f"Field {f} is different!"
         else:
             raise ValueError(f"Don't know how to compare type {type(val1)}")


### PR DESCRIPTION
Summary:
D32694315 changes the implementation of sorting in NMS to stable sort. While the C2 operators are using non-stable sort. This causes test failure such as:
- mobile-vision/d2go/tests:fb_test_meta_arch_rcnn - test_export_caffe2 (d2go.tests.fb.test_meta_arch_rcnn.TestFBNetV2MaskRCNNFP32) (architecture: x86_64, buildmode: dev-nosan, buildsystem: buck, compiler: clang, sanitizer: none) https://www.internalfb.com/intern/testinfra/diagnostics/7318349463675961.562949999530318.1640814509/
- mobile-vision/d2go/tests:fb_test_meta_arch_rcnn - test_export_torchscript_mobile_c2_ops (d2go.tests.fb.test_meta_arch_rcnn.TestFBNetV2MaskRCNNFP32) (architecture: x86_64, buildmode: dev-nosan, buildsystem: buck, compiler: clang, sanitizer: none) https://www.internalfb.com/intern/testinfra/diagnostics/7318349463675961.844424980844724.1640814504/

To illustrate, in the failed test_export_caffe2 test, the inputs of BoxWithNMSLimit are:
```
(Pdb) ws.FetchBlob("246")
array([[0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568, 0.01234568, 0.01234568, 0.01234568, 0.01234568,
        0.01234568]], dtype=float32)
(Pdb) ws.FetchBlob("248")
array([[ 0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,
         0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0.,
        10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10.,
        20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,  0.,  0., 10., 20.,
         0.,  0., 10., 20.,  0.,  0., 10., 20.]], dtype=float32)
(Pdb) ws.FetchBlob("249")
array([1.], dtype=float32)
```
This contains 81 boxes (representing 81 classes) with equal score, stable sort will return the class id 0; while the non-stable sort returns class id 50.

This diff changes the sorting to stable sort for BoxWithNMSLimit op.

Differential Revision: D33355251

