### PR TITLE
Fix description error

### DIFF
--- a/detectron2/data/samplers/distributed_sampler.py
+++ b/detectron2/data/samplers/distributed_sampler.py
@@ -167,7 +167,7 @@ class RepeatFactorTrainingSampler(Sampler):
         Args:
             dataset_dicts (list[dict]): annotations in Detectron2 dataset format.
             repeat_thresh (float): frequency threshold below which data is repeated.
-                If the frequency is half of `repeat_thresh`, the image will be
+                If the frequency is quarter of `repeat_thresh`, the image will be
                 repeated twice.
 
         Returns:


### PR DESCRIPTION
Since repeat factor is calculated by `max(1, sqrt(t / f(c)))`, frequency should be quarter of the threshold

