### PR TITLE
Add ID field in visualizer

### DIFF
--- a/detectron2/tracking/bbox_iou_tracker.py
+++ b/detectron2/tracking/bbox_iou_tracker.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright 2004-present Facebook. All Rights Reserved.
+import copy
+from typing import List
+
+import numpy as np
+import torch
+from detectron2.structures.boxes import pairwise_iou
+from detectron2.structures import Boxes, Instances
+from .base_tracker import BaseTracker, TRACKER_HEADS_REGISTRY
+from detectron2.config import configurable
+from ..config.config import CfgNode as CfgNode_
+
+
+@TRACKER_HEADS_REGISTRY.register()
+class BBoxIOUTracker(BaseTracker):
+    """
+    A bounding box tracker to assign ID based on IoU between current and previous instances
+    """
+    @configurable
+    def __init__(
+        self,
+        video_height: int,
+        video_width: int,
+        max_num_instances: int = 200,
+        max_lost_frame_count: int = 0,
+        min_box_rel_dim: float = 0.02,
+        min_instance_period: int = 1,
+        track_iou_threshold: float = 0.5,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self._video_height = video_height
+        self._video_width = video_width
+        self._max_num_instances = max_num_instances
+        self._max_lost_frame_count = max_lost_frame_count
+        self._min_box_rel_dim = min_box_rel_dim
+        self._min_instance_period = min_instance_period
+        self._track_iou_threshold = track_iou_threshold
+
+    @classmethod
+    def from_config(cls, cfg: CfgNode_):
+        """
+        Old style initialization using CfgNode
+
+        Args:
+            cfg: D2 CfgNode, config file
+        Return:
+            dictionary storing arguments for __init__ method
+        """
+        assert "VIDEO_HEIGHT" in cfg.TRACKER_HEADS
+        assert "VIDEO_WIDTH" in cfg.TRACKER_HEADS
+        video_height = cfg.TRACKER_HEADS.get("VIDEO_HEIGHT")
+        video_width = cfg.TRACKER_HEADS.get("VIDEO_WIDTH")
+        max_num_instances = cfg.TRACKER_HEADS.get("MAX_NUM_INSTANCES", 200)
+        max_lost_frame_count = cfg.TRACKER_HEADS.get("MAX_LOST_FRAME_COUNT", 0)
+        min_box_rel_dim = cfg.TRACKER_HEADS.get("MIN_BOX_REL_DIM", 0.02)
+        min_instance_period = cfg.TRACKER_HEADS.get("MIN_INSTANCE_PERIOD", 1)
+        track_iou_threshold = cfg.TRACKER_HEADS.get("TRACK_IOU_THRESHOLD", 0.5)
+        return {
+            "_target_": "detectron2.tracking.bbox_iou_tracker.BBoxIOUTracker",
+            "video_height": video_height,
+            "video_width": video_width,
+            "max_num_instances": max_num_instances,
+            "max_lost_frame_count": max_lost_frame_count,
+            "min_box_rel_dim": min_box_rel_dim,
+            "min_instance_period": min_instance_period,
+            "track_iou_threshold": track_iou_threshold
+        }
+
+    def update(self, instances: Instances) -> Instances:
+        """
+        See BaseTracker description
+        """
+        if instances.has("pred_keypoints"):
+            raise NotImplementedError("Need to add support for keypoints")
+        instances = self._initialize_extra_fields(instances)
+        if self._prev_instances is not None:
+            # calculate IoU of all bbox pairs
+            iou_all = pairwise_iou(
+                boxes1=instances.pred_boxes,
+                boxes2=self._prev_instances.pred_boxes,
+            )
+            # sort IoU in descending order
+            bbox_pairs = self._create_prediction_pairs(instances, iou_all)
+            # assign previous ID to current bbox if IoU > track_iou_threshold
+            self._reset_fields()
+            for bbox_pair in bbox_pairs:
+                if bbox_pair["IoU"] < self._track_iou_threshold:
+                    continue
+                idx = bbox_pair["idx"]
+                prev_id = bbox_pair["prev_id"]
+                if idx in self._matched_idx or prev_id in self._matched_ID:
+                    continue
+                instances.ID[idx] = prev_id
+                instances.ID_period[idx] = bbox_pair["prev_period"] + 1
+                instances.lost_frame_count[idx] = 0
+                self._matched_idx.add(idx)
+                self._matched_ID.add(prev_id)
+                self._untracked_prev_idx.remove(bbox_pair["prev_idx"])
+            instances = self._assign_new_id(instances)
+            instances = self._merge_untracked_instances(instances)
+        self._prev_instances = copy.deepcopy(instances)
+        return instances
+
+    def _create_prediction_pairs(
+        self, instances: Instances, iou_all: np.ndarray
+    ) -> List:
+        """
+        For all instances in previous and current frames, create pairs. For each
+        pair, store index of the instance in current frame predcitions, index in
+        previous predictions, ID in previous predictions, IoU of the bboxes in this
+        pair, period in previous predictions.
+
+        Args:
+            instances: D2 Instances, for predictions of the current frame
+            iou_all: IoU for all bboxes pairs
+        Return:
+            A list of IoU for all pairs
+        """
+        bbox_pairs = []
+        for i in range(len(instances)):
+            for j in range(len(self._prev_instances)):
+                bbox_pairs.append(
+                    {
+                        "idx": i,
+                        "prev_idx": j,
+                        "prev_id": self._prev_instances.ID[j],
+                        "IoU": iou_all[i, j],
+                        "prev_period": self._prev_instances.ID_period[j],
+                    }
+                )
+        return bbox_pairs
+
+    def _initialize_extra_fields(self, instances: Instances) -> Instances:
+        """
+        If input instances don't have ID, ID_period, lost_frame_count fields,
+        this method is used to initialize these fields.
+
+        Args:
+            instances: D2 Instances, for predictions of the current frame
+        Return:
+            D2 Instances with extra fields added
+        """
+        if not instances.has("ID"):
+            instances.set("ID", [None] * len(instances))
+        if not instances.has("ID_period"):
+            instances.set("ID_period", [None] * len(instances))
+        if not instances.has("lost_frame_count"):
+            instances.set("lost_frame_count", [None] * len(instances))
+        if self._prev_instances is None:
+            instances.ID = list(range(len(instances)))
+            self._id_count += len(instances)
+            instances.ID_period = [1] * len(instances)
+            instances.lost_frame_count = [0] * len(instances)
+        return instances
+
+    def _reset_fields(self):
+        """
+        Before each uodate call, reset fields first
+        """
+        self._matched_idx = set()
+        self._matched_ID = set()
+        self._untracked_prev_idx = set(range(len(self._prev_instances)))
+
+    def _assign_new_id(self, instances: Instances) -> Instances:
+        """
+        For each untracked instance, assign a new id
+
+        Args:
+            instances: D2 Instances, for predictions of the current frame
+        Return:
+            D2 Instances with new ID assigned
+        """
+        untracked_idx = set(range(len(instances))).difference(self._matched_idx)
+        for idx in untracked_idx:
+            instances.ID[idx] = self._id_count
+            self._id_count += 1
+            instances.ID_period[idx] = 1
+            instances.lost_frame_count[idx] = 0
+        return instances
+
+    def _merge_untracked_instances(self, instances: Instances) -> Instances:
+        """
+        For untracked previous instances, under certain condition, still keep them
+        in tracking and merge with the current instances.
+
+        Args:
+            instances: D2 Instances, for predictions of the current frame
+        Return:
+            D2 Instances merging current instances and instances from previous
+            frame decided to keep tracking
+        """
+        untracked_instances = Instances(
+            image_size=instances.image_size,
+            pred_boxes=[],
+            pred_masks=[],
+            pred_classes=[],
+            scores=[],
+            ID=[],
+            ID_period=[],
+            lost_frame_count=[],
+        )
+        prev_bboxes = list(self._prev_instances.pred_boxes)
+        prev_classes = list(self._prev_instances.pred_classes)
+        prev_scores = list(self._prev_instances.scores)
+        prev_ID_period = self._prev_instances.ID_period
+        if instances.has("pred_masks"):
+            prev_masks = list(self._prev_instances.pred_masks)
+        for idx in self._untracked_prev_idx:
+            x_left, y_top, x_right, y_bot = prev_bboxes[idx]
+            if (
+                (1.0 * (x_right - x_left) / self._video_width < self._min_box_rel_dim)
+                or (1.0 * (y_bot - y_top) / self._video_height < self._min_box_rel_dim)
+                or self._prev_instances.lost_frame_count[idx] >= self._max_lost_frame_count
+                or prev_ID_period[idx] <= self._min_instance_period
+            ):
+                continue
+            untracked_instances.pred_boxes.append(list(prev_bboxes[idx].numpy()))
+            untracked_instances.pred_classes.append(int(prev_classes[idx]))
+            untracked_instances.scores.append(float(prev_scores[idx]))
+            untracked_instances.ID.append(self._prev_instances.ID[idx])
+            untracked_instances.ID_period.append(self._prev_instances.ID_period[idx])
+            untracked_instances.lost_frame_count.append(
+                self._prev_instances.lost_frame_count[idx] + 1
+            )
+            if instances.has("pred_masks"):
+                untracked_instances.pred_masks.append(prev_masks[idx].numpy().astype(np.uint8))
+
+        untracked_instances.pred_boxes = Boxes(torch.FloatTensor(untracked_instances.pred_boxes))
+        untracked_instances.pred_classes = torch.IntTensor(untracked_instances.pred_classes)
+        untracked_instances.scores = torch.FloatTensor(untracked_instances.scores)
+        if instances.has("pred_masks"):
+            untracked_instances.pred_masks = torch.IntTensor(untracked_instances.pred_masks)
+        else:
+            untracked_instances.remove("pred_masks")
+
+        return Instances.cat(
+            [
+                instances,
+                untracked_instances,
+            ]
+        )

--- a/detectron2/utils/colormap.py
+++ b/detectron2/utils/colormap.py
@@ -6,8 +6,9 @@ Copied from Detectron, and removed gray colors.
 """
 
 import numpy as np
+import random
 
-__all__ = ["colormap", "random_color"]
+__all__ = ["colormap", "random_color", "random_colors"]
 
 # fmt: off
 # RGB:
@@ -121,6 +122,23 @@ def random_color(rgb=False, maximum=255):
     ret = _COLORS[idx] * maximum
     if not rgb:
         ret = ret[::-1]
+    return ret
+
+
+def random_colors(N, rgb=False, maximum=255):
+    """
+    Args:
+        N (int): number of unique colors needed
+        rgb (bool): whether to return RGB colors or BGR colors.
+        maximum (int): either 255 or 1
+
+    Returns:
+        ndarray: a list of random_color
+    """
+    indices = random.sample(range(len(_COLORS)), N)
+    ret = [_COLORS[i] * maximum for i in indices]
+    if not rgb:
+        ret = [x[::-1] for x in ret]
     return ret
 
 

--- a/detectron2/utils/video_visualizer.py
+++ b/detectron2/utils/video_visualizer.py
@@ -49,6 +49,11 @@ class VideoVisualizer:
             ColorMode.IMAGE_BW,
         ], "Other mode not supported yet."
         self._instance_mode = instance_mode
+        # currently _COLORS only support max=74 colors
+        self._max_num_instances = self.metadata.get("max_num_instances", 74)
+        self._assigned_colors = {}
+        self._color_pool = random_colors(self._max_num_instances, rgb=True, maximum=1)
+        self._color_idx_set = set(range(len(self._color_pool)))
 
     def draw_instance_predictions(self, frame, predictions):
         """

--- a/tests/tracking/test_bbox_iou_tracker.py
+++ b/tests/tracking/test_bbox_iou_tracker.py
@@ -1,0 +1,158 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+import torch
+import numpy as np
+
+from detectron2.tracking.bbox_iou_tracker import BBoxIOUTracker
+from typing import Dict
+from detectron2.structures import Boxes, Instances
+from detectron2.config import instantiate, CfgNode as CfgNode_
+from copy import deepcopy
+
+
+class TestBBoxIOUTracker(unittest.TestCase):
+    def setUp(self):
+        self._img_size = np.array([600, 800])
+        self._prev_boxes = np.array(
+            [
+                [101, 101, 200, 200],
+                [301, 301, 450, 450],
+            ]
+        ).astype(np.float32)
+        self._prev_scores = np.array([0.9, 0.9])
+        self._prev_classes = np.array([1, 1])
+        self._prev_masks = np.ones((2, 600, 800)).astype("uint8")
+        self._curr_boxes = np.array(
+            [
+                [302, 303, 451, 452],
+                [101, 102, 201, 203],
+            ]
+        ).astype(np.float32)
+        self._curr_scores = np.array([0.95, 0.85])
+        self._curr_classes = np.array([1, 1])
+        self._curr_masks = np.ones((2, 600, 800)).astype("uint8")
+
+        self._prev_instances = {
+            "image_size": self._img_size,
+            "pred_boxes": self._prev_boxes,
+            "scores": self._prev_scores,
+            "pred_classes": self._prev_classes,
+            "pred_masks": self._prev_masks,
+        }
+        self._prev_instances = self._convertDictPredictionToInstance(self._prev_instances)
+        self._curr_instances = {
+            "image_size": self._img_size,
+            "pred_boxes": self._curr_boxes,
+            "scores": self._curr_scores,
+            "pred_classes": self._curr_classes,
+            "pred_masks": self._curr_masks,
+        }
+        self._curr_instances = self._convertDictPredictionToInstance(self._curr_instances)
+
+        self._max_num_instances = 200
+        self._max_lost_frame_count = 0
+        self._min_box_rel_dim = 0.02
+        self._min_instance_period = 1
+        self._track_iou_threshold = 0.5
+
+    def _convertDictPredictionToInstance(self, prediction: Dict) -> Instances:
+        """
+        convert prediction from Dict to D2 Instances format
+        """
+        res = Instances(
+            image_size=torch.IntTensor(prediction["image_size"]),
+            pred_boxes=Boxes(torch.FloatTensor(prediction["pred_boxes"])),
+            pred_masks=torch.IntTensor(prediction["pred_masks"]),
+            pred_classes=torch.IntTensor(prediction["pred_classes"]),
+            scores=torch.FloatTensor(prediction["scores"]),
+        )
+        return res
+
+    def test_init(self):
+        cfg = {
+            "_target_": "detectron2.tracking.bbox_iou_tracker.BBoxIOUTracker",
+            "video_height": self._img_size[0],
+            "video_width": self._img_size[1],
+            "max_num_instances": self._max_num_instances,
+            "max_lost_frame_count": self._max_lost_frame_count,
+            "min_box_rel_dim": self._min_box_rel_dim,
+            "min_instance_period": self._min_instance_period,
+            "track_iou_threshold": self._track_iou_threshold
+        }
+        tracker = instantiate(cfg)
+        self.assertTrue(tracker._video_height == self._img_size[0])
+
+    def test_from_config(self):
+        cfg = CfgNode_()
+        cfg.TRACKER_HEADS = CfgNode_()
+        cfg.TRACKER_HEADS.VIDEO_HEIGHT = int(self._img_size[0])
+        cfg.TRACKER_HEADS.VIDEO_WIDTH = int(self._img_size[1])
+        cfg.TRACKER_HEADS.MAX_NUM_INSTANCES = self._max_num_instances
+        cfg.TRACKER_HEADS.MAX_LOST_FRAME_COUNT = self._max_lost_frame_count
+        cfg.TRACKER_HEADS.MIN_BOX_REL_DIM = self._min_box_rel_dim
+        cfg.TRACKER_HEADS.MIN_INSTANCE_PERIOD = self._min_instance_period
+        cfg.TRACKER_HEADS.TRACK_IOU_THRESHOLD = self._track_iou_threshold
+        input_arg = BBoxIOUTracker.from_config(cfg)
+        tracker = instantiate(input_arg)
+        self.assertTrue(tracker._video_height == self._img_size[0])
+
+    def test_initialize_extra_fields(self):
+        cfg = {
+            "_target_": "detectron2.tracking.bbox_iou_tracker.BBoxIOUTracker",
+            "video_height": self._img_size[0],
+            "video_width": self._img_size[1],
+            "max_num_instances": self._max_num_instances,
+            "max_lost_frame_count": self._max_lost_frame_count,
+            "min_box_rel_dim": self._min_box_rel_dim,
+            "min_instance_period": self._min_instance_period,
+            "track_iou_threshold": self._track_iou_threshold
+        }
+        tracker = instantiate(cfg)
+        instances = tracker._initialize_extra_fields(self._curr_instances)
+        self.assertTrue(instances.has("ID"))
+        self.assertTrue(instances.has("ID_period"))
+        self.assertTrue(instances.has("lost_frame_count"))
+
+    def test_assign_new_id(self):
+        cfg = {
+            "_target_": "detectron2.tracking.bbox_iou_tracker.BBoxIOUTracker",
+            "video_height": self._img_size[0],
+            "video_width": self._img_size[1],
+            "max_num_instances": self._max_num_instances,
+            "max_lost_frame_count": self._max_lost_frame_count,
+            "min_box_rel_dim": self._min_box_rel_dim,
+            "min_instance_period": self._min_instance_period,
+            "track_iou_threshold": self._track_iou_threshold
+        }
+        tracker = instantiate(cfg)
+        instances = deepcopy(self._curr_instances)
+        instances = tracker._initialize_extra_fields(instances)
+        instances = tracker._assign_new_id(instances)
+        self.assertTrue(len(instances.ID) == 2)
+        self.assertTrue(instances.ID[0] == 2)
+        self.assertTrue(instances.ID[1] == 3)
+
+    def test_update(self):
+        cfg = {
+            "_target_": "detectron2.tracking.bbox_iou_tracker.BBoxIOUTracker",
+            "video_height": self._img_size[0],
+            "video_width": self._img_size[1],
+            "max_num_instances": self._max_num_instances,
+            "max_lost_frame_count": self._max_lost_frame_count,
+            "min_box_rel_dim": self._min_box_rel_dim,
+            "min_instance_period": self._min_instance_period,
+            "track_iou_threshold": self._track_iou_threshold
+        }
+        tracker = instantiate(cfg)
+        prev_instances = tracker.update(self._prev_instances)
+        self.assertTrue(len(prev_instances.ID) == 2)
+        self.assertTrue(prev_instances.ID[0] == 0)
+        self.assertTrue(prev_instances.ID[1] == 1)
+        curr_instances = tracker.update(self._curr_instances)
+        self.assertTrue(len(curr_instances.ID) == 2)
+        self.assertTrue(curr_instances.ID[0] == 1)
+        self.assertTrue(curr_instances.ID[1] == 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Modify D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f) video_visualizer to be compatible with ID field in tracking output

Differential Revision: D32685252

