### PR TITLE
use public trainer API to re-create data loader for QAT

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -301,8 +301,13 @@ class SimpleTrainer(TrainerBase):
             self._data_loader_iter_obj = iter(self.data_loader)
         return self._data_loader_iter_obj
 
-    def reset_data_loader(self, data_loader):
+    def reset_data_loader(self, data_loader_builder):
+        """
+        Delete and replace the current data loader with a new one, which will be created
+        by calling `data_loader_builder` (without argument).
+        """
         del self.data_loader
+        data_loader = data_loader_builder()
         self.data_loader = data_loader
         self._data_loader_iter_obj = None
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -55,7 +55,7 @@ class TestTrainer(unittest.TestCase):
             model, self._data_loader(device), torch.optim.SGD(model.parameters(), 0.1)
         )
         trainer.train(0, 10)
-        trainer.reset_data_loader(self._data_loader(device))
+        trainer.reset_data_loader(lambda: self._data_loader(device))
         trainer.train(0, 10)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")


### PR DESCRIPTION
Summary:
- The QAT was using old code prior to D36786902 (https://github.com/facebookresearch/detectron2/commit/e566079fb853afc2752e909a2b50e031cc2291ee), update to use public API
- Make `trainer:reset_data_loader` to take lazy lambda expression in order to delay the creation of dataloader. It's possible that we don't have enough RAM to hold two data loader at the same time, so we need to delete the first one, then create the second one.

Differential Revision: D38330148

