### PR TITLE
Fix Caffe2 ONNX export

### DIFF
--- a/detectron2/export/caffe2_export.py
+++ b/detectron2/export/caffe2_export.py
@@ -14,6 +14,9 @@ from tabulate import tabulate
 from termcolor import colored
 from torch.onnx import OperatorExportTypes
 
+# ONNX does no ship onnx.optimizer since version 1.9+
+import onnxoptimizer
+
 from .shared import (
     ScopedWS,
     construct_init_net_from_params,
@@ -64,10 +67,10 @@ def export_onnx_model(model, inputs):
             onnx_model = onnx.load_from_string(f.getvalue())
 
     # Apply ONNX's Optimization
-    all_passes = onnx.optimizer.get_available_passes()
+    all_passes = onnxoptimizer.get_available_passes()
     passes = ["fuse_bn_into_conv"]
     assert all(p in all_passes for p in passes)
-    onnx_model = onnx.optimizer.optimize(onnx_model, passes)
+    onnx_model = onnxoptimizer.optimize(onnx_model, passes)
     return onnx_model
 
 

--- a/detectron2/export/caffe2_export.py
+++ b/detectron2/export/caffe2_export.py
@@ -14,9 +14,6 @@ from tabulate import tabulate
 from termcolor import colored
 from torch.onnx import OperatorExportTypes
 
-# ONNX does no ship onnx.optimizer since version 1.9+
-import onnxoptimizer
-
 from .shared import (
     ScopedWS,
     construct_init_net_from_params,
@@ -66,11 +63,6 @@ def export_onnx_model(model, inputs):
             )
             onnx_model = onnx.load_from_string(f.getvalue())
 
-    # Apply ONNX's Optimization
-    all_passes = onnxoptimizer.get_available_passes()
-    passes = ["fuse_bn_into_conv"]
-    assert all(p in all_passes for p in passes)
-    onnx_model = onnxoptimizer.optimize(onnx_model, passes)
     return onnx_model
 
 

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -90,7 +90,7 @@ and then export the model into Caffe2, TorchScript or ONNX format.
 The converted model is able to run in either Python or C++ without detectron2/torchvision dependency, on CPU or GPUs.
 It has a runtime optimized for CPU & mobile inference, but not optimized for GPU inference.
 
-This feature requires 1.9 > ONNX ≥ 1.6.
+This feature requires ONNX ≥ 1.6.
 
 ### Coverage
 

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 import torch
+from torch.hub import _check_module_exists
 
 from detectron2 import model_zoo
 from detectron2.export import Caffe2Model, Caffe2Tracer
@@ -16,6 +17,7 @@ from detectron2.utils.testing import get_sample_coco_image
 # TODO: this test requires manifold access, see: T88318502
 # Running it on CircleCI causes crash, not sure why.
 @unittest.skipIf(os.environ.get("CIRCLECI"), "Caffe2 tests crash on CircleCI.")
+@unittest.skipIf(not _check_module_exists("onnx"), "ONNX not installed.")
 class TestCaffe2Export(unittest.TestCase):
     def setUp(self):
         setup_logger()


### PR DESCRIPTION
This PR fixes the `Caffe2Tracer.export_caffe2` API for the latest pytorch repo

Before this PR, all tests at `tests/test_export_caffe2.py` were failing as the latest onnx does not have `onnx.optimizer` namespace anymore. Moreover, `fuse_bn_into_conv` optimization is already performed by `torch.onnx.export`

Depends on https://github.com/pytorch/pytorch/pull/75718
Fixes #3488
Fixes https://github.com/pytorch/pytorch/issues/69674 (PyTorch repo)