### PR TITLE
Bugfix: when deploying a Detectron2 model, make sure that the created tensors are located on the right device

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -86,7 +86,8 @@ class ImageList(object):
 
         image_sizes = [(im.shape[-2], im.shape[-1]) for im in tensors]
         image_sizes_tensor = [shapes_to_tensor(x) for x in image_sizes]
-        max_size = torch.stack(image_sizes_tensor).max(0).values
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        max_size = torch.stack(image_sizes_tensor).max(0).values.to(device)
 
         if padding_constraints is not None:
             square_size = padding_constraints.get("square_size", 0)


### PR DESCRIPTION
Earlier, when you try to deploy a Detectron2 model on for example a Triton server, the following error occured:
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!` (see also [here](https://github.com/triton-inference-server/server/issues/2024)). This has been resolved by sending the newly created tensor to the right device.