### PR TITLE
Add support to PanopticFPN to ONNX exporter

### DIFF
--- a/docs/notes/compatibility.md
+++ b/docs/notes/compatibility.md
@@ -68,13 +68,14 @@ model-level compatibility. The major ones are:
 explains more details on the above mentioned issues
 about pixels, coordinates, and "+1"s.
 
+## Compatibility with ONNX Runtime
 
-## Compatibility with Caffe2
+[//]: # (Add more doc/examples when ONNX Runtime is supported on the CI)
+Most ops are available in [ONNX Runtime](https://onnxruntime.ai), therefore,
+many models trained with detectron2 can be converted to ONNX using tracing
+or scripting methods and executed by ONNX Runtime.
+See [Deployment](../tutorials/deployment.md) to learn how to export a model to ONNX.
 
-As mentioned above, despite the incompatibilities with Detectron, the relevant
-ops have been implemented in Caffe2.
-Therefore, models trained with detectron2 can be converted in Caffe2.
-See [Deployment](../tutorials/deployment.md) for the tutorial.
 
 ## Compatibility with TensorFlow
 
@@ -82,3 +83,10 @@ Most ops are available in TensorFlow, although some tiny differences in
 the implementation of resize / ROIAlign / padding need to be addressed.
 A working conversion script is provided by [tensorpack Faster R-CNN](https://github.com/tensorpack/tensorpack/tree/master/examples/FasterRCNN/convert_d2)
 to run a standard detectron2 model in TensorFlow.
+
+## (DEPRECATED) Compatibility with Caffe2
+
+As mentioned above, despite the incompatibilities with Detectron, the relevant
+ops have been implemented in Caffe2.
+Therefore, models trained with detectron2 can be converted in Caffe2.
+See [Deployment](../tutorials/deployment.md) for the tutorial.

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -6,12 +6,8 @@ A few basic concepts about this process:
 __"Export method"__ is how a Python model is fully serialized to a deployable format.
 We support the following export methods:
 
-* `tracing`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it\
-This method produces a standardized ONNX graph that can be used by any ONNX runtime, such as \
-[ONNX Runtime](https://onnxruntime.ai/)
-* `scripting`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it\
-This method produces a standardized ONNX graph that can be used by any ONNX runtime, such as \
-[ONNX Runtime](https://onnxruntime.ai/)
+* `tracing`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it
+* `scripting`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it
 * `caffe2_tracing`: replace parts of the model by caffe2 operators, then use tracing.
 This method produces a Caffe2-specific ONNX graph that can be used only by the [Caffe2](https://caffe2.ai/).
 Caffe2 support has been ***DEPRECATED*** by PyTorch, therefore, we don't plan to support it, but contributions are welcome.
@@ -27,33 +23,33 @@ A runtime is often tied to a specific format
 We currently support the following combination and each has some limitations:
 
 ```eval_rst
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-|       Export Method        |   tracing   |  scripting  | tracing/scripting | caffe2_tracing (DEPRECATED) |
-+============================+=============+=============+===================+=============================+
-| **Formats**                | TorchScript | TorchScript |       ONNX        | Caffe2, TorchScript, ONNX   |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| **Runtime**                | PyTorch     | PyTorch     |    ONNX Runtime   | Caffe2, PyTorch             |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| C++/Python inference       | ✅           | ✅           | ✅                 | ✅                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| Dynamic resolution         | ✅           | ✅           | ✅                 | ✅                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| Batch size requirement     | Constant    | Dynamic     | Dynamic           | Batch inference unsupported |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| Extra runtime deps         | torchvision | torchvision | torchvision       | Caffe2 ops (usually already |
-|                            |             |             |                   |                             |
-|                            |             |             |                   | included in PyTorch)        |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| Faster/Mask/Keypoint R-CNN | ✅           | ✅           | ✅                 | ✅                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| RetinaNet                  | ✅           | ✅           | ✅                 | ✅                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| PointRend R-CNN            | ✅           | ❌           | ✅                 | ❌                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| Cascade R-CNN              | ✅           | ❌           | ✅                 | ❌                           |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
-| PanopticFPN                | ✅           | N/A         | ✅                 | N/A                         |
-+----------------------------+-------------+-------------+-------------------+-----------------------------+
++----------------------------+-----------------------+-----------------------+-----------------------------+
+|       Export Method        |   tracing             |  scripting            | caffe2_tracing (DEPRECATED) |
++============================+=======================+=======================+=============================+
+| **Formats**                | TorchScript, ONNX     | TorchScript, ONNX     | Caffe2, TorchScript, ONNX   |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| **Runtime**                | PyTorch, ONNX Runtime | PyTorch, ONNX Runtime | Caffe2, PyTorch             |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| C++/Python inference       | ✅                     | ✅                     | ✅                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| Dynamic resolution         | ✅                     | ✅                     | ✅                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| Batch size requirement     | Constant              | Dynamic               | Batch inference unsupported |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| Extra runtime deps         | torchvision           | torchvision           | Caffe2 ops (usually already |
+|                            |                       |                       |                             |
+|                            |                       |                       | included in PyTorch)        |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| Faster/Mask/Keypoint R-CNN | ✅                     | ✅                     | ✅                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| RetinaNet                  | ✅                     | ✅                     | ✅                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| PointRend R-CNN            | ✅                     | ❌                     | ❌                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| Cascade R-CNN              | ✅                     | ❌                     | ❌                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
+| PanopticFPN                | ✅                     | ❌                     | ❌                           |
++----------------------------+-----------------------+-----------------------+-----------------------------+
 
 ```
 

--- a/docs/tutorials/deployment.md
+++ b/docs/tutorials/deployment.md
@@ -6,64 +6,74 @@ A few basic concepts about this process:
 __"Export method"__ is how a Python model is fully serialized to a deployable format.
 We support the following export methods:
 
-* `tracing`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it
-* `scripting`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it
+* `tracing`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it\
+This method produces a standardized ONNX graph that can be used by any ONNX runtime, such as \
+[ONNX Runtime](https://onnxruntime.ai/)
+* `scripting`: see [pytorch documentation](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) to learn about it\
+This method produces a standardized ONNX graph that can be used by any ONNX runtime, such as \
+[ONNX Runtime](https://onnxruntime.ai/)
 * `caffe2_tracing`: replace parts of the model by caffe2 operators, then use tracing.
+This method produces a Caffe2-specific ONNX graph that can be used only by the [Caffe2](https://caffe2.ai/).
+Caffe2 support has been ***DEPRECATED*** by PyTorch, therefore, we don't plan to support it, but contributions are welcome.
 
-__"Format"__ is how a serialized model is described in a file, e.g.
-TorchScript, Caffe2 protobuf, ONNX format.
+
+__"Format"__ is how a serialized model is stored in a file, e.g.
+TorchScript, ONNX format or Caffe2 protobuf. We don't plan to work on additional support for other formats, but contributions are welcome.
+
 __"Runtime"__ is an engine that loads a serialized model and executes it,
-e.g., PyTorch, Caffe2, TensorFlow, onnxruntime, TensorRT, etc.
+e.g., PyTorch, ONNX Runtime, TensorFlow, TensorRT, (DEPRECATED) Caffe2, etc.
 A runtime is often tied to a specific format
-(e.g. PyTorch needs TorchScript format, Caffe2 needs protobuf format).
+(e.g. PyTorch needs TorchScript format, ONNX Runtime requires ONNX format, (DEPRECATED) Caffe2 needs protobuf format).
 We currently support the following combination and each has some limitations:
 
 ```eval_rst
-+----------------------------+-------------+-------------+-----------------------------+
-|       Export Method        |   tracing   |  scripting  |       caffe2_tracing        |
-+============================+=============+=============+=============================+
-| **Formats**                | TorchScript | TorchScript | Caffe2, TorchScript, ONNX   |
-+----------------------------+-------------+-------------+-----------------------------+
-| **Runtime**                | PyTorch     | PyTorch     | Caffe2, PyTorch             |
-+----------------------------+-------------+-------------+-----------------------------+
-| C++/Python inference       | ✅          | ✅          | ✅                          |
-+----------------------------+-------------+-------------+-----------------------------+
-| Dynamic resolution         | ✅          | ✅          | ✅                          |
-+----------------------------+-------------+-------------+-----------------------------+
-| Batch size requirement     | Constant    | Dynamic     | Batch inference unsupported |
-+----------------------------+-------------+-------------+-----------------------------+
-| Extra runtime deps         | torchvision | torchvision | Caffe2 ops (usually already |
-|                            |             |             |                             |
-|                            |             |             | included in PyTorch)        |
-+----------------------------+-------------+-------------+-----------------------------+
-| Faster/Mask/Keypoint R-CNN | ✅          | ✅          | ✅                          |
-+----------------------------+-------------+-------------+-----------------------------+
-| RetinaNet                  | ✅          | ✅          | ✅                          |
-+----------------------------+-------------+-------------+-----------------------------+
-| PointRend R-CNN            | ✅          | ❌          | ❌                          |
-+----------------------------+-------------+-------------+-----------------------------+
-| Cascade R-CNN              | ✅          | ❌          | ❌                          |
-+----------------------------+-------------+-------------+-----------------------------+
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+|       Export Method        |   tracing   |  scripting  | tracing/scripting | caffe2_tracing (DEPRECATED) |
++============================+=============+=============+===================+=============================+
+| **Formats**                | TorchScript | TorchScript |       ONNX        | Caffe2, TorchScript, ONNX   |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| **Runtime**                | PyTorch     | PyTorch     |    ONNX Runtime   | Caffe2, PyTorch             |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| C++/Python inference       | ✅           | ✅           | ✅                 | ✅                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| Dynamic resolution         | ✅           | ✅           | ✅                 | ✅                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| Batch size requirement     | Constant    | Dynamic     | Dynamic           | Batch inference unsupported |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| Extra runtime deps         | torchvision | torchvision | torchvision       | Caffe2 ops (usually already |
+|                            |             |             |                   |                             |
+|                            |             |             |                   | included in PyTorch)        |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| Faster/Mask/Keypoint R-CNN | ✅           | ✅           | ✅                 | ✅                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| RetinaNet                  | ✅           | ✅           | ✅                 | ✅                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| PointRend R-CNN            | ✅           | ❌           | ✅                 | ❌                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| Cascade R-CNN              | ✅           | ❌           | ✅                 | ❌                           |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
+| PanopticFPN                | ✅           | N/A         | ✅                 | N/A                         |
++----------------------------+-------------+-------------+-------------------+-----------------------------+
 
 ```
 
-`caffe2_tracing` is going to be deprecated.
-We don't plan to work on additional support for other formats/runtime, but contributions are welcome.
-
-
 ## Deployment with Tracing or Scripting
 
-Models can be exported to TorchScript format, by either
+[//]: # (Make distinction between TorchScript and ONNX when ONNX Runtime is on CI)
+Models can be exported to TorchScript or ONNX format, by either
 [tracing or scripting](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html).
-The output model file can be loaded without detectron2 dependency in either Python or C++.
-The exported model often requires torchvision (or its C++ library) dependency for some custom ops.
+[ONNX format](https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html) can be used
+with both export methods.
+The output model file can be loaded without `detectron2` dependency in either Python or C++.
+The exported model often requires `torchvision` (or its C++ library) dependency for some custom ops.
 
 This feature requires PyTorch ≥ 1.8.
 
 ### Coverage
+
 Most official models under the meta architectures `GeneralizedRCNN` and `RetinaNet`
 are supported in both tracing and scripting mode.
-Cascade R-CNN and PointRend are currently supported in tracing.
+`Cascade R-CNN`, `PointRend` and `PanopticFPN` are currently supported in tracing.
 Users' custom extensions are supported if they are also scriptable or traceable.
 
 For models exported with tracing, dynamic input resolution is allowed, but batch size
@@ -81,15 +91,21 @@ Please check that these examples can run, and then modify for your use cases.
 The usage now requires some user effort and necessary knowledge for each model to workaround the limitation of scripting and tracing.
 In the future we plan to wrap these under simpler APIs to lower the bar to use them.
 
-## Deployment with Caffe2-tracing
+A quick example for using `tools/deploy/export_models.py` is:
+
+## (DEPRECATED) Deployment with Caffe2-tracing
+
 We provide [Caffe2Tracer](../modules/export.html#detectron2.export.Caffe2Tracer)
 that performs the export logic.
-It replaces parts of the model with Caffe2 operators,
+It replaces parts of the model with Caffe2 operators (which are not part of ONNX standard),
 and then export the model into Caffe2, TorchScript or ONNX format.
 
-The converted model is able to run in either Python or C++ without detectron2/torchvision dependency, on CPU or GPUs.
+The converted model is able to run in either Python or C++ without `detectron2`/`torchvision` dependency, on CPU or GPUs.
 It has a runtime optimized for CPU & mobile inference, but not optimized for GPU inference.
 
+Because Caffe2 has been deprecated, in order to run the model, [PyTorch](http://pytorch.org/) has to be
+[compiled from source](https://github.com/pytorch/pytorch#from-source) with the build flag `BUILD_CAFFE2=1`.
+There are no pre-built PyTorch packages with Caffe2 publicly available.
 This feature requires ONNX ≥ 1.6.
 
 ### Coverage
@@ -110,20 +126,29 @@ these APIs to convert a standard model. For custom models/datasets, you can add 
 ### Use the model in C++/Python
 
 The model can be loaded in C++ and deployed with
-either Caffe2 or Pytorch runtime.. [C++ examples](../../tools/deploy/) for Mask R-CNN
-are given as a reference. Note that:
+either [ONNX Runtime](https://onnxruntime.ai), or [Pytorch](https://pytorch.org) for models exported using
+tracing or scripting. The deprecated Caffe2 compiled from source can be used to deploy models exported
+using tracing, scripting or caffe2_tracing.
+Refer to [C++ examples](../../tools/deploy/) to checkout usage examples for Mask R-CNN.
 
-* Models exported with `caffe2_tracing` method take a special input format
-  described in [documentation](../modules/export.html#detectron2.export.Caffe2Tracer).
-  This was taken care of in the C++ example.
+Note that the converted models do not contain post-processing operations that
+transform raw layer outputs into formatted predictions.
+For example, the C++ examples only produce raw outputs (28x28 masks) from the final
+layers that are not post-processed, because in actual deployment, an application often needs
+its custom lightweight post-processing, so this step is left for users.
 
-* The converted models do not contain post-processing operations that
-  transform raw layer outputs into formatted predictions.
-  For example, the C++ examples only produce raw outputs (28x28 masks) from the final
-  layers that are not post-processed, because in actual deployment, an application often needs
-  its custom lightweight post-processing, so this step is left for users.
+#### (DEPRECATED) Caffe2 notes
 
-To help use the Caffe2-format model in python,
+For Models exported with `caffe2_tracing` method, note that:
+
+* The resulting model takes a special input format described in
+[documentation](../modules/export.html#detectron2.export.Caffe2Tracer).
+This was taken care of in the C++ example.
+
+* To run the model, a prebuilt PyTorch package (e.g. from `pip install torch`) cannot be used.
+Instead, you have to compile PyTorch from source with Caffe2 lib support.
+
+* To help using the Caffe2-format model in python,
 we provide a python wrapper around the converted model, in the
 [Caffe2Model.\_\_call\_\_](../modules/export.html#detectron2.export.Caffe2Model.__call__) method.
 This method has an interface that's identical to the [pytorch versions of models](./models.md),
@@ -132,6 +157,7 @@ This wrapper can serve as a reference for how to use Caffe2's python API,
 or for how to implement pre/post-processing in actual deployment.
 
 ## Conversion to TensorFlow
+
 [tensorpack Faster R-CNN](https://github.com/tensorpack/tensorpack/tree/master/examples/FasterRCNN/convert_d2)
-provides scripts to convert a few standard detectron2 R-CNN models to TensorFlow's pb format.
+provides scripts to convert a few standard `detectron2` R-CNN models to TensorFlow's pb format.
 It works by translating configs and weights, therefore only support a few models.


### PR DESCRIPTION
This PR extends `tools/deploy/export_model.py` with code to enable `PanopticFPN` to be exported to ONNX using tracing

It also improves `compatibility.md` and `deployment.md` with extra information about ONNX compatibility, while it also highlights the deprecation of Caffe2

Fixes https://github.com/facebookresearch/detectron2/issues/4354