### PR TITLE
sort input glob in densenet apply_net.py

### DIFF
--- a/projects/DensePose/apply_net.py
+++ b/projects/DensePose/apply_net.py
@@ -131,7 +131,7 @@ class InferenceAction(Action):
         elif os.path.isfile(input_spec):
             file_list = [input_spec]
         else:
-            file_list = glob.glob(input_spec)
+            file_list = sorted(glob.glob(input_spec))
         return file_list
 
 


### PR DESCRIPTION
This python glob library does not sort alphabetically (even though bash glob expansion is always alphabetical). Wrap with `sorted` to get the same behavior as bash. More info: https://stackoverflow.com/questions/6773584/how-are-glob-globs-return-values-ordered 

This important when running inference on video frames, where the # appended to the output image must follow the ordering of input frames. Otherwise, the output frames are scrambled.

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

