### PR TITLE
Add cfg.SOLVER.NUM_DECAYS in the default config

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -541,6 +541,8 @@ _C.SOLVER.WEIGHT_DECAY_NORM = 0.0
 _C.SOLVER.GAMMA = 0.1
 # The iteration number to decrease learning rate by GAMMA.
 _C.SOLVER.STEPS = (30000,)
+# Number of decays in WarmupStepWithFixedGammaLR schedule
+_C.SOLVER.NUM_DECAYS = 600
 
 _C.SOLVER.WARMUP_FACTOR = 1.0 / 1000
 _C.SOLVER.WARMUP_ITERS = 1000


### PR DESCRIPTION
Summary: cfg.SOLVER.NUM_DECAYS is needed for the WarmupStepWithFixedGammaLR schedule.

Differential Revision: D39363550

