### PR TITLE
Enable torch tracing by changing assertions in d2go forwards to allow for torch.fx.proxy.Proxy type.

### DIFF
--- a/detectron2/layers/__init__.py
+++ b/detectron2/layers/__init__.py
@@ -18,6 +18,7 @@ from .wrappers import (
     empty_input_loss_func_wrapper,
     shapes_to_tensor,
     move_device_like,
+    assert_fx_safe,
 )
 from .blocks import CNNBlockBase, DepthwiseSeparableConv2d
 from .aspp import ASPP

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -11,6 +11,7 @@ is implemented
 import warnings
 from typing import List, Optional
 import torch
+from torch.fx._symbolic_trace import is_fx_tracing
 from torch.nn import functional as F
 
 
@@ -146,3 +147,19 @@ def move_device_like(src: torch.Tensor, dst: torch.Tensor) -> torch.Tensor:
     as constant during tracing, scripting the casting process as whole can workaround this issue.
     """
     return src.to(dst.device)
+
+
+# @torch.jit.ignore
+# # Function type annotation intentionally missing `fx.proxy.Proxy` in the Union,
+# # since that type can't be understood by the Torch JIT script engine.
+# def is_fx_tracing() -> bool:
+#     """Returns True if FX tracing is underway, which can mean that types
+#     encountered can be masked inside an fx.proxy.Proxy object"""
+#     return is_tracing()
+
+
+@torch.jit.ignore
+# Build a FX-tracing safe version of assert
+def assert_fx_safe(condition: bool, message: str):
+    if not is_fx_tracing():
+        assert condition, message


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/d2go/pull/241

Torch FX tracing propagates a type of `torch.fx.proxy.Proxy` through the graph.

Existing type assertions in the d2go code base trigger during torch FX tracing, causing tracing to fail.

This diff adds a helper function `is_fx_proxy()`, for checking for `torch.fx.proxy.Proxy` instances, then uses this to guard the existing assertions, thus enabling the tracing, as well as maintaining the originally intended functionality.

Differential Revision: D35518556

