### PR TITLE
Fix dockerfile for downloading pytorch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
 # install dependencies
 # See https://pytorch.org/ for other options if you use a different version of CUDA
 RUN pip install --user tensorboard cmake   # cmake from apt-get is too old
-RUN pip install --user torch==1.10 torchvision==0.11.1 -f https://download.pytorch.org/whl/cu111/torch_stable.html
+RUN pip install --user torch==1.10 torchvision==0.11.1 --trusted-host download.pytorch.org -f http://download.pytorch.org/whl/cu111/torch_stable.html
 
 RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'
 # install detectron2


### PR DESCRIPTION
This PR is a quick fix for the downloading of PyTorch in the Dockerfile. Previously, without the `--trusted-host` option for pip, it is possible to get the following SSL connection problem and pip will ignore the provided URL, making the downloaded PyTorch wheel compiled with `cudatoolkit==10.2` instead of the desired `cudatoolkit==11.1`.
```
Step 13/21 : RUN pip install --user torch==1.10 torchvision==0.11.1 -f https://download.pytorch.org/whl/cu111/torch_stable.html
 ---> Running in bd4a6e4d3943
Looking in links: https://download.pytorch.org/whl/cu111/torch_stable.html
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /whl/cu111/torch_stable.html
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /whl/cu111/torch_stable.html
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /whl/cu111/torch_stable.html
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /whl/cu111/torch_stable.html
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)': /whl/cu111/torch_stable.html
Could not fetch URL https://download.pytorch.org/whl/cu111/torch_stable.html: There was a problem confirming the ssl certificate:
HTTPSConnectionPool(host='download.pytorch.org', port=443): Max retries exceeded with url: /whl/cu111/torch_stable.html (Caused by SSLError(SSLError(1, '[SSL:
CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),)) - skipping
```
```
 RuntimeError:
    The detected CUDA version (11.1) mismatches the version that was used to compile
    PyTorch (10.2). Please make sure to use the same CUDA versions.
```
