### PR TITLE
Add assertion error if model not c2 compatible

### DIFF
--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -1,10 +1,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
+from typing import Dict
+
 import torch
 import torch.nn.functional as F
 
-from detectron2.layers import cat
+from detectron2.layers import ShapeSpec, cat
 from detectron2.layers.roi_align_rotated import ROIAlignRotated
 from detectron2.modeling import poolers
 from detectron2.modeling.proposal_generator import rpn
@@ -162,6 +164,14 @@ class Caffe2Compatible(object):
 
 
 class Caffe2RPN(Caffe2Compatible, rpn.RPN):
+
+    @classmethod
+    def from_config(cls, cfg, input_shape: Dict[str, ShapeSpec]):
+        ret = super(Caffe2Compatible, cls).from_config(cfg, input_shape)
+        assert tuple(cfg.MODEL.RPN.BBOX_REG_WEIGHTS) == (1., 1., 1., 1.) or \
+            tuple(cfg.MODEL.RPN.BBOX_REG_WEIGHTS) == (1., 1., 1., 1., 1.)
+        return ret
+
     def _generate_proposals(
         self, images, objectness_logits_pred, anchor_deltas_pred, gt_instances=None
     ):

--- a/tests/export/test_c10.py
+++ b/tests/export/test_c10.py
@@ -1,0 +1,18 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+import unittest
+from detectron2.config import get_cfg
+from detectron2.export.c10 import Caffe2RPN
+from detectron2.layers import ShapeSpec
+
+
+class TestCaffe2RPN(unittest.TestCase):
+
+    def test_instantiation(self):
+        cfg = get_cfg()
+        cfg.MODEL.RPN.BBOX_REG_WEIGHTS = (1, 1, 1, 1, 1)
+        input_shapes = {'res4': ShapeSpec(channels=256, stride=4)}
+        rpn = Caffe2RPN(cfg, input_shapes)
+        assert rpn is not None
+        cfg.MODEL.RPN.BBOX_REG_WEIGHTS = (10, 10, 5, 5, 1)
+        with self.assertRaises(AssertionError):
+            rpn = Caffe2RPN(cfg, input_shapes)


### PR DESCRIPTION
Summary: The caffe 2 model exported was not handling MODEL.RPN.BBOX_REG_WEIGHTS) different of (1., 1., 1., 1.) or (1., 1., 1., 1., 1.) correctly because the config is not passed to caffe2 generate_proposals config. Modifying it won't slove the issue as there will be an api change customers like boltnn will have to manage. This fix is to fail during caffe2 export for non supported config to avoid non regression behavior troubleshooting

Reviewed By: sstsai-adl

Differential Revision: D36489096

