### PR TITLE
fix rotated bounding box tracing inference error

### DIFF
--- a/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/rotated_fast_rcnn.py
@@ -80,6 +80,7 @@ def fast_rcnn_inference_rotated(
     return [x[0] for x in result_per_image], [x[1] for x in result_per_image]
 
 
+@torch.no_grad()
 def fast_rcnn_inference_single_image_rotated(
     boxes, scores, image_shape, score_thresh, nms_thresh, topk_per_image
 ):

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(
         "future",  # used by caffe2
         "pydot",  # used to save caffe2 SVGs
         "dataclasses; python_version<'3.7'",
-        "omegaconf>=2.1",
+        "omegaconf>=2.1,<=2.2.0",
         "hydra-core>=1.1",
         "black==21.4b2",
         "scipy>1.5.1",


### PR DESCRIPTION
Summary:
Fixes run time error:
RuntimeError: Output 0 of SelectBackward0 is a view and is being modified inplace. This view is the output of a function that returns multiple views. Such functions do not allow the output views to be modified inplace. You should replace the inplace operation by an out-of-place one.

Differential Revision: D36433376

