### PR TITLE
use python >=3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ version_parameters: &version_parameters
       default: "https://download.pytorch.org/whl/torch_stable.html"
     python_version:  # NOTE: only affect linux
       type: string
-      default: '3.6.8'
+      default: '3.7.9'
 
   environment:
     PYTORCH_VERSION: << parameters.pytorch_version >>

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,10 +10,10 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         # flake8-bugbear flake8-comprehensions are useful but not available internally
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 ## Installation
 
 ### Requirements
-- Linux or macOS with Python ≥ 3.6
+- Linux or macOS with Python ≥ 3.7
 - PyTorch ≥ 1.8 and [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
   Install them together at [pytorch.org](https://pytorch.org) to make sure of this
 - OpenCV is optional but needed by demo and visualization
@@ -259,4 +259,3 @@ See
   which has step-by-step instructions.
 
 * __Docker__: The official [Dockerfile](docker) installs detectron2 with a few simple commands.
-

--- a/dev/packaging/build_all_wheels.sh
+++ b/dev/packaging/build_all_wheels.sh
@@ -26,7 +26,7 @@ build_one() {
   echo "Launching container $container_name ..."
   container_id="$container_name"_"$cu"_"$pytorch_ver"
 
-  py_versions=(3.6 3.7 3.8 3.9)
+  py_versions=(3.7 3.8 3.9)
 
   for py in "${py_versions[@]}"; do
     docker run -itd \

--- a/dev/packaging/build_wheel.sh
+++ b/dev/packaging/build_wheel.sh
@@ -10,7 +10,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Build Settings:"
 echo "CU_VERSION: $CU_VERSION"                 # e.g. cu101
 echo "D2_VERSION_SUFFIX: $D2_VERSION_SUFFIX"   # e.g. +cu101 or ""
-echo "PYTHON_VERSION: $PYTHON_VERSION"         # e.g. 3.6
+echo "PYTHON_VERSION: $PYTHON_VERSION"         # e.g. 3.7
 echo "PYTORCH_VERSION: $PYTORCH_VERSION"       # e.g. 1.4
 
 setup_cuda
@@ -21,7 +21,7 @@ ln -sv /usr/bin/ninja-build /usr/bin/ninja || true
 
 pip_install pip numpy -U
 pip_install "torch==$PYTORCH_VERSION" \
-	-f https://download.pytorch.org/whl/"$CU_VERSION"/torch_stable.html
+  -f https://download.pytorch.org/whl/"$CU_VERSION"/torch_stable.html
 
 # use separate directories to allow parallel build
 BASE_BUILD_DIR=build/$CU_VERSION-py$PYTHON_VERSION-pt$PYTORCH_VERSION

--- a/dev/packaging/pkg_helpers.bash
+++ b/dev/packaging/pkg_helpers.bash
@@ -63,7 +63,6 @@ setup_cuda() {
 
 setup_wheel_python() {
   case "$PYTHON_VERSION" in
-    3.6) python_abi=cp36-cp36m ;;
     3.7) python_abi=cp37-cp37m ;;
     3.8) python_abi=cp38-cp38 ;;
     3.9) python_abi=cp39-cp39 ;;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ else:
     # skip this when building locally
     intersphinx_timeout = 0.5
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.6", None),
+    "python": ("https://docs.python.org/3.7", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "torch": ("https://pytorch.org/docs/master/", None),
 }

--- a/projects/DensePose/doc/GETTING_STARTED.md
+++ b/projects/DensePose/doc/GETTING_STARTED.md
@@ -63,7 +63,7 @@ Please refer to [Apply Net](TOOL_APPLY_NET.md) for more details on this tool
 DensePose can also be installed as a Python package for integration with other software.
 
 The following dependencies are needed:
-- Python >= 3.6
+- Python >= 3.7
 - [PyTorch](https://pytorch.org/get-started/locally/#start-locally) >= 1.7 (to match [detectron2 requirements](https://detectron2.readthedocs.io/en/latest/tutorials/install.html#requirements))
 - [torchvision](https://pytorch.org/vision/stable/) version [compatible with your version of PyTorch](https://github.com/pytorch/vision#installation)
 

--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -32,7 +32,7 @@ setup(
     version=get_detectron2_current_version(),
     url="https://github.com/facebookresearch/detectron2/tree/main/projects/DensePose",
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "av>=8.0.3",
         "detectron2@git+https://github.com/facebookresearch/detectron2.git",

--- a/projects/TensorMask/setup.py
+++ b/projects/TensorMask/setup.py
@@ -63,7 +63,7 @@ setup(
     version="0.1",
     author="FAIR",
     packages=find_packages(exclude=("configs", "tests")),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     ext_modules=get_extensions(),
     cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension},
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ sections=FUTURE,STDLIB,THIRDPARTY,myself,FIRSTPARTY,LOCALFOLDER
 default_section=FIRSTPARTY
 
 [mypy]
-python_version=3.6
+python_version=3.7
 ignore_missing_imports = True
 warn_unused_configs = True
 disallow_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
     packages=find_packages(exclude=("configs", "tests*")) + list(PROJECTS.keys()),
     package_dir=PROJECTS,
     package_data={"detectron2.model_zoo": get_model_zoo_configs()},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         # These dependencies are not pure-python.
         # In general, avoid adding more dependencies like them because they are not


### PR DESCRIPTION
Summary:
X-link: https://github.com/fairinternal/detectron2/pull/571

fix CircleCI Test Failure as fairscale requires 3.7+

Differential Revision: D37022594

