### PR TITLE
support specifying matching_heuristics from filename

### DIFF
--- a/detectron2/utils/file_io.py
+++ b/detectron2/utils/file_io.py
@@ -1,4 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import os
+from urllib.parse import urlparse
 from iopath.common.file_io import HTTPURLHandler, OneDrivePathHandler, PathHandler
 from iopath.common.file_io import PathManager as PathManagerBase
 
@@ -25,11 +27,16 @@ class Detectron2Handler(PathHandler):
         return [self.PREFIX]
 
     def _get_local_path(self, path, **kwargs):
+        parsed_url = urlparse(path)
+        path = parsed_url._replace(query="").geturl()  # remove query from path
         name = path[len(self.PREFIX) :]
         return PathManager.get_local_path(self.S3_DETECTRON2_PREFIX + name, **kwargs)
 
     def _open(self, path, mode="r", **kwargs):
         return PathManager.open(self._get_local_path(path), mode, **kwargs)
+
+    def _isfile(self, path: str, **kwargs):
+        return os.path.isfile(self._get_local_path(path))
 
 
 PathManager.register_handler(HTTPURLHandler())

--- a/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_h_75ep.py
+++ b/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_h_75ep.py
@@ -9,7 +9,9 @@ from .cascade_mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_l_100ep.py
@@ -9,7 +9,9 @@ from .cascade_mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_b_100ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_b_100ep.py
@@ -15,7 +15,9 @@ model = model_zoo.get_config("common/models/mask_rcnn_vitdet.py").model
 train = model_zoo.get_config("common/train.py").train
 train.amp.enabled = True
 train.ddp.fp16_compression = True
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_base.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_base.pth?matching_heuristics=True"
+)
 
 
 # Schedule

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_h_75ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_h_75ep.py
@@ -9,7 +9,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_l_100ep.py
@@ -9,7 +9,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24

--- a/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_h_100ep.py
+++ b/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_h_100ep.py
@@ -10,7 +10,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     optimizer,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_l_100ep.py
@@ -10,7 +10,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     optimizer,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24


### PR DESCRIPTION
Summary:
D35519683 (https://github.com/facebookresearch/detectron2/commit/0ad20f13e23f2f4454be6196c1cd38e2171b294c) changed the default `matching_heuristics` from `False` to `True`, it may cause some issues:
- potential bug report: https://fb.workplace.com/groups/2240361332735959/posts/5264606250311437/?comment_id=5265167493588646
- bloated logging: https://github.com/facebookresearch/detectron2/issues/4364

This diff reverts the default value back to `False`, and introduce a way to specify this option via filename url.

Differential Revision: D41145857

