### PR TITLE
Remove black from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,6 @@ setup(
         "dataclasses; python_version<'3.7'",
         "omegaconf>=2.1",
         "hydra-core>=1.1",
-        "black",
         "timm",
         "packaging",
         # NOTE: When adding new dependencies, if it is required at import time (in addition


### PR DESCRIPTION
Slim down the set of required dependencies. Removes `black` from `install_requires`: it is already listed as an optional dev dependency for detectron2.

