### PR TITLE
add pyproject.toml to enable pep517 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ install_detectron2: &install_detectron2
         # Remove first, in case it's in the CI cache
         pip uninstall -y detectron2
 
-        pip install --progress-bar off -e .[all]
+        pip install --no-build-isolation --progress-bar off -e .[all]
         python -m detectron2.utils.collect_env
         ./datasets/prepare_for_tests.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "torch"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
This change ensures that the package supports [PEP 517](https://peps.python.org/pep-0517/). The lack of this support was originally raised in #2644.

Without this change, any build system that relies on PEP 517 will fail.

<details>
<summary><b>Without this fix</b></summary>
<p>

```console
root@9a48205e7209:/# pip install --no-deps --use-pep517 git+https://github.com/facebookresearch/detectron2.git
Collecting git+https://github.com/facebookresearch/detectron2.git
  Cloning https://github.com/facebookresearch/detectron2.git to /tmp/pip-req-build-qjru1x0c
  Running command git clone -q https://github.com/facebookresearch/detectron2.git /tmp/pip-req-build-qjru1x0c
  Resolved https://github.com/facebookresearch/detectron2.git to commit 42c44b622eb7b179576bdac218c84c107fff8eab
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmp6071tx0g
       cwd: /tmp/pip-req-build-qjru1x0c
  Complete output (18 lines):
  Traceback (most recent call last):
    File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
      main()
    File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 117, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/tmp/pip-build-env-34h5ufq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 177, in get_requires_for_build_wheel
      return self._get_build_requires(
    File "/tmp/pip-build-env-34h5ufq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 159, in _get_build_requires
      self.run_setup()
    File "/tmp/pip-build-env-34h5ufq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 281, in run_setup
      super(_BuildMetaLegacyBackend,
    File "/tmp/pip-build-env-34h5ufq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 174, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 10, in <module>
      import torch
  ModuleNotFoundError: No module named 'torch'
  ----------------------------------------
WARNING: Discarding git+https://github.com/facebookresearch/detectron2.git. Command errored out with exit status 1: /usr/local/bin/python /usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmp6071tx0g Check the logs for full command output.
ERROR: Command errored out with exit status 1: /usr/local/bin/python /usr/local/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmp6071tx0g Check the logs for full command output.
WARNING: You are using pip version 21.2.4; however, version 22.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```

</p>
</details>

<details>
<summary><b>After this fix</b></summary>
<p>

```console
root@9a48205e7209:/# pip install --no-deps --use-pep517 git+https://github.com/abn/detectron2.git@pep517
Collecting git+https://github.com/abn/detectron2.git@pep517
  Cloning https://github.com/abn/detectron2.git (to revision pep517) to /tmp/pip-req-build-17xowvfd
  Running command git clone -q https://github.com/abn/detectron2.git /tmp/pip-req-build-17xowvfd
  Running command git checkout -b pep517 --track origin/pep517
  Switched to a new branch 'pep517'
  Branch 'pep517' set up to track remote branch 'pep517' from 'origin'.
  Resolved https://github.com/abn/detectron2.git to commit 729f16284adab8ab6ecc2d8c7e6682a28746b7f5
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: detectron2
  Building wheel for detectron2 (PEP 517) ... done
  Created wheel for detectron2: filename=detectron2-0.6-cp310-cp310-linux_x86_64.whl size=5650000 sha256=3d75165986d210457375a8fa1149bad84c64a2c7448fd169accc5d490a85a125
  Stored in directory: /tmp/pip-ephem-wheel-cache-1gxvwuei/wheels/25/de/67/85e415cdf6fc04be2a62f03dea61a2b292f8e2d186e84914a2
Successfully built detectron2
Installing collected packages: detectron2
Successfully installed detectron2-0.6
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
WARNING: You are using pip version 21.2.4; however, version 22.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
```

</p>
</details>
