### PR TITLE
optimize the bbox computation while using rotate data augmentation in instance segmentation

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -280,12 +280,6 @@ def transform_instance_annotations(
     """
     if isinstance(transforms, (tuple, list)):
         transforms = T.TransformList(transforms)
-    # bbox is 1d (per-instance bounding box)
-    bbox = BoxMode.convert(annotation["bbox"], annotation["bbox_mode"], BoxMode.XYXY_ABS)
-    # clip transformed bbox to image size
-    bbox = transforms.apply_box(np.array([bbox]))[0].clip(min=0)
-    annotation["bbox"] = np.minimum(bbox, list(image_size + image_size)[::-1])
-    annotation["bbox_mode"] = BoxMode.XYXY_ABS
 
     if "segmentation" in annotation:
         # each instance contains 1 or more polygons
@@ -308,6 +302,40 @@ def transform_instance_annotations(
                 "Supported types are: polygons as list[list[float] or ndarray],"
                 " COCO-style RLE as a dict.".format(type(segm))
             )
+        
+        # flag of whether transforms has the class of RotationTransform
+        flag = False
+        
+        for transform in transforms:
+            if transform.__class__.__name__ == 'RotationTransform':
+                flag = True
+                
+                # rotated segmentation
+                polygons_rot = [np.asarray(p).reshape(-1, 2) for p in annotation["segmentation"]]   
+                
+                # compute the min_area rectangle of rotated object segmentation
+                rotatedRect = cv2.minAreaRect(polygons_rot[0].astype('float32'))
+                box = cv2.boxPoints(rotatedRect)
+                
+                # compute the left-top and right-bottom points of rotated object segmentation
+                box_x_min = min(box[:, 0])
+                box_y_min = min(box[:, 1])
+                box_x_max = max(box[:, 0])
+                box_y_max = max(box[:, 1])
+                bbox = np.expand_dims(np.array([box_x_min, box_y_min, box_x_max, box_y_max]), 0)
+                
+                # clip transformed bbox to image size
+                bbox = bbox[0].clip(min=0)
+                annotation["bbox"] = np.minimum(bbox, list(image_size + image_size)[::-1])
+                annotation["bbox_mode"] = BoxMode.XYXY_ABS
+                
+        if not flag:
+            # bbox is 1d (per-instance bounding box)
+            bbox = BoxMode.convert(annotation["bbox"], annotation["bbox_mode"], BoxMode.XYXY_ABS)
+            # clip transformed bbox to image size
+            bbox = transforms.apply_box(np.array([bbox]))[0].clip(min=0)
+            annotation["bbox"] = np.minimum(bbox, list(image_size + image_size)[::-1])
+            annotation["bbox_mode"] = BoxMode.XYXY_ABS
 
     if "keypoints" in annotation:
         keypoints = transform_keypoint_annotations(


### PR DESCRIPTION
This PR is related to the issue of #4292.

While using rotate data augmentation in instance segmentation, the bbox computation after rotation in function `transform_instance_annotations` is using the rotated bbox. This can lead to larger bbox than expected, as mentioned in #4292. Alternatively, I use rotated segmentation to compute the min_area rectangle and the corresponding left-top annd right-bottom points as the rotated bbox. This is more precise and better to the model convergence.

To maintain the code compatibility, I will check if there is rotating augmentation during training and then do the optimized op (i.e., if no rotating augmentation, this op will not be applied). Besides, no args or functions will be added.

The following figure shows the optimized effect:

![image](https://user-images.githubusercontent.com/46739135/179385093-dd0ca275-d533-4862-926f-639f6adb373e.png)

Any questions will be appreciated ^-^
