### PR TITLE
Fix UserWarning for meshgrid in new pytorch versions

### DIFF
--- a/detectron2/modeling/anchor_generator.py
+++ b/detectron2/modeling/anchor_generator.py
@@ -49,7 +49,7 @@ def _create_grid_offsets(
         target_device_tensor,
     )
 
-    shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
+    shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x, indexing='ij')
     shift_x = shift_x.reshape(-1)
     shift_y = shift_y.reshape(-1)
     return shift_x, shift_y

--- a/detectron2/modeling/backbone/swin.py
+++ b/detectron2/modeling/backbone/swin.py
@@ -116,7 +116,7 @@ class WindowAttention(nn.Module):
         # get pair-wise relative position index for each token inside the window
         coords_h = torch.arange(self.window_size[0])
         coords_w = torch.arange(self.window_size[1])
-        coords = torch.stack(torch.meshgrid([coords_h, coords_w]))  # 2, Wh, Ww
+        coords = torch.stack(torch.meshgrid([coords_h, coords_w], indexing='ij'))  # 2, Wh, Ww
         coords_flatten = torch.flatten(coords, 1)  # 2, Wh*Ww
         relative_coords = coords_flatten[:, :, None] - coords_flatten[:, None, :]  # 2, Wh*Ww, Wh*Ww
         relative_coords = relative_coords.permute(1, 2, 0).contiguous()  # Wh*Ww, Wh*Ww, 2

--- a/projects/DensePose/densepose/modeling/losses/cycle_pix2shape.py
+++ b/projects/DensePose/densepose/modeling/losses/cycle_pix2shape.py
@@ -22,7 +22,7 @@ def _create_pixel_dist_matrix(grid_size: int) -> torch.Tensor:
     # row = i // grid_size
     # col = i % grid_size
     pix_coords = (
-        torch.stack(torch.meshgrid(rows, cols), -1).reshape((grid_size * grid_size, 2)).float()
+        torch.stack(torch.meshgrid(rows, cols, indexing='ij'), -1).reshape((grid_size * grid_size, 2)).float()
     )
     return squared_euclidean_distance_matrix(pix_coords, pix_coords)
 
@@ -128,7 +128,7 @@ class PixToShapeCycleLoss(nn.Module):
                 )
                 # pixel distances [M, M]
                 pixel_dists = self.pixel_dists.to(pixel_embeddings.device)[
-                    torch.meshgrid(pixel_indices_flattened, pixel_indices_flattened)
+                    torch.meshgrid(pixel_indices_flattened, pixel_indices_flattened, indexing='ij')
                 ]
                 # pixel embeddings [M, D]
                 pixel_embeddings_sampled = normalize_embeddings(

--- a/projects/DensePose/densepose/modeling/losses/cycle_shape2shape.py
+++ b/projects/DensePose/densepose/modeling/losses/cycle_shape2shape.py
@@ -87,7 +87,7 @@ class ShapeToShapeCycleLoss(nn.Module):
         geodists = mesh.geodists
         if indices is not None:
             embeddings = embeddings[indices]
-            geodists = geodists[torch.meshgrid(indices, indices)]
+            geodists = geodists[torch.meshgrid(indices, indices, indexing='ij')]
         return embeddings, geodists
 
     def _forward_one_pair(

--- a/projects/DensePose/tests/test_video_keyframe_dataset.py
+++ b/projects/DensePose/tests/test_video_keyframe_dataset.py
@@ -19,7 +19,7 @@ except ImportError:
 
 # copied from torchvision test/test_io.py
 def _create_video_frames(num_frames, height, width):
-    y, x = torch.meshgrid(torch.linspace(-2, 2, height), torch.linspace(-2, 2, width))
+    y, x = torch.meshgrid(torch.linspace(-2, 2, height), torch.linspace(-2, 2, width), indexing='ij')
     data = []
     for i in range(num_frames):
         xc = float(i) / num_frames

--- a/projects/Panoptic-DeepLab/panoptic_deeplab/post_processing.py
+++ b/projects/Panoptic-DeepLab/panoptic_deeplab/post_processing.py
@@ -60,6 +60,7 @@ def group_pixels(center_points, offsets):
     y_coord, x_coord = torch.meshgrid(
         torch.arange(height, dtype=offsets.dtype, device=offsets.device),
         torch.arange(width, dtype=offsets.dtype, device=offsets.device),
+        indexing='ij'
     )
     coord = torch.cat((y_coord.unsqueeze(0), x_coord.unsqueeze(0)), dim=0)
 

--- a/projects/TensorMask/tensormask/arch.py
+++ b/projects/TensorMask/tensormask/arch.py
@@ -261,7 +261,7 @@ class TensorMaskAnchorGenerator(DefaultAnchorGenerator):
             shifts_h = torch.arange(0, grid_height, dtype=torch.int64, device=device)
             shifts_w = torch.arange(0, grid_width, dtype=torch.int64, device=device)
             shifts_a = torch.arange(0, base_anchors.shape[0], dtype=torch.int64, device=device)
-            grids = torch.meshgrid(shifts_l, shifts_i, shifts_h, shifts_w, shifts_a)
+            grids = torch.meshgrid(shifts_l, shifts_i, shifts_h, shifts_w, shifts_a, indexing='ij')
 
             indexes.append(torch.stack(grids, dim=5).view(-1, 5))
 

--- a/tests/layers/test_mask_ops.py
+++ b/tests/layers/test_mask_ops.py
@@ -44,7 +44,7 @@ def rasterize_polygons_with_grid_sample(full_image_bit_mask, box, mask_size, thr
 
     mask_x = (mask_x - 0.5) / (img_w - 1) * 2 + -1
     mask_y = (mask_y - 0.5) / (img_h - 1) * 2 + -1
-    gy, gx = torch.meshgrid(torch.from_numpy(mask_y), torch.from_numpy(mask_x))
+    gy, gx = torch.meshgrid(torch.from_numpy(mask_y), torch.from_numpy(mask_x), indexing='ij')
     ind = torch.stack([gx, gy], dim=-1).to(dtype=torch.float32)
 
     full_image_bit_mask = torch.from_numpy(full_image_bit_mask)


### PR DESCRIPTION
To eliminate the UserWarning in Pytorch>1.10.0

For more detail please see: 
https://pytorch.org/docs/stable/generated/torch.meshgrid.html#torch.meshgrid