### PR TITLE
update git protocol in requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ tabulate
 cloudpickle
 Pillow
 future
-git+git://github.com/facebookresearch/fvcore.git
+git+https://github.com/facebookresearch/fvcore.git
 https://download.pytorch.org/whl/cpu/torch-1.8.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 https://download.pytorch.org/whl/cpu/torchvision-0.9.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 omegaconf>=2.1.0.dev24


### PR DESCRIPTION
installing dependencies in `docs/requirements.txt` gives the following error.
updated the git protocol from git+git to git+https

```
10:46:52 PM: Collecting git+git://github.com/facebookresearch/fvcore.git (from -r requirements.txt (line 18))
10:46:52 PM:   Cloning git://github.com/facebookresearch/fvcore.git to /tmp/pip-req-build-aiwe16rj
10:46:52 PM:   Running command git clone -q git://github.com/facebookresearch/fvcore.git /tmp/pip-req-build-aiwe16rj
10:46:52 PM:   fatal: remote error:
10:46:52 PM:     The unauthenticated git protocol on port 9418 is no longer supported.
10:46:52 PM:   Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```