### PR TITLE
Fix PyTorch Rounding UserWarning

### DIFF
--- a/projects/PointRend/point_rend/point_features.py
+++ b/projects/PointRend/point_rend/point_features.py
@@ -139,7 +139,7 @@ def get_uncertain_point_coords_on_grid(uncertainty_map, num_points):
     point_indices = torch.topk(uncertainty_map.view(R, H * W), k=num_points, dim=1)[1]
     point_coords = torch.zeros(R, num_points, 2, dtype=torch.float, device=uncertainty_map.device)
     point_coords[:, :, 0] = w_step / 2.0 + (point_indices % W).to(torch.float) * w_step
-    point_coords[:, :, 1] = h_step / 2.0 + (point_indices // W).to(torch.float) * h_step
+    point_coords[:, :, 1] = h_step / 2.0 + (torch.div(point_indices, W, rounding_mode='trunc')).to(torch.float) * h_step
     return point_indices, point_coords
 
 


### PR DESCRIPTION
**Fixed User Warning:**
detectron2/projects/point_rend/point_features.py:142: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  point_coords[:, :, 1] = h_step / 2.0 + (point_indices // W).to(torch.float) * h_step

Replaced the original line 142

```point_coords[:, :, 1] = h_step / 2.0 + (point_indices // W).to(torch.float) * h_step```

with 

```point_coords[:, :, 1] = h_step / 2.0 + (torch.div(point_indices, W, rounding_mode='trunc')).to(torch.float) * h_step```. 

Warning appears during inference when using a model trained with the PointRend mask head.
