### PR TITLE
CODEOWNERS proposal for Detectron2 + Microsoft collaboration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,22 +8,28 @@ cpu: &cpu
     image: ubuntu-2004:202107-02
   resource_class: medium
 
-gpu: &gpu
+cuda111: &cuda111
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
     image: ubuntu-1604-cuda-11.1:202012-01
   resource_class: gpu.nvidia.small
 
+cuda113: &cuda113
+  machine:
+    # NOTE: use a cuda version that supports PyTorch nightly builds
+    image: ubuntu-2004-cuda-11.4:202110-01
+  resource_class: gpu.nvidia.small
+
 windows-cpu: &windows_cpu
   machine:
-    resource_class: windows.medium
     image: windows-server-2019-vs2019:stable
-    shell: powershell.exe
+  resource_class: windows.medium
+  shell: powershell.exe
 
 # windows-gpu: &windows_gpu
 #     machine:
-#       resource_class: windows.gpu.nvidia.medium
 #       image: windows-server-2019-nvidia:stable
+#     resource_class: windows.gpu.nvidia.medium
 
 version_parameters: &version_parameters
   parameters:
@@ -36,7 +42,7 @@ version_parameters: &version_parameters
       # use test wheels index to have access to RC wheels
       # https://download.pytorch.org/whl/test/torch_test.html
       default: "https://download.pytorch.org/whl/torch_stable.html"
-    python_version:  # NOTE: only affect linux
+    python_version:  # NOTE: only affects linux
       type: string
       default: '3.7.9'
 
@@ -60,6 +66,37 @@ version_parameters: &version_parameters
 #         sudo /bin/bash ./NVIDIA-Linux-x86_64-430.40.run -s --no-drm
 #         nvidia-smi
 
+setupcuda113: &setupcuda113
+  run:
+    name: Setup CUDA 11.3
+    working_directory: ~/
+    command: |
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+      sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+      sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+      sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+      sudo apt-get update
+      sudo apt-get -y install cuda-11-3
+      sudo update-alternatives --install /usr/local/cuda cuda /usr/local/cuda-11.3 50
+      echo "Done installing CUDA 11.3"
+      sudo apt autoremove
+      sudo apt-get clean
+      nvidia-smi
+      sudo update-alternatives --display cuda
+
+removecuda114: &removecuda114
+  run:
+    name: Remove CUDA 11.4
+    working_directory: ~/
+    command: |
+      echo "Remove CUDA 11.4"
+      sudo update-alternatives --remove cuda /usr/local/cuda-11.4
+      sudo apt-get -y remove --purge cuda-11-4
+      sudo apt autoremove
+      sudo apt-get clean
+      echo "Done removing CUDA 11.4"
+      sudo update-alternatives --display cuda
+
 add_ssh_keys: &add_ssh_keys
   # https://circleci.com/docs/2.0/add-ssh-key/
   - add_ssh_keys:
@@ -71,8 +108,8 @@ install_python: &install_python
       name: Install Python
       working_directory: ~/
       command: |
-        # upgrade pyenv
-        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd
+        pyenv install -l
         pyenv install -s $PYTHON_VERSION
         pyenv global $PYTHON_VERSION
         python --version
@@ -114,15 +151,28 @@ install_linux_dep: &install_linux_dep
         pip install --progress-bar off -U 'git+https://github.com/facebookresearch/fvcore'
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         pip install --progress-bar off ninja opencv-python-headless pytest tensorboard pycocotools onnx
-        pip install --progress-bar off torch==$PYTORCH_VERSION -f $PYTORCH_INDEX
-        if [[ "$TORCHVISION_VERSION" == "master" ]]; then
-          pip install git+https://github.com/pytorch/vision.git
+        if [[ "$PYTORCH_VERSION" == "master" ]]; then
+          echo "Installing torch/torchvision from $PYTORCH_INDEX"
+          # Remove first, in case it's in the CI cache
+          pip uninstall -y torch torchvision
+          pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
         else
-          pip install --progress-bar off torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
+          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
         fi
 
+        python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+        python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
         python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+        echo "Python packages"
+        python -c "import sys; print(sys.executable)"
+        python --version
+        pip list
+        echo "GCC Compiler"
         gcc --version
+        echo "OS Environment Variables"
+        env
+
 
 install_detectron2: &install_detectron2
   - run:
@@ -169,7 +219,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -181,11 +231,10 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
-
-  linux_gpu_tests:
-    <<: *gpu
+  linux_cuda111_tests:
+    <<: *cuda111
     <<: *version_parameters
 
     working_directory: ~/detectron2
@@ -195,7 +244,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_python
       - <<: *install_linux_dep
@@ -207,7 +256,35 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
+  linux_cuda113_tests:
+    <<: *cuda113
+    <<: *version_parameters
+
+    working_directory: ~/detectron2
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
+      - <<: *setupcuda113
+      - <<: *removecuda114
+      - <<: *install_python
+      - <<: *install_linux_dep
+      - <<: *install_detectron2
+      - <<: *run_unittests
+      - <<: *uninstall_tests
+
+      - save_cache:
+          paths:
+            - /opt/circleci/.pyenv
+            - ~/.torch
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
+
 
   windows_cpu_build:
     <<: *windows_cpu
@@ -220,7 +297,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - run:
           name: Install Dependencies
@@ -230,12 +307,28 @@ jobs:
             pip install opencv-python-headless pytest-xdist pycocotools tensorboard onnx
             pip install -U git+https://github.com/facebookresearch/iopath
             pip install -U git+https://github.com/facebookresearch/fvcore
-            pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            if($env:PYTORCH_VERSION -eq "master"){
+              Write-Output "Installing torch/torchvision from $env:PYTORCH_INDEX"
+              pip uninstall -y torch torchvision
+              pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
+            }else{
+              Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
+              pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            }
+            python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+            python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+            python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+            Write-Output "Python packages"
+            python -c "import sys; print(sys.executable)"
+            python --version
+            pip list
+            echo "OS Environment Variables"
+            dir env:
 
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20220503
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -248,23 +341,42 @@ workflows:
           name: linux_cpu_tests_pytorch1.10
           pytorch_version: '1.10.0+cpu'
           torchvision_version: '0.11.1+cpu'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.8
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch_master
+          python_version: '3.9.4'
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.8
           pytorch_version: '1.8.1+cu111'
           torchvision_version: '0.9.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.9
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.9
           pytorch_version: '1.9+cu111'
           torchvision_version: '0.10+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.10
           pytorch_version: '1.10+cu111'
           torchvision_version: '0.11.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10_python39
+      - linux_cuda111_tests:
+          name: linux_cuda111_tests_pytorch1.10_python39
           pytorch_version: '1.10+cu111'
           torchvision_version: '0.11.1+cu111'
           python_version: '3.9.6'
+      - linux_cuda113_tests:
+          name: linux_cuda113_tests_pytorch_master_python39
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          python_version: '3.9.4'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cu113'
       - windows_cpu_build:
+          name: windows_cpu_build_pytorch1.10
           pytorch_version: '1.10+cpu'
           torchvision_version: '0.11.1+cpu'
+      - windows_cpu_build:
+          name: windows_cpu_build_pytorch_master
+          pytorch_version: 'master'
+          torchvision_version: 'master'
+          python_version: '3.7.3'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cpu'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ install_linux_dep: &install_linux_dep
           # Remove first, in case it's in the CI cache
           pip uninstall -y torch torchvision
           pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+          pip install -v --progress-bar off omegaconf==2.1.2   # needed by FCOSE2ETest::test_empty_data
         else
           echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
           pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -71,13 +71,13 @@ jobs:
           python -m pip install -U pip
           python -m pip install ninja opencv-python-headless onnx pytest-xdist
           if [[ "${{matrix.torch}}" == "master" ]]; then
-            echo "Installing torch/torchvision from ${{pytorch_index}}"
+            echo "Installing torch/torchvision from ${{matrix.pytorch_index}}"
             # Remove first, in case it's in the CI cache
             pip uninstall -y torch torchvision
-            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{pytorch_index}}
+            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{matrix.pytorch_index}}
           else
-            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}} from ${{pytorch_index}}"
-            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f ${{pytorch_index}}
+            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}}"
+            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}}
           fi
 
           # install from github to get latest; install iopath first since fvcore depends on it

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ["1.8", "1.9", "1.10"]
+        torch: ["1.8", "1.9", "1.10", "master"]
         include:
           - torch: "1.8"
             torchvision: 0.9
@@ -45,6 +45,9 @@ jobs:
             torchvision: "0.10"
           - torch: "1.10"
             torchvision: "0.11.1"
+          - torch: "master"
+            torchvision: "master"
+            pytorch_index: "https://download.pytorch.org/whl/nightly/cpu"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets
@@ -61,16 +64,36 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.7/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220119
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220503
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           python -m pip install ninja opencv-python-headless onnx pytest-xdist
-          python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+          if [[ "${{matrix.torch}}" == "master" ]]; then
+            echo "Installing torch/torchvision from ${{pytorch_index}}"
+            # Remove first, in case it's in the CI cache
+            pip uninstall -y torch torchvision
+            pip install -v --pre torch>1.11 torchvision>0.12 --progress-bar off -f ${{pytorch_index}}
+          else
+            echo "Installing torch==${{matrix.torch}} and torchvision==${{matrix.torchvision}} from ${{pytorch_index}}"
+            python -m pip install --progress-bar off torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f ${{pytorch_index}}
+          fi
+
           # install from github to get latest; install iopath first since fvcore depends on it
           python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
           python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+
+          python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+          python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+          python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+          echo "Python packages"
+          pip list
+          echo "GCC Compiler"
+          gcc --version
+          echo "Environment Variables"
+          env
+
 
       - name: Build and install
         run: |

--- a/detectron2/modeling/meta_arch/retinanet.py
+++ b/detectron2/modeling/meta_arch/retinanet.py
@@ -353,11 +353,16 @@ class RetinaNetHead(nn.Module):
                 )
 
         else:
-            norm_name = str(type(get_norm(norm, 1)))
-            if "BN" in norm_name:
-                logger.warning(
-                    f"Shared BatchNorm (type={norm_name}) may not work well in RetinaNetHead."
-                )
+            try:
+                norm_name = str(type(get_norm(norm, 1)))
+                if "BN" in norm_name:
+                    logger.warning(
+                        f"Shared BatchNorm (type={norm_name}) may not work well in RetinaNetHead."
+                    )
+            except ValueError:
+                # https://github.com/pytorch/pytorch/pull/74293
+                if isinstance(norm, str):
+                    logger.warning(f"No BatchNorm was found for '{norm}' for RetinaNetHead.")
 
         cls_subnet = []
         bbox_subnet = []

--- a/detectron2/modeling/meta_arch/retinanet.py
+++ b/detectron2/modeling/meta_arch/retinanet.py
@@ -353,16 +353,11 @@ class RetinaNetHead(nn.Module):
                 )
 
         else:
-            try:
-                norm_name = str(type(get_norm(norm, 1)))
-                if "BN" in norm_name:
-                    logger.warning(
-                        f"Shared BatchNorm (type={norm_name}) may not work well in RetinaNetHead."
-                    )
-            except ValueError:
-                # https://github.com/pytorch/pytorch/pull/74293
-                if isinstance(norm, str):
-                    logger.warning(f"No BatchNorm was found for '{norm}' for RetinaNetHead.")
+            norm_name = str(type(get_norm(norm, 32)))
+            if "BN" in norm_name:
+                logger.warning(
+                    f"Shared BatchNorm (type={norm_name}) may not work well in RetinaNetHead."
+                )
 
         cls_subnet = []
         bbox_subnet = []

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -11,7 +11,6 @@ import torch.onnx.symbolic_helper as sym_help
 from packaging import version
 from torch._C import ListType
 from torch.onnx import register_custom_op_symbolic
-import unittest
 
 from detectron2 import model_zoo
 from detectron2.config import CfgNode, LazyConfig, instantiate

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -11,6 +11,7 @@ import torch.onnx.symbolic_helper as sym_help
 from packaging import version
 from torch._C import ListType
 from torch.onnx import register_custom_op_symbolic
+import unittest
 
 from detectron2 import model_zoo
 from detectron2.config import CfgNode, LazyConfig, instantiate
@@ -20,10 +21,15 @@ from detectron2.modeling import build_model
 from detectron2.structures import Boxes, Instances, ROIMasks
 from detectron2.utils.file_io import PathManager
 
-
 """
 Internal utilities for tests. Don't use except for writing tests.
 """
+
+
+skip_on_torch_nightly = unittest.skipIf(
+    ".dev" in torch.__version__ or "+git" in torch.__version__,
+    f"The test cannot run on pyTorch nightly releases ({torch.__version__}).",
+)
 
 
 def get_model_no_weights(config_path):

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -21,6 +21,7 @@ except ImportError:
         f"PyTorch does not have Caffe2 support. Skipping all tests in {__name__}"
     ) from None
 
+
 # TODO: this test requires manifold access, see: T88318502
 # Running it on CircleCI causes crash, not sure why.
 @unittest.skipIf(os.environ.get("CIRCLECI"), "Caffe2 tests crash on CircleCI.")

--- a/tests/test_export_caffe2.py
+++ b/tests/test_export_caffe2.py
@@ -21,7 +21,6 @@ except ImportError:
         f"PyTorch does not have Caffe2 support. Skipping all tests in {__name__}"
     ) from None
 
-
 # TODO: this test requires manifold access, see: T88318502
 # Running it on CircleCI causes crash, not sure why.
 @unittest.skipIf(os.environ.get("CIRCLECI"), "Caffe2 tests crash on CircleCI.")

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -28,8 +28,8 @@ from detectron2.utils.testing import (
     convert_scripted_instances,
     get_sample_coco_image,
     random_boxes,
-    skipIfOnCPUCI,
     skip_on_torch_nightly,
+    skipIfOnCPUCI,
 )
 
 

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -29,6 +29,7 @@ from detectron2.utils.testing import (
     get_sample_coco_image,
     random_boxes,
     skipIfOnCPUCI,
+    skip_on_torch_nightly,
 )
 
 
@@ -43,6 +44,7 @@ class TestScripting(unittest.TestCase):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")
 
     @skipIfOnCPUCI
+    @skip_on_torch_nightly
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 


### PR DESCRIPTION
This PR proposes a collaboration between Meta Research and Microsoft, in which Microsoft would love to help Detectron2 folks to maintain ONNX export support for Detectron2's models.

In this proposal, ONNX-specific files would be moved (whenever possible) to common folders so that Microsoft's PyTorch-ONNX Converter team can review and merge PRs related to ONNX-only.

Ideally a couple common files would also be part of the files Microsoft could review/merge. Such files are related to Testing helpers, Pipeline definitions and documentation files. When significant changes are present in this common files, a `label` wuld be added to the PR, say `onnx-needs-info` so that Detectron2 team could provide their feedback. An alternative would be splitting/duplicating a couple files for complete separation, which is also reasonable to Microsoft.

This is just a small draft to show the idea. The same agreement is also in place with Meta's PyTorch project and @malfet and friends have been great allies in this collaboration effort.