### PR TITLE
Add quantization support for FCOS

### DIFF
--- a/detectron2/modeling/meta_arch/retinanet.py
+++ b/detectron2/modeling/meta_arch/retinanet.py
@@ -347,10 +347,10 @@ class RetinaNetHead(nn.Module):
             )
             bn_class = nn.BatchNorm2d if norm == "BN" else nn.SyncBatchNorm
 
-            def norm(c):
-                return CycleBatchNormList(
-                    length=self._num_features, bn_class=bn_class, num_features=c
-                )
+            # def norm(c):
+            #     return CycleBatchNormList(
+            #         length=self._num_features, bn_class=bn_class, num_features=c
+            #     )
 
         else:
             norm_name = str(type(get_norm(norm, 1)))


### PR DESCRIPTION
Summary:
Add quantization support for FCOS

run
```
buck run mobile-vision/d2go/tools:exporter -- --runner YOURRUNNER --predictor-types torchscript_int8 \
--config-file CONFIG_FOR_FCOS \
--output-dir OUTPUT_DIR \
INPUT.MIN_SIZE_TEST 600 \
INPUT.MAX_SIZE_TEST 800 \
D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f)GO_DATA.AUG_OPS.TEST "['ResizeShortestEdgeOp']" \
DATALOADER.NUM_WORKERS 0 \
QUANTIZATION.PTQ.CALIBRATION_NUM_IMAGES 16 \
QUANTIZATION.BACKEND fbgemm
```

Differential Revision: D38102296

