### PR TITLE
torchscript_mask_rcnn.cpp: fix compilation error

### DIFF
--- a/tools/deploy/torchscript_mask_rcnn.cpp
+++ b/tools/deploy/torchscript_mask_rcnn.cpp
@@ -135,7 +135,8 @@ Usage:
       export_method == "caffe2_tracing" || export_method == "tracing" ||
       export_method == "scripting");
 
-  torch::jit::getBailoutDepth() = 1;
+  torch::jit::FusionStrategy strat = {{torch::jit::FusionBehavior::DYNAMIC, 1}};
+  torch::jit::setFusionStrategy(strat);
   torch::autograd::AutoGradMode guard(false);
   auto module = torch::jit::load(argv[1]);
 


### PR DESCRIPTION
Summary: The API changed on this line to return an rvalue instead of an lvalue (atomic<int>& -> size_t) from D33801501. I've followed that diff to what seems to be the new API.

Reviewed By: ebyrne

Differential Revision: D36394835

