### PR TITLE
Add elliptical bounding box rotation to RotationTransform

### DIFF
--- a/detectron2/data/transforms/transform.py
+++ b/detectron2/data/transforms/transform.py
@@ -165,7 +165,7 @@ class RotationTransform(Transform):
     number of degrees counter clockwise around its center.
     """
 
-    def __init__(self, h, w, angle, expand=True, center=None, interp=None):
+    def __init__(self, h, w, angle, expand=True, center=None, interp=None, box_method="largest"):
         """
         Args:
             h, w (int): original image size
@@ -176,6 +176,11 @@ class RotationTransform(Transform):
                 if left to None, the center will be fit to the center of each image
                 center has no effect if expand=True because it only affects shifting
             interp: cv2 interpolation method, default cv2.INTER_LINEAR
+            box_method: either _largest_ (default) or _ellipse_. Affects how bboxes are rotated.
+                If _ellipse_, then bboxes are resized as if the object is an ellipse rather than a 
+                rectangle, which avoids creating oversized bounding boxes.
+                If _largest_, this will transform the corner points and use their minimum/maximum 
+                to create a new axis-aligned box.
         """
         super().__init__()
         image_center = np.array((w / 2, h / 2))
@@ -196,6 +201,10 @@ class RotationTransform(Transform):
         self.rm_coords = self.create_rotation_matrix()
         # Needed because of this problem https://github.com/opencv/opencv/issues/11784
         self.rm_image = self.create_rotation_matrix(offset=-0.5)
+
+        if box_method not in ["largest", "ellipse"]:
+            raise ValueError(f"Method '{box_method}' is not a valid box rotation method.")
+        self.box_method = box_method
 
     def apply_image(self, img, interp=None):
         """
@@ -219,6 +228,30 @@ class RotationTransform(Transform):
     def apply_segmentation(self, segmentation):
         segmentation = self.apply_image(segmentation, interp=cv2.INTER_NEAREST)
         return segmentation
+
+    def apply_box(self, box):
+        """
+        box should be a Nx4 floating point array of XYXY format in absolute coordinates.
+        If box_method="largest" (default), this will transform the corner points and use their minimum/maximum to create a new axis-aligned box.
+        If box_method="elliptical", this will synthesize a new bounding box as if the object was an ellipsis, which avoids enlarging the bounding box.
+        """
+        if self.box_method == 'largest':
+            return super().apply_box(box)
+        else:
+            box = np.asarray(box)
+            w, h = box[:, 2] - box[:, 0], box[:, 3] - box[:, 1]
+            x, y = box[:, 0]+w/2, box[:, 1]+h/2
+
+            # Create 32 keypoints along ellipsis
+            coords = [[x+np.sin(t)*(w/2), y+np.cos(t)*(h/2)] for t in np.arange(0, 2*np.pi, 0.2)] # 32x2xN
+            coords = np.moveaxis(coords, 2, 0).reshape(-1, 2) # (N*32)x2
+
+            # Transform these coordinates in the same way as rectangle coordinates
+            coords = self.apply_coords(coords).reshape(-1, 32, 2) # Nx32x2
+            minxy = coords.min(axis=1)
+            maxxy = coords.max(axis=1)
+            trans_boxes = np.concatenate((minxy, maxxy), axis=1)
+            return trans_boxes
 
     def create_rotation_matrix(self, offset=0):
         center = (self.center[0] + offset, self.center[1] + offset)

--- a/detectron2/data/transforms/transform.py
+++ b/detectron2/data/transforms/transform.py
@@ -177,9 +177,9 @@ class RotationTransform(Transform):
                 center has no effect if expand=True because it only affects shifting
             interp: cv2 interpolation method, default cv2.INTER_LINEAR
             box_method: either _largest_ (default) or _ellipse_. Affects how bboxes are rotated.
-                If _ellipse_, then bboxes are resized as if the object is an ellipse rather than a 
+                If _ellipse_, then bboxes are resized as if the object is an ellipse rather than a
                 rectangle, which avoids creating oversized bounding boxes.
-                If _largest_, this will transform the corner points and use their minimum/maximum 
+                If _largest_, this will transform the corner points and use their minimum/maximum
                 to create a new axis-aligned box.
         """
         super().__init__()
@@ -235,19 +235,22 @@ class RotationTransform(Transform):
         If box_method="largest" (default), this will transform the corner points and use their minimum/maximum to create a new axis-aligned box.
         If box_method="elliptical", this will synthesize a new bounding box as if the object was an ellipsis, which avoids enlarging the bounding box.
         """
-        if self.box_method == 'largest':
+        if self.box_method == "largest":
             return super().apply_box(box)
         else:
             box = np.asarray(box)
             w, h = box[:, 2] - box[:, 0], box[:, 3] - box[:, 1]
-            x, y = box[:, 0]+w/2, box[:, 1]+h/2
+            x, y = box[:, 0] + w / 2, box[:, 1] + h / 2
 
             # Create 32 keypoints along ellipsis
-            coords = [[x+np.sin(t)*(w/2), y+np.cos(t)*(h/2)] for t in np.arange(0, 2*np.pi, 0.2)] # 32x2xN
-            coords = np.moveaxis(coords, 2, 0).reshape(-1, 2) # (N*32)x2
+            coords = [
+                [x + np.sin(t) * (w / 2), y + np.cos(t) * (h / 2)]
+                for t in np.arange(0, 2 * np.pi, 0.2)
+            ]  # 32x2xN
+            coords = np.moveaxis(coords, 2, 0).reshape(-1, 2)  # (N*32)x2
 
             # Transform these coordinates in the same way as rectangle coordinates
-            coords = self.apply_coords(coords).reshape(-1, 32, 2) # Nx32x2
+            coords = self.apply_coords(coords).reshape(-1, 32, 2)  # Nx32x2
             minxy = coords.min(axis=1)
             maxxy = coords.max(axis=1)
             trans_boxes = np.concatenate((minxy, maxxy), axis=1)


### PR DESCRIPTION
This PR adds a small extension to the `RotationTransform` Transform; the user can choose to rotate bounding boxes by approximating the underlying object as an ellipsis rather than a rectangle.

This solves a common problem with using rotations, where the bounding boxes are enlarged ([this can significantly hurt performance](https://arxiv.org/pdf/2109.13488.pdf)).

In the below image, the original bounding box is shown in **red**, the "normal" way of rotating the bounding box (current behaviour) is shown in **blue**. The elliptical method added by this PR is shown in **green**. As you can see, the rectangular boxes are significantly larger than the objects which the boxes are for.  
[Source code for the below image](https://gist.github.com/mxbi/985896b0f5579e0ab8d3d2a37b8859a9)

<img width="387" alt="image" src="https://user-images.githubusercontent.com/6796648/178600066-4087ceb9-f40a-4bec-8cb4-79427566a983.png">

This PR adds this feature by overloading `RotationTransform.apply_box` and adding a new parameter `box_method`. **The default behaviour is unchanged**, but if the user sets `box_method='ellipsis'` they will get the tighter elliptical boxes.

I have documented the feature, run the linter, and agreed to the CLA! Thank you for considering

For reference: [[Paper showing significant performance improvements]](https://arxiv.org/abs/2109.13488) [[Same feature in albumentations]](https://github.com/albumentations-team/albumentations/pull/1203)