### PR TITLE
make AspectRatioGrouped dataset re-iterable

### DIFF
--- a/detectron2/data/common.py
+++ b/detectron2/data/common.py
@@ -237,5 +237,8 @@ class AspectRatioGroupedDataset(data.IterableDataset):
             bucket = self._buckets[bucket_id]
             bucket.append(d)
             if len(bucket) == self.batch_size:
-                yield bucket[:]
+                data = bucket[:]
+                # Clear bucket first, because code after yield is not
+                # guaranteed to execute
                 del bucket[:]
+                yield data


### PR DESCRIPTION
* Re-iterate AspectRatioGrouped dataset may cause memory leak. This PR fixes the issue. This will close https://github.com/facebookresearch/detectron2/issues/3847.