### PR TITLE
Add CUDA 11.3 + PyTorch 1.11.0 and 1.12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,22 +8,28 @@ cpu: &cpu
     image: ubuntu-2004:202107-02
   resource_class: medium
 
-gpu: &gpu
+cuda111: &cuda111
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
     image: ubuntu-1604-cuda-11.1:202012-01
   resource_class: gpu.nvidia.small
 
+cuda113: &cuda113
+  machine:
+    # NOTE: use a cuda version that supports PyTorch nightly builds
+    image: ubuntu-2004-cuda-11.4:202110-01
+  resource_class: gpu.nvidia.small
+
 windows-cpu: &windows_cpu
   machine:
-    resource_class: windows.medium
     image: windows-server-2019-vs2019:stable
-    shell: powershell.exe
+  resource_class: windows.medium
+  shell: powershell.exe
 
 # windows-gpu: &windows_gpu
 #     machine:
-#       resource_class: windows.gpu.nvidia.medium
 #       image: windows-server-2019-nvidia:stable
+#     resource_class: windows.gpu.nvidia.medium
 
 version_parameters: &version_parameters
   parameters:
@@ -36,7 +42,7 @@ version_parameters: &version_parameters
       # use test wheels index to have access to RC wheels
       # https://download.pytorch.org/whl/test/torch_test.html
       default: "https://download.pytorch.org/whl/torch_stable.html"
-    python_version:  # NOTE: only affect linux
+    python_version:  # NOTE: only affects linux
       type: string
       default: '3.8.6'
 
@@ -60,6 +66,37 @@ version_parameters: &version_parameters
 #         sudo /bin/bash ./NVIDIA-Linux-x86_64-430.40.run -s --no-drm
 #         nvidia-smi
 
+setupcuda113: &setupcuda113
+  run:
+    name: Setup CUDA 11.3
+    working_directory: ~/
+    command: |
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+      sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+      sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+      sudo apt-get update
+      sudo apt-get -y install cuda-11-3
+      sudo update-alternatives --install /usr/local/cuda cuda /usr/local/cuda-11.3 50
+      echo "Done installing CUDA 11.3"
+      sudo apt autoremove
+      sudo apt-get clean
+      nvidia-smi
+      sudo update-alternatives --display cuda
+
+removecuda114: &removecuda114
+  run:
+    name: Remove CUDA 11.4
+    working_directory: ~/
+    command: |
+      echo "Remove CUDA 11.4"
+      sudo update-alternatives --remove cuda /usr/local/cuda-11.4
+      sudo apt-get -y remove --purge cuda-11-4
+      sudo apt autoremove
+      sudo apt-get clean
+      echo "Done removing CUDA 11.4"
+      sudo update-alternatives --display cuda
+
 add_ssh_keys: &add_ssh_keys
   # https://circleci.com/docs/2.0/add-ssh-key/
   - add_ssh_keys:
@@ -71,8 +108,8 @@ install_python: &install_python
       name: Install Python
       working_directory: ~/
       command: |
-        # upgrade pyenv
-        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd
+        pyenv install -l
         pyenv install -s $PYTHON_VERSION
         pyenv global $PYTHON_VERSION
         python --version
@@ -115,15 +152,28 @@ install_linux_dep: &install_linux_dep
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
-        pip install --progress-bar off torch==$PYTORCH_VERSION -f $PYTORCH_INDEX
-        if [[ "$TORCHVISION_VERSION" == "master" ]]; then
-          pip install git+https://github.com/pytorch/vision.git
+        if [[ "$PYTORCH_VERSION" == "master" ]]; then
+          echo "Installing torch/torchvision from $PYTORCH_INDEX"
+          # Remove first, in case it's in the CI cache
+          pip uninstall -y torch torchvision
+          pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
         else
-          pip install --progress-bar off torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
+          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
         fi
 
+        python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+        python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
         python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+        echo "Python packages"
+        python -c "import sys; print(sys.executable)"
+        python --version
+        pip list
+        echo "GCC Compiler"
         gcc --version
+        echo "OS Environment Variables"
+        env
+
 
 install_detectron2: &install_detectron2
   - run:
@@ -170,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -182,11 +232,10 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
-
-  linux_gpu_tests:
-    <<: *gpu
+  linux_cuda111_tests:
+    <<: *cuda111
     <<: *version_parameters
 
     working_directory: ~/detectron2
@@ -196,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -208,7 +257,35 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
+  linux_cuda113_tests:
+    <<: *cuda113
+    <<: *version_parameters
+
+    working_directory: ~/detectron2
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
+      - <<: *setupcuda113
+      - <<: *removecuda114
+      - <<: *install_python
+      - <<: *install_linux_dep
+      - <<: *install_detectron2
+      - <<: *run_unittests
+      - <<: *uninstall_tests
+
+      - save_cache:
+          paths:
+            - /opt/circleci/.pyenv
+            - ~/.torch
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
 
   windows_cpu_build:
     <<: *windows_cpu
@@ -221,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - run:
           name: Install Dependencies
@@ -231,12 +308,28 @@ jobs:
             pip install opencv-python-headless pytest-xdist pycocotools tensorboard onnx
             pip install -U git+https://github.com/facebookresearch/iopath
             pip install -U git+https://github.com/facebookresearch/fvcore
-            pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            if($env:PYTORCH_VERSION -eq "master"){
+              Write-Output "Installing torch/torchvision from $env:PYTORCH_INDEX"
+              pip uninstall -y torch torchvision
+              pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
+            }else{
+              Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
+              pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            }
+            python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+            python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+            python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+            Write-Output "Python packages"
+            python -c "import sys; print(sys.executable)"
+            python --version
+            pip list
+            echo "OS Environment Variables"
+            dir env:
 
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -249,23 +342,42 @@ workflows:
           name: linux_cpu_tests_pytorch1.10
           pytorch_version: '1.10.0+cpu'
           torchvision_version: '0.11.1+cpu'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.8
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch_master
+          python_version: '3.9.4'
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.8
           pytorch_version: '1.8.1+cu111'
           torchvision_version: '0.9.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.9
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.9
           pytorch_version: '1.9+cu111'
           torchvision_version: '0.10+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.10
           pytorch_version: '1.10+cu111'
           torchvision_version: '0.11.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10_python39
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.10_python39
           pytorch_version: '1.10+cu111'
           torchvision_version: '0.11.1+cu111'
           python_version: '3.9.6'
+      - linux_cuda113_tests:
+          name: linux_cuda113_tests_pytorch_master_python39
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          python_version: '3.9.4'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cu113'
       - windows_cpu_build:
+          name: windows_cpu_build_pytorch1.10
           pytorch_version: '1.10+cpu'
           torchvision_version: '0.11.1+cpu'
+      - windows_cpu_build:
+          name: windows_cpu_build_pytorch_master
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          python_version: '3.7.3'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -234,7 +234,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -247,7 +247,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -259,7 +259,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
   linux_cuda113_tests:
     <<: *cuda114
@@ -272,7 +272,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -286,7 +286,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
 
   windows_cpu_build:
@@ -300,7 +300,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
       - run:
           name: Install Dependencies
@@ -331,7 +331,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990009
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -232,7 +232,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -245,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -257,7 +257,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
   linux_cuda113_tests:
     <<: *cuda113
@@ -270,7 +270,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -284,7 +284,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
 
   windows_cpu_build:
@@ -298,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
       - run:
           name: Install Dependencies
@@ -314,7 +314,7 @@ jobs:
               pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
             }else{
               Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
-              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION --extra-index-url $env:PYTORCH_INDEX
             }
             python -c 'import torch; print("PyTorch Version:", torch.__version__)'
             python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
@@ -329,7 +329,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -229,7 +229,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -242,7 +242,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -254,7 +254,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
   linux_cuda113_tests:
     <<: *cuda114
@@ -267,7 +267,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -281,7 +281,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
 
   windows_cpu_build:
@@ -295,7 +295,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
       - run:
           name: Install Dependencies
@@ -326,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ install_linux_dep: &install_linux_dep
           # Remove first, in case it's in the CI cache
           pip uninstall -y torch torchvision
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+          pip install -v --progress-bar off omegaconf==2.1.2   # needed by FCOSE2ETest::test_empty_data
         else
           echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
           pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
               pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
             }else{
               Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
-              pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
             }
             python -c 'import torch; print("PyTorch Version:", torch.__version__)'
             python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,15 +151,15 @@ install_linux_dep: &install_linux_dep
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
+        pip install -v --progress-bar off omegaconf
         if [[ "${PYTORCH_VERSION}" == "master" ]]; then
           echo "Installing torch/torchvision from ${PYTORCH_INDEX}"
           # Remove first, in case it's in the CI cache
           pip uninstall -y torch torchvision
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url ${PYTORCH_INDEX}
-          pip install -v --progress-bar off omegaconf
         else
           echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX}"
-          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f ${PYTORCH_INDEX}
+          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} --extra-index-url ${PYTORCH_INDEX}
         fi
 
         python -c 'import torch; print("PyTorch Version:", torch.__version__)'
@@ -217,7 +217,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -229,7 +229,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -242,7 +242,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -254,7 +254,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
   linux_cuda113_tests:
     <<: *cuda114
@@ -267,7 +267,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -281,7 +281,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
 
   windows_cpu_build:
@@ -295,7 +295,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
       - run:
           name: Install Dependencies
@@ -326,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990006
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ cuda111: &cuda111
     image: ubuntu-1604-cuda-11.1:202012-01
   resource_class: gpu.nvidia.small
 
-cuda113: &cuda113
+cuda114: &cuda114
   machine:
     image: ubuntu-2004-cuda-11.4:202110-01
   resource_class: gpu.nvidia.small
@@ -159,7 +159,7 @@ install_linux_dep: &install_linux_dep
           pip install -v --progress-bar off omegaconf
         else
           echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX}"
-          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} --extra-index-url ${PYTORCH_INDEX}
+          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f ${PYTORCH_INDEX}
         fi
 
         python -c 'import torch; print("PyTorch Version:", torch.__version__)'
@@ -171,9 +171,6 @@ install_linux_dep: &install_linux_dep
         pip list
         echo "GCC Compiler"
         gcc --version
-        echo "OS Environment Variables"
-        env
-
 
 install_detectron2: &install_detectron2
   - run:
@@ -220,7 +217,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -232,7 +229,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -245,7 +242,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -257,10 +254,10 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
   linux_cuda113_tests:
-    <<: *cuda113
+    <<: *cuda114
     <<: *version_parameters
 
     working_directory: ~/detectron2
@@ -270,7 +267,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -284,7 +281,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
 
   windows_cpu_build:
@@ -298,7 +295,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
       - run:
           name: Install Dependencies
@@ -329,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990005
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,8 +158,13 @@ install_linux_dep: &install_linux_dep
           pip uninstall -y torch torchvision
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url ${PYTORCH_INDEX}
         else
-          echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX}"
-          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f ${PYTORCH_INDEX}
+          LABEL_VERSION=$(echo "${PYTORCH_VERSION}" | cut -d "+" -f 2 -s)
+          echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX} and label version ${LABEL_VERSION}"
+          if [[ "${LABEL_VERSION}" == "cu113" ]]; then
+            pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} --extra-index-url ${PYTORCH_INDEX}
+          else
+            pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f ${PYTORCH_INDEX}
+          fi
         fi
 
         python -c 'import torch; print("PyTorch Version:", torch.__version__)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,8 @@ install_python: &install_python
       command: |
         cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd
         pyenv install -l
-        pyenv install -s $PYTHON_VERSION
-        pyenv global $PYTHON_VERSION
+        pyenv install -s ${PYTHON_VERSION}
+        pyenv global ${PYTHON_VERSION}
         python --version
         which python
         pip install --upgrade pip
@@ -121,7 +121,7 @@ setup_venv: &setup_venv
       working_directory: ~/
       command: |
         python -m venv ~/venv
-        echo ". ~/venv/bin/activate" >> $BASH_ENV
+        echo ". ~/venv/bin/activate" >> ${BASH_ENV}
         . ~/venv/bin/activate
         python --version
         which python
@@ -151,15 +151,15 @@ install_linux_dep: &install_linux_dep
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
-        if [[ "$PYTORCH_VERSION" == "master" ]]; then
-          echo "Installing torch/torchvision from $PYTORCH_INDEX"
+        if [[ "${PYTORCH_VERSION}" == "master" ]]; then
+          echo "Installing torch/torchvision from ${PYTORCH_INDEX}"
           # Remove first, in case it's in the CI cache
           pip uninstall -y torch torchvision
-          pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+          pip install -v --progress-bar off --pre torch torchvision --extra-index-url ${PYTORCH_INDEX}
           pip install -v --progress-bar off omegaconf
         else
-          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
-          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+          echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX}"
+          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} --extra-index-url ${PYTORCH_INDEX}
         fi
 
         python -c 'import torch; print("PyTorch Version:", torch.__version__)'
@@ -314,7 +314,7 @@ jobs:
               pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
             }else{
               Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
-              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION --index-url $env:PYTORCH_INDEX
+              pip install --progress-bar off torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
             }
             python -c 'import torch; print("PyTorch Version:", torch.__version__)'
             python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
@@ -373,14 +373,14 @@ workflows:
           python_version: '3.9.6'
       - linux_cuda113_tests:
           name: linux_cuda113_tests_pytorch1.11_python39
-          pytorch_version: '1.11.0'
-          torchvision_version: '0.12.0'
+          pytorch_version: '1.11.0+cu113'
+          torchvision_version: '0.12.0+cu113'
           python_version: '3.9.4'
           pytorch_index: 'https://download.pytorch.org/whl/cu113'
       - linux_cuda113_tests:
           name: linux_cuda113_tests_pytorch1.12_python39
-          pytorch_version: '1.12.1'
-          torchvision_version: '0.13.1'
+          pytorch_version: '1.12.1+cu113'
+          torchvision_version: '0.13.1+cu113'
           python_version: '3.9.4'
           pytorch_index: 'https://download.pytorch.org/whl/cu113'
       - windows_cpu_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -232,7 +232,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -245,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -257,7 +257,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
   linux_cuda113_tests:
     <<: *cuda113
@@ -270,7 +270,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -284,7 +284,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
 
   windows_cpu_build:
@@ -298,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
       - run:
           name: Install Dependencies
@@ -329,7 +329,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -373,14 +373,14 @@ workflows:
           python_version: '3.9.6'
       - linux_cuda113_tests:
           name: linux_cuda113_tests_pytorch1.11_python39
-          pytorch_version: '1.11.0+cu113'
-          torchvision_version: '0.12.0+cu113'
+          pytorch_version: '1.11.0'
+          torchvision_version: '0.12.0'
           python_version: '3.9.4'
           pytorch_index: 'https://download.pytorch.org/whl/cu113'
       - linux_cuda113_tests:
           name: linux_cuda113_tests_pytorch1.12_python39
-          pytorch_version: '1.12.1+cu113'
-          torchvision_version: '0.13.1+cu113'
+          pytorch_version: '1.12.1'
+          torchvision_version: '0.13.1'
           python_version: '3.9.4'
           pytorch_index: 'https://download.pytorch.org/whl/cu113'
       - windows_cpu_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -232,7 +232,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -245,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -257,7 +257,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
   linux_cuda113_tests:
     <<: *cuda113
@@ -270,7 +270,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -284,7 +284,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
 
   windows_cpu_build:
@@ -298,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
       - run:
           name: Install Dependencies
@@ -329,7 +329,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990001
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990002
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
               pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
             }else{
               Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
-              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION --extra-index-url $env:PYTORCH_INDEX
+              pip install --progress-bar off --pre torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION --index-url $env:PYTORCH_INDEX
             }
             python -c 'import torch; print("PyTorch Version:", torch.__version__)'
             python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ install_linux_dep: &install_linux_dep
           # Remove first, in case it's in the CI cache
           pip uninstall -y torch torchvision
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
-          pip install -v --progress-bar off omegaconf==2.1.2   # needed by FCOSE2ETest::test_empty_data
+          pip install -v --progress-bar off omegaconf
         else
           echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
           pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ install_linux_dep: &install_linux_dep
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url ${PYTORCH_INDEX}
         else
           echo "Installing torch==${PYTORCH_VERSION} and torchvision==${TORCHVISION_VERSION} from ${PYTORCH_INDEX}"
-          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} --extra-index-url ${PYTORCH_INDEX}
+          pip install -v --progress-bar off torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} -f ${PYTORCH_INDEX}
         fi
 
         python -c 'import torch; print("PyTorch Version:", torch.__version__)'
@@ -217,7 +217,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -229,7 +229,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -242,7 +242,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -254,7 +254,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
   linux_cuda113_tests:
     <<: *cuda114
@@ -267,7 +267,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -281,7 +281,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
 
   windows_cpu_build:
@@ -295,7 +295,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
       - run:
           name: Install Dependencies
@@ -326,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990007
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990008
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -232,7 +232,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -245,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -257,7 +257,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
   linux_cuda113_tests:
     <<: *cuda113
@@ -270,7 +270,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -284,7 +284,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
 
   windows_cpu_build:
@@ -298,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
       - run:
           name: Install Dependencies
@@ -329,7 +329,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990003
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20990004
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -364,11 +364,11 @@ workflows:
           torchvision_version: '0.10+cu111'
       - linux_cuda111_tests:
           name: linux_cuda111_tests_pytorch1.10
-          pytorch_version: '1.10+cu111'
+          pytorch_version: '1.10.0+cu111'
           torchvision_version: '0.11.1+cu111'
       - linux_cuda111_tests:
           name: linux_cuda111_tests_pytorch1.10_python39
-          pytorch_version: '1.10+cu111'
+          pytorch_version: '1.10.0+cu111'
           torchvision_version: '0.11.1+cu111'
           python_version: '3.9.6'
       - linux_cuda113_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ cuda111: &cuda111
 
 cuda113: &cuda113
   machine:
-    # NOTE: use a cuda version that supports PyTorch nightly builds
     image: ubuntu-2004-cuda-11.4:202110-01
   resource_class: gpu.nvidia.small
 
@@ -221,7 +220,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -233,7 +232,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
   linux_cuda111_tests:
     <<: *cuda111
@@ -246,7 +245,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -258,7 +257,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
   linux_cuda113_tests:
     <<: *cuda113
@@ -271,7 +270,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
       - <<: *setupcuda113
       - <<: *removecuda114
@@ -285,7 +284,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
 
   windows_cpu_build:
@@ -299,7 +298,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
       - run:
           name: Install Dependencies
@@ -330,7 +329,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -344,11 +343,17 @@ workflows:
           pytorch_version: '1.10.0+cpu'
           torchvision_version: '0.11.1+cpu'
       - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch_master
+          name: linux_cpu_tests_pytorch1.11
           python_version: '3.9.4'
-          pytorch_version: 'master'
-          torchvision_version: 'master'
-          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'
+          pytorch_version: '1.11.0'
+          torchvision_version: '0.12.0'
+          pytorch_index: 'https://download.pytorch.org/whl/cpu'
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch1.12
+          python_version: '3.9.4'
+          pytorch_version: '1.12.1'
+          torchvision_version: '0.13.1'
+          pytorch_index: 'https://download.pytorch.org/whl/cpu'
       - linux_cuda111_tests:
           name: linux_cuda111_tests_pytorch1.8
           pytorch_version: '1.8.1+cu111'
@@ -367,18 +372,30 @@ workflows:
           torchvision_version: '0.11.1+cu111'
           python_version: '3.9.6'
       - linux_cuda113_tests:
-          name: linux_cuda113_tests_pytorch_master_python39
-          pytorch_version: 'master'
-          torchvision_version: 'master'
+          name: linux_cuda113_tests_pytorch1.11_python39
+          pytorch_version: '1.11.0+cu113'
+          torchvision_version: '0.12.0+cu113'
           python_version: '3.9.4'
-          pytorch_index: 'https://download.pytorch.org/whl/nightly/cu113'
+          pytorch_index: 'https://download.pytorch.org/whl/cu113'
+      - linux_cuda113_tests:
+          name: linux_cuda113_tests_pytorch1.12_python39
+          pytorch_version: '1.12.1+cu113'
+          torchvision_version: '0.13.1+cu113'
+          python_version: '3.9.4'
+          pytorch_index: 'https://download.pytorch.org/whl/cu113'
       - windows_cpu_build:
           name: windows_cpu_build_pytorch1.10
           pytorch_version: '1.10+cpu'
           torchvision_version: '0.11.1+cpu'
       - windows_cpu_build:
-          name: windows_cpu_build_pytorch_master
-          pytorch_version: 'master'
-          torchvision_version: 'master'
+          name: windows_cpu_build_pytorch_1.11
+          pytorch_version: '1.11.0+cpu'
+          torchvision_version: '0.12.0+cpu'
           python_version: '3.7.3'
-          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'
+          pytorch_index: 'https://download.pytorch.org/whl/cpu'
+      - windows_cpu_build:
+          name: windows_cpu_build_pytorch_1.12
+          pytorch_version: '1.12.1+cpu'
+          torchvision_version: '0.13.1+cpu'
+          python_version: '3.7.3'
+          pytorch_index: 'https://download.pytorch.org/whl/cpu'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ["1.8", "1.9", "1.10"]
+        torch: ["1.8", "1.9", "1.10", "master"]
         include:
           - torch: "1.8"
             torchvision: 0.9
@@ -45,6 +45,9 @@ jobs:
             torchvision: "0.10"
           - torch: "1.10"
             torchvision: "0.11.1"
+          - torch: "master"
+            torchvision: "master"
+            pytorch_index: "https://download.pytorch.org/whl/nightly/cpu"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets
@@ -61,16 +64,36 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220119
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220503
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           python -m pip install ninja opencv-python-headless onnx pytest-xdist
-          python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+          if [[ "${{matrix.torch}}" == "master" ]]; then
+            echo "Installing torch/torchvision from ${{pytorch_index}}"
+            # Remove first, in case it's in the CI cache
+            pip uninstall -y torch torchvision
+            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{pytorch_index}}
+          else
+            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}} from ${{pytorch_index}}"
+            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f ${{pytorch_index}}
+          fi
+
           # install from github to get latest; install iopath first since fvcore depends on it
           python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
           python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+
+          python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+          python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+          python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+          echo "Python packages"
+          pip list
+          echo "GCC Compiler"
+          gcc --version
+          echo "Environment Variables"
+          env
+
 
       - name: Build and install
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990007
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990008
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,13 +71,13 @@ jobs:
           python -m pip install -U pip
           python -m pip install ninja opencv-python-headless onnx pytest-xdist
           if [[ "${{matrix.torch}}" == "master" ]]; then
-            echo "Installing torch/torchvision from ${{pytorch_index}}"
+            echo "Installing torch/torchvision from ${{matrix.pytorch_index}}"
             # Remove first, in case it's in the CI cache
             pip uninstall -y torch torchvision
-            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{pytorch_index}}
+            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{matrix.pytorch_index}}
           else
-            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}} from ${{pytorch_index}}"
-            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f ${{pytorch_index}}
+            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}}"
+            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}}
           fi
 
           # install from github to get latest; install iopath first since fvcore depends on it

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,17 +37,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ["1.8", "1.9", "1.10", "master"]
+        torch: ["1.8", "1.9", "1.10", "1.11.0", "1.12.1"]
         include:
           - torch: "1.8"
-            torchvision: 0.9
+            torchvision: "0.9"
           - torch: "1.9"
             torchvision: "0.10"
           - torch: "1.10"
             torchvision: "0.11.1"
-          - torch: "master"
-            torchvision: "master"
-            pytorch_index: "https://download.pytorch.org/whl/nightly/cpu"
+          - torch: "1.11.0"
+            torchvision: "0.12.0"
+          - torch: "1.12.1"
+            torchvision: "0.13.1"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets
@@ -64,7 +65,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220503
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230227
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990008
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990009
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230227
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990001
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990001
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20990007
 
       - name: Install dependencies
         run: |

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -11,7 +11,6 @@ import torch.onnx.symbolic_helper as sym_help
 from packaging import version
 from torch._C import ListType
 from torch.onnx import register_custom_op_symbolic
-import unittest
 
 from detectron2 import model_zoo
 from detectron2.config import CfgNode, LazyConfig, instantiate

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -181,6 +181,20 @@ def min_torch_version(min_version: str) -> bool:
     return installed_version >= min_version
 
 
+def max_torch_version(max_version: str) -> bool:
+    """
+    Returns True when torch's  version is at most `max_version`.
+    """
+    try:
+        import torch
+    except ImportError:
+        return False
+
+    installed_version = version.parse(torch.__version__.split("+")[0])
+    max_version = version.parse(max_version)
+    return installed_version <= max_version
+
+
 def has_dynamic_axes(onnx_model):
     """
     Return True when all ONNX input/output have only dynamic axes for all ranks
@@ -309,6 +323,14 @@ def skipIfUnsupportedMinTorchVersion(min_version):
     """
     reason = f"module 'torch' has __version__ {torch.__version__}" f", required is: {min_version}"
     return unittest.skipIf(not min_torch_version(min_version), reason)
+
+
+def skipIfUnsupportedMaxTorchVersion(max_version):
+    """
+    Skips tests for PyTorch versions newer than max_version.
+    """
+    reason = f"module 'torch' has __version__ {torch.__version__}" f", required is: {max_version}"
+    return unittest.skipIf(not max_torch_version(max_version), reason)
 
 
 # TODO: Remove after PyTorch 1.11.1+ is used by detectron2's CI

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -11,6 +11,7 @@ import torch.onnx.symbolic_helper as sym_help
 from packaging import version
 from torch._C import ListType
 from torch.onnx import register_custom_op_symbolic
+import unittest
 
 from detectron2 import model_zoo
 from detectron2.config import CfgNode, LazyConfig, instantiate
@@ -20,10 +21,15 @@ from detectron2.modeling import build_model
 from detectron2.structures import Boxes, Instances, ROIMasks
 from detectron2.utils.file_io import PathManager
 
-
 """
 Internal utilities for tests. Don't use except for writing tests.
 """
+
+
+skip_on_torch_nightly = unittest.skipIf(
+    ".dev" in torch.__version__ or "+git" in torch.__version__,
+    f"The test cannot run on pyTorch nightly releases ({torch.__version__}).",
+)
 
 
 def get_model_no_weights(config_path):

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -21,6 +21,7 @@ except ImportError:
         f"PyTorch does not have Caffe2 support. Skipping all tests in {__name__}"
     ) from None
 
+
 # TODO: this test requires manifold access, see: T88318502
 # Running it on CircleCI causes crash, not sure why.
 @unittest.skipIf(os.environ.get("CIRCLECI"), "Caffe2 tests crash on CircleCI.")

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -21,7 +21,6 @@ except ImportError:
         f"PyTorch does not have Caffe2 support. Skipping all tests in {__name__}"
     ) from None
 
-
 # TODO: this test requires manifold access, see: T88318502
 # Running it on CircleCI causes crash, not sure why.
 @unittest.skipIf(os.environ.get("CIRCLECI"), "Caffe2 tests crash on CircleCI.")

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -28,8 +28,8 @@ from detectron2.utils.testing import (
     convert_scripted_instances,
     get_sample_coco_image,
     random_boxes,
-    skipIfOnCPUCI,
     skip_on_torch_nightly,
+    skipIfOnCPUCI,
 )
 
 

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -30,6 +30,7 @@ from detectron2.utils.testing import (
     random_boxes,
     skip_on_torch_nightly,
     skipIfOnCPUCI,
+    skipIfUnsupportedMaxTorchVersion,
 )
 
 
@@ -45,6 +46,7 @@ class TestScripting(unittest.TestCase):
 
     @skipIfOnCPUCI
     @skip_on_torch_nightly
+    @skipIfUnsupportedMaxTorchVersion("1.11.0")  # TODO: Minor numerical discrepancy on 1.12.0
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -29,6 +29,7 @@ from detectron2.utils.testing import (
     get_sample_coco_image,
     random_boxes,
     skipIfOnCPUCI,
+    skip_on_torch_nightly,
 )
 
 
@@ -43,6 +44,7 @@ class TestScripting(unittest.TestCase):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")
 
     @skipIfOnCPUCI
+    @skip_on_torch_nightly
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 


### PR DESCRIPTION
Currently CI supports only CUDA 11.1, which is sufficient for PyTorch versions up to 1.10.
For PyTorch 1.11+ and nightly builds, the minimum CUDA version is 11.3.

This PR adds 3 new pipelines:
* Linux CUDA 11.3 which installs PyTorch, TorchVision, Detectron2 nightly builds.
* Linux CUDA 11.3 which installs PyTorch 1.11 and 1.12 stable release with matching TorchVision and Detectron2 builds.
* Linux CPU which installs PyTorch, TorchVision, Detectron2 nightly builds.
* Windows CPU which install PyTorch, TorchVision, Detectron2 nightly builds.

The new pipelines are important to test end-to-end ONNX export tests, in which PyTorch inference results are numerically compared with the ONNX Runtime's . A second benefit is help identifying ONNX export issues earlier in the development cycle.

ps: Nightly builds are only installed in the new pipelines (aka `windows_cpu_build_pytorch_master`, `linux_cuda113_tests_pytorch_master_python39`, `linux_cpu_tests_pytorch_master`. All existing pipelines are intact.