### PR TITLE
Add ONNX support to KRCNNConvDeconvUpsampleHead

### DIFF
--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -176,6 +176,21 @@ def min_torch_version(min_version: str) -> bool:
     return installed_version >= min_version
 
 
+def has_dynamic_axes(onnx_model):
+    """
+    Return True when all ONNX input/output have only dynamic axes for all ranks
+    """
+    return all(
+        not dim.dim_param.isnumeric()
+        for inp in onnx_model.graph.input
+        for dim in inp.type.tensor_type.shape.dim
+    ) and all(
+        not dim.dim_param.isnumeric()
+        for out in onnx_model.graph.output
+        for dim in out.type.tensor_type.shape.dim
+    )
+
+
 def register_custom_op_onnx_export(
     opname: str, symbolic_fn: Callable, opset_version: int, min_version: str
 ) -> None:


### PR DESCRIPTION
In order to export `KRCNNConvDeconvUpsampleHead` to ONNX using `torch.jit.script`, changes to both PyTorch and detectron2:

- Pytorch has a bug which prevents a tensor wrapped by a list as float. Refer to the required [fix](https://github.com/pytorch/pytorch/pull/81386)

- `detectron2/structures/keypoints.py::heatmaps_to_keypoints` internally does advanced indexing on a `squeeze`d tensor. The aforementioned `squeeze` fails rank inference due to the presence of `onnx::If` on its implementation (to support dynamic dims). The fix is replacing `squeeze` by `reshape`.  A possible fix to `squeeze` on PyTorch side might be done too (TBD and would take some time), but the proposed change here does not bring any consequence to detectron2 while it enables ONNX support with scriptable `KRCNNConvDeconvUpsampleHead `.

After the proposed changes, the `KRCNNConvDeconvUpsampleHead` does include a `Loop` node to represent a for-loop inside the model and `dynamic outputs`, as shown below:

![image](https://user-images.githubusercontent.com/5469809/179559001-f60fb8af-ec79-4758-b271-736467b5d96f.png)

This PR has been tested with ONNX Runtime (this [PR](https://github.com/facebookresearch/detectron2/pull/4205)) to ensure the ONNX output matches PyTorch's for different `gen_input(X, Y)` combinations and it succeeded. The model was converted to ONNX once with a particular input and tested with inputs of different shapes and compared to equality to PyTorch's
Depends on: https://github.com/pytorch/pytorch/pull/81386 and https://github.com/facebookresearch/detectron2/pull/4291