### PR TITLE
Fix self overlapping masks

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -691,8 +691,7 @@ class Visualizer:
                 self.draw_box(boxes[i], edge_color=color)
 
             if masks is not None:
-                for segment in masks[i].polygons:
-                    self.draw_polygon(segment.reshape(-1, 2), color, alpha=alpha)
+                self.draw_binary_mask(masks[i].mask, color, alpha=alpha)
 
             if labels is not None:
                 # first get a box


### PR DESCRIPTION
This is an attempt to fix issue https://github.com/facebookresearch/detectron2/issues/3515

# Explanation
Currently the Visualizer sometimes produces masks where a section of the mask is "doubled" (see example images in the referenced issue).

The current pipeline for drawing an item mask is the following. First  [`findContours`](https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0) is applied to the binary prediction mask in order to extract the perimeter of each segment in the mask (**Note**: this can result in multiple contours including nested ones). The resulting polygon(s) are passed to the [`overlay_instances`](https://github.com/facebookresearch/detectron2/blob/6999554d5a02e0c9c7a22c1abd8f6eb6812fad0a/detectron2/utils/visualizer.py#L607) method where for **each** segment (i.e. extracted perimeter/polygon) the drawing method [`draw_polygon`](https://github.com/facebookresearch/detectron2/blob/6999554d5a02e0c9c7a22c1abd8f6eb6812fad0a/detectron2/utils/visualizer.py#L1114) is called. Internally the method creates a matplolib `Polygon` class with `fill=True`. This means that while the [`GenericMask`](https://github.com/facebookresearch/detectron2/blob/6999554d5a02e0c9c7a22c1abd8f6eb6812fad0a/detectron2/utils/visualizer.py#L59) class contains information about having holes in the mask said information is not used in the drawing pipeline and instead the entire polygon is filled.

![image](https://user-images.githubusercontent.com/8616415/155969316-7533d0c8-3493-4c19-b967-43033b32e4f7.png)

The "doubling" of certain areas of the mask can then be explained given the perimeter extraction method together with the drawing method. Consider the example image above which represents a roughly rectangular object with a hole in the mask. The aforementioned `findContours` method would result in two perimeters (i.e. one inside the other) as there are two edges (one edge from black to white and one from white to black). The drawing method would then draw a polygon **for each** perimeter with `fill=True`. The final result then is a "doubling" of the mask where the hole was supposed to be. See the example image below

![image](https://user-images.githubusercontent.com/8616415/155970338-3c2e1023-18c8-4b91-9549-2854df438bef.png)

# Proposed solution
In order to avoid these issues, instead of drawing a polygon for each contour the proposed solution directly draws the binary mask using the already existing `draw_binary_mask` method which takes into account the information regarding holes in the mask. An example image using the proposed solution can be seen below

![image](https://user-images.githubusercontent.com/8616415/155971217-f095997b-9195-4d48-90ca-607fb12559f1.png)

**Note**: The issues described above seem to apply only in the case of Instance Segmentation as the `draw_binary_mask` method **is called** in the case of Semantic Segmentation or KeyPoints Detection. 
