### PR TITLE
use py3.9 for linter CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,10 +10,10 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         # flake8-bugbear flake8-comprehensions are useful but not available internally
         run: |


### PR DESCRIPTION
Summary:
linter failed to run: https://github.com/facebookresearch/detectron2/actions/runs/3348881377/jobs/5548693962

Similar issue: https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean, suggest using Python3.9

Differential Revision: D40822952

