### PR TITLE
MinIoURandomCrop augmentation in d2go for detection models

### DIFF
--- a/detectron2/data/detection_utils.py
+++ b/detectron2/data/detection_utils.py
@@ -254,6 +254,19 @@ def transform_proposals(dataset_dict, image_shape, transforms, *, proposal_topk,
         dataset_dict["proposals"] = proposals
 
 
+def get_bbox(annotation):
+    """
+    Get bbox from data
+    Args:
+        annotation (dict): dict of instance annotations for a single instance.
+    Returns:
+        bbox (ndarray): x1, y1, x2, y2 coordinates
+    """
+    # bbox is 1d (per-instance bounding box)
+    bbox = BoxMode.convert(annotation["bbox"], annotation["bbox_mode"], BoxMode.XYXY_ABS)
+    return bbox
+
+
 def transform_instance_annotations(
     annotation, transforms, image_size, *, keypoint_hflip_indices=None
 ):

--- a/detectron2/data/transforms/augmentation_impl.py
+++ b/detectron2/data/transforms/augmentation_impl.py
@@ -5,6 +5,7 @@ Implement many useful :class:`Augmentation`.
 """
 import numpy as np
 import sys
+from numpy import random
 from typing import Tuple
 import torch
 from fvcore.transforms.transform import (
@@ -18,6 +19,8 @@ from fvcore.transforms.transform import (
     VFlipTransform,
 )
 from PIL import Image
+
+from detectron2.structures import Boxes, pairwise_iou
 
 from .augmentation import Augmentation, _transform_to_aug
 from .transform import ExtentTransform, ResizeTransform, RotationTransform
@@ -38,6 +41,7 @@ __all__ = [
     "ResizeShortestEdge",
     "RandomCrop_CategoryAreaConstraint",
     "RandomResize",
+    "MinIoURandomCrop",
 ]
 
 
@@ -645,3 +649,91 @@ class RandomResize(Augmentation):
         shape_idx = np.random.randint(low=0, high=len(self.shape_list))
         h, w = self.shape_list[shape_idx]
         return ResizeTransform(image.shape[0], image.shape[1], h, w, self.interp)
+
+
+class MinIoURandomCrop(Augmentation):
+    """Random crop the image & bboxes, the cropped patches have minimum IoU
+    requirement with original image & bboxes, the IoU threshold is randomly
+    selected from min_ious.
+
+    Args:
+        min_ious (tuple): minimum IoU threshold for all intersections with
+        bounding boxes
+        min_crop_size (float): minimum crop's size (i.e. h,w := a*h, a*w,
+        where a >= min_crop_size).
+    """
+
+    def __init__(
+        self,
+        min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
+        min_crop_size=0.3,
+        mode_trials=1000,
+        crop_trials=50,
+    ):
+        # 1: return ori img
+        self.min_ious = min_ious
+        self.sample_mode = (1, *min_ious, 0)
+        self.min_crop_size = min_crop_size
+        self.mode_trials = mode_trials
+        self.crop_trials = crop_trials
+
+    def get_transform(self, image, boxes):
+        """Call function to crop images and bounding boxes with minimum IoU
+        constraint.
+
+        Args:
+            results (dict): Result dict from loading pipeline.
+
+        Returns:
+            dict: Result dict with images and bounding boxes cropped, \
+                'img_shape' key is updated.
+        """
+        if boxes is None:
+            return NoOpTransform()
+        h, w, c = image.shape
+        for _ in range(self.mode_trials):
+            mode = random.choice(self.sample_mode)
+            self.mode = mode
+            if mode == 1:
+                return NoOpTransform()
+
+            min_iou = mode
+            for _ in range(self.crop_trials):
+                new_w = random.uniform(self.min_crop_size * w, w)
+                new_h = random.uniform(self.min_crop_size * h, h)
+
+                # h / w in [0.5, 2]
+                if new_h / new_w < 0.5 or new_h / new_w > 2:
+                    continue
+
+                left = random.uniform(w - new_w)
+                top = random.uniform(h - new_h)
+
+                patch = np.array((int(left), int(top), int(left + new_w), int(top + new_h)))
+                # Line or point crop is not allowed
+                if patch[2] == patch[0] or patch[3] == patch[1]:
+                    continue
+                overlaps = pairwise_iou(
+                    Boxes(patch.reshape(-1, 4)), Boxes(boxes.reshape(-1, 4))
+                ).reshape(-1)
+                if len(overlaps) > 0 and overlaps.min() < min_iou:
+                    continue
+
+                # center of boxes should inside the crop img
+                # only adjust boxes and instance masks when the gt is not empty
+                if len(overlaps) > 0:
+                    # adjust boxes
+                    def is_center_of_bboxes_in_patch(boxes, patch):
+                        center = (boxes[:, :2] + boxes[:, 2:]) / 2
+                        mask = (
+                            (center[:, 0] > patch[0])
+                            * (center[:, 1] > patch[1])
+                            * (center[:, 0] < patch[2])
+                            * (center[:, 1] < patch[3])
+                        )
+                        return mask
+
+                    mask = is_center_of_bboxes_in_patch(boxes, patch)
+                    if not mask.any():
+                        continue
+                return CropTransform(int(left), int(top), int(new_w), int(new_h))


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/d2go/pull/443

Add MinIoURandomCrop augmentation.
Example of aug
<img width="423" alt="Screenshot 2022-12-12 at 16 49 46" src="https://user-images.githubusercontent.com/16614162/207157618-32b77a1f-e5b0-4c72-a202-3e173b4b622c.png">
<img width="400" alt="Screenshot 2022-12-12 at 16 49 55" src="https://user-images.githubusercontent.com/16614162/207157627-99fa0b46-8aff-4ea9-970e-afde71a7ea5b.png">
<img width="255" alt="Screenshot 2022-12-12 at 16 50 05" src="https://user-images.githubusercontent.com/16614162/207157631-a815ccbc-2daf-45f3-a33b-37a58298283e.png">

Data overhead is around 0.04 sec

Differential Revision: D41804643

