### PR TITLE
Fix import exceptions in tracing.py for older (<1.12) versions of pytorch

### DIFF
--- a/detectron2/modeling/poolers.py
+++ b/detectron2/modeling/poolers.py
@@ -7,7 +7,7 @@ from torchvision.ops import RoIPool
 
 from detectron2.layers import ROIAlign, ROIAlignRotated, cat, nonzero_tuple, shapes_to_tensor
 from detectron2.structures import Boxes
-from detectron2.utils.tracing import assert_fx_safe
+from detectron2.utils.tracing import assert_fx_safe, is_fx_tracing
 
 """
 To export ROIPooler to torchscript, in this file, variables that should be annotated with
@@ -220,9 +220,11 @@ class ROIPooler(nn.Module):
         """
         num_level_assignments = len(self.level_poolers)
 
-        assert_fx_safe(
-            isinstance(x, list) and isinstance(box_lists, list), "Arguments to pooler must be lists"
-        )
+        if not is_fx_tracing():
+            torch._assert(
+                isinstance(x, list) and isinstance(box_lists, list),
+                "Arguments to pooler must be lists",
+            )
         assert_fx_safe(
             len(x) == num_level_assignments,
             "unequal value, num_level_assignments={}, but x is list of {} Tensors".format(


### PR DESCRIPTION
Summary:
Recently landed D35518556 (https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0) / Github: 36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0 throws an exception with older versions of PyTorch, due to a missing library for import. This has been reported by multiple members of the PyTorch community at https://github.com/facebookresearch/detectron2/commit/36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0

This change uses `try/except` to check for libraries and set flags on presence/absence to later guard code that would use them.

Differential Revision: D38879134

