### PR TITLE
Adding videos from Meta Open Source team

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ It supports a number of computer vision research projects and production applica
 <div align="center">
   <img src="https://user-images.githubusercontent.com/1381301/66535560-d3422200-eace-11e9-9123-5535d469db19.png"/>
 </div>
+<br>
 
-### What's New
+## Learn More about Detectron2
+
+Explain Like I’m 5: Detectron2            |  Using Machine Learning with Detectron2
+:-------------------------:|:-------------------------:
+[![Explain Like I’m 5: Detectron2](https://img.youtube.com/vi/1oq1Ye7dFqc/0.jpg)](https://www.youtube.com/watch?v=1oq1Ye7dFqc)  |  [![Using Machine Learning with Detectron2](https://img.youtube.com/vi/eUSgtfK4ivk/0.jpg)](https://www.youtube.com/watch?v=eUSgtfK4ivk)
+
+## What's New
 * Includes new capabilities such as panoptic segmentation, Densepose, Cascade R-CNN, rotated bounding boxes, PointRend,
   DeepLab, etc.
 * Used as a library to support building [research projects](projects/) on top of it.


### PR DESCRIPTION
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Hermes home page](https://hermesengine.dev/) or in Docusaurus home page](https://docusaurus.io/)

## Test plan

This is how the video appears on the README:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12485205/154199761-7f8d958e-c4c0-4d9d-8c5a-c99f504e45f8.png">
