### PR TITLE
Add empty input handler loss func wrapper

### DIFF
--- a/detectron2/layers/__init__.py
+++ b/detectron2/layers/__init__.py
@@ -15,6 +15,7 @@ from .wrappers import (
     Linear,
     nonzero_tuple,
     cross_entropy,
+    empty_input_loss_func_wrapper,
     shapes_to_tensor,
     move_device_like,
 )

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -45,14 +45,19 @@ def cat(tensors: List[torch.Tensor], dim: int = 0):
     return torch.cat(tensors, dim)
 
 
-def cross_entropy(input, target, *, reduction="mean", **kwargs):
-    """
-    Same as `torch.nn.functional.cross_entropy`, but returns 0 (instead of nan)
-    for empty inputs.
-    """
-    if target.numel() == 0 and reduction == "mean":
-        return input.sum() * 0.0  # connect the gradient
-    return F.cross_entropy(input, target, reduction=reduction, **kwargs)
+def empty_input_loss_func_wrapper(loss_func):
+    def wrapped_loss_func(input, target, *, reduction="mean", **kwargs):
+        """
+        Same as `loss_func`, but returns 0 (instead of nan) for empty inputs.
+        """
+        if target.numel() == 0 and reduction == "mean":
+            return input.sum() * 0.0  # connect the gradient
+        return loss_func(input, target, reduction=reduction, **kwargs)
+
+    return wrapped_loss_func
+
+
+cross_entropy = empty_input_loss_func_wrapper(F.cross_entropy)
 
 
 class _NewEmptyTensorOp(torch.autograd.Function):


### PR DESCRIPTION
Summary:
In detectron 2, there are some wrappers created around commonly used loss funcs, like cross_entropy, to handle empty inputs and prevent a NaN output.

There are a few other loss funcs that may be useful to have in custom D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f)Go model development that aren't included here, such as mse_loss. In keeping things consistent, it would be nice to have the same wrapper logic for these other loss funcs ad hoc. Rather than having them included in Detectron 2, where it might not be relevant, we expose the wrapper function separately while maintaining the same functionalities that Detectron 2 has currently.

Differential Revision: D36902118

