### PR TITLE
fix bug for GN in Pytorch 1.12.1

### DIFF
--- a/detectron2/modeling/meta_arch/retinanet.py
+++ b/detectron2/modeling/meta_arch/retinanet.py
@@ -353,7 +353,7 @@ class RetinaNetHead(nn.Module):
                 )
 
         else:
-            norm_name = str(type(get_norm(norm, 1)))
+            norm_name = str(type(get_norm(norm, 32)))
             if "BN" in norm_name:
                 logger.warning(
                     f"Shared BatchNorm (type={norm_name}) may not work well in RetinaNetHead."


### PR DESCRIPTION

For PyTorch 1.12.1, it will throw error if `num_channels` is not be divisible by `num_groups`:

https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/normalization.py#L251-L252

cc @ppwwyyxx 