### PR TITLE
upgrade python from 3.6.9 to 3.7.x in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,15 @@ FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
-	python3-opencv ca-certificates python3-dev git wget sudo ninja-build
-RUN ln -sv /usr/bin/python3 /usr/bin/python
+    python3.7 python3.7-dev python3.7-distutils \
+    python3-opencv ca-certificates git wget sudo ninja-build
+
+# Make python3 available for python3.7
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+RUN update-alternatives --config python3
+# Make python available for python3.7
+RUN ln -sv /usr/bin/python3.7 /usr/bin/python
 
 # create a non-root user
 ARG USER_ID=1000
@@ -14,9 +21,12 @@ USER appuser
 WORKDIR /home/appuser
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
-	python3 get-pip.py --user && \
+RUN wget https://bootstrap.pypa.io/pip/get-pip.py && \
+	python3.7 get-pip.py --user && \
 	rm get-pip.py
+
+# Important! Otherwise, it uses existing numpy from host-modules which throws error
+RUN pip install --user numpy==1.20.3
 
 # install dependencies
 # See https://pytorch.org/ for other options if you use a different version of CUDA


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/detectron2/issues/4394 https://github.com/facebookresearch/detectron2/issues/4335 by upgrading Python version from 3.6 to 3.7 inside `nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04` docker image. 
