### PR TITLE
Fix visualizer.py error.

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -875,6 +875,7 @@ class Visualizer:
             font_size = self._default_font_size
 
         # since the text background is dark, we don't want the text to be dark
+        color = [min(max(c, 0.0), 1.0) for c in color]
         color = np.maximum(list(mplc.to_rgb(color)), 0.2)
         color[np.argmax(color)] = max(0.8, np.max(color))
 


### PR DESCRIPTION
For certain cases, the floating value exceeds 1.0, which causes the following ValueError
```
raise ValueError("RGBA values should be within 0-1 range")
```
from matplotlib/colors.py.

The following code clips the value so it is kept within the range [0, 1].
