### PR TITLE
support postprocess on the output of scripted models

### DIFF
--- a/detectron2/modeling/postprocessing.py
+++ b/detectron2/modeling/postprocessing.py
@@ -2,7 +2,7 @@
 import torch
 from torch.nn import functional as F
 
-from detectron2.structures import Instances, ROIMasks
+from detectron2.structures import Boxes, Instances, ROIMasks
 
 
 # perhaps should rename to "resize_instance"
@@ -44,6 +44,11 @@ def detector_postprocess(
         output_height_tmp / results.image_size[0],
     )
     results = Instances(new_size, **results.get_fields())
+    # .get_fields() returns Tensor, need to cast it back to Boxes.
+    if results.has("pred_boxes") and isinstance(results.pred_boxes, torch.Tensor):
+        results.pred_boxes = Boxes(results.pred_boxes)
+    if results.has("proposal_boxes") and isinstance(results.proposal_boxes, torch.Tensor):
+        results.proposal_boxes = Boxes(results.proposal_boxes)
 
     if results.has("pred_boxes"):
         output_boxes = results.pred_boxes

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -74,6 +74,9 @@ class TestScripting(unittest.TestCase):
             instance = model.inference(inputs, do_postprocess=False)[0]
             scripted_instance = script_model.inference(inputs, do_postprocess=False)[0]
         assert_instances_allclose(instance, scripted_instance)
+        instance = detector_postprocess(instance, image.shape[1], image.shape[2])
+        scripted_instance = detector_postprocess(scripted_instance, image.shape[1], image.shape[2])
+        assert_instances_allclose(instance, scripted_instance)
 
     def _test_retinanet_model(self, config_path):
         model = model_zoo.get(config_path, trained=True)


### PR DESCRIPTION
Summary:
The `get_fields()` in the `ScriptedInstances` will convert `Boxes` to the Tensor,
https://github.com/facebookresearch/detectron2/blob/main/detectron2/export/torchscript_patch.py#L270-L271. This will cause issue when we call `detector_postprocess` on the output of scripted model.

Differential Revision: D36336655

