### PR TITLE
Update projects README.md by adding the external project link for Mask Transfiner in CVPR'2022

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -45,4 +45,4 @@ External projects in the community that use detectron2:
 + [Sparse R-CNN](https://github.com/PeizeSun/SparseR-CNN)
 + [BCNet](https://github.com/lkeab/BCNet), a bilayer decoupling instance segmentation method.
 + [DD3D](https://github.com/TRI-ML/dd3d), A fully convolutional 3D detector.
-
++ [Mask Transfiner](https://github.com/SysCV/transfiner), high-quality instance segmentation with efficient quadtree transformer.


### PR DESCRIPTION
Add the external project link for Mask Transfiner in CVPR2022, which is detectron2-based project outperforming PointRend, SOLQ, QueryInst etc.

