### PR TITLE
update to use torch.optim.lr_scheduler.LRScheduler

### DIFF
--- a/detectron2/engine/hooks.py
+++ b/detectron2/engine/hooks.py
@@ -21,6 +21,7 @@ from fvcore.nn.precise_bn import get_bn_modules, update_bn_stats
 import detectron2.utils.comm as comm
 from detectron2.evaluation.testing import flatten_results_dict
 from detectron2.solver import LRMultiplier
+from detectron2.solver import LRScheduler as _LRScheduler
 from detectron2.utils.events import EventStorage, EventWriter
 from detectron2.utils.file_io import PathManager
 
@@ -362,12 +363,12 @@ class LRScheduler(HookBase):
         return self._scheduler or self.trainer.scheduler
 
     def state_dict(self):
-        if isinstance(self.scheduler, torch.optim.lr_scheduler._LRScheduler):
+        if isinstance(self.scheduler, _LRScheduler):
             return self.scheduler.state_dict()
         return {}
 
     def load_state_dict(self, state_dict):
-        if isinstance(self.scheduler, torch.optim.lr_scheduler._LRScheduler):
+        if isinstance(self.scheduler, _LRScheduler):
             logger = logging.getLogger(__name__)
             logger.info("Loading scheduler from state_dict ...")
             self.scheduler.load_state_dict(state_dict)

--- a/detectron2/solver/__init__.py
+++ b/detectron2/solver/__init__.py
@@ -1,5 +1,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from .build import build_lr_scheduler, build_optimizer, get_default_optimizer_params
-from .lr_scheduler import WarmupCosineLR, WarmupMultiStepLR, LRMultiplier, WarmupParamScheduler
+from .lr_scheduler import (
+    LRMultiplier,
+    LRScheduler,
+    WarmupCosineLR,
+    WarmupMultiStepLR,
+    WarmupParamScheduler,
+)
 
 __all__ = [k for k in globals().keys() if not k.startswith("_")]

--- a/detectron2/solver/build.py
+++ b/detectron2/solver/build.py
@@ -15,7 +15,7 @@ from fvcore.common.param_scheduler import (
 from detectron2.config import CfgNode
 from detectron2.utils.env import TORCH_VERSION
 
-from .lr_scheduler import LRMultiplier, WarmupParamScheduler
+from .lr_scheduler import LRMultiplier, LRScheduler, WarmupParamScheduler
 
 _GradientClipperInput = Union[torch.Tensor, Iterable[torch.Tensor]]
 _GradientClipper = Callable[[_GradientClipperInput], None]
@@ -267,9 +267,7 @@ def reduce_param_groups(params: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return ret
 
 
-def build_lr_scheduler(
-    cfg: CfgNode, optimizer: torch.optim.Optimizer
-) -> torch.optim.lr_scheduler._LRScheduler:
+def build_lr_scheduler(cfg: CfgNode, optimizer: torch.optim.Optimizer) -> LRScheduler:
     """
     Build a LR scheduler from config.
     """

--- a/detectron2/solver/lr_scheduler.py
+++ b/detectron2/solver/lr_scheduler.py
@@ -11,6 +11,11 @@ from fvcore.common.param_scheduler import (
     ParamScheduler,
 )
 
+try:
+    from torch.optim.lr_scheduler import LRScheduler
+except ImportError:
+    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,7 +57,7 @@ class WarmupParamScheduler(CompositeParamScheduler):
         )
 
 
-class LRMultiplier(torch.optim.lr_scheduler._LRScheduler):
+class LRMultiplier(LRScheduler):
     """
     A LRScheduler which uses fvcore :class:`ParamScheduler` to multiply the
     learning rate of each param in the optimizer.
@@ -95,7 +100,7 @@ class LRMultiplier(torch.optim.lr_scheduler._LRScheduler):
     ):
         """
         Args:
-            optimizer, last_iter: See ``torch.optim.lr_scheduler._LRScheduler``.
+            optimizer, last_iter: See ``torch.optim.lr_scheduler.LRScheduler``.
                 ``last_iter`` is the same as ``last_epoch``.
             multiplier: a fvcore ParamScheduler that defines the multiplier on
                 every LR of the optimizer
@@ -132,7 +137,7 @@ Content below is no longer needed!
 # MultiStepLR with WarmupLR but the current LRScheduler design doesn't allow it.
 
 
-class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
+class WarmupMultiStepLR(LRScheduler):
     def __init__(
         self,
         optimizer: torch.optim.Optimizer,
@@ -171,7 +176,7 @@ class WarmupMultiStepLR(torch.optim.lr_scheduler._LRScheduler):
         return self.get_lr()
 
 
-class WarmupCosineLR(torch.optim.lr_scheduler._LRScheduler):
+class WarmupCosineLR(LRScheduler):
     def __init__(
         self,
         optimizer: torch.optim.Optimizer,

--- a/detectron2/utils/file_io.py
+++ b/detectron2/utils/file_io.py
@@ -1,4 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import os
+from urllib.parse import urlparse
 from iopath.common.file_io import HTTPURLHandler, OneDrivePathHandler, PathHandler
 from iopath.common.file_io import PathManager as PathManagerBase
 
@@ -25,11 +27,16 @@ class Detectron2Handler(PathHandler):
         return [self.PREFIX]
 
     def _get_local_path(self, path, **kwargs):
+        parsed_url = urlparse(path)
+        path = parsed_url._replace(query="").geturl()  # remove query from path
         name = path[len(self.PREFIX) :]
         return PathManager.get_local_path(self.S3_DETECTRON2_PREFIX + name, **kwargs)
 
     def _open(self, path, mode="r", **kwargs):
         return PathManager.open(self._get_local_path(path), mode, **kwargs)
+
+    def _isfile(self, path: str, **kwargs):
+        return os.path.isfile(self._get_local_path(path))
 
 
 PathManager.register_handler(HTTPURLHandler())

--- a/projects/DeepLab/deeplab/build_solver.py
+++ b/projects/DeepLab/deeplab/build_solver.py
@@ -2,14 +2,13 @@
 import torch
 
 from detectron2.config import CfgNode
+from detectron2.solver import LRScheduler
 from detectron2.solver import build_lr_scheduler as build_d2_lr_scheduler
 
 from .lr_scheduler import WarmupPolyLR
 
 
-def build_lr_scheduler(
-    cfg: CfgNode, optimizer: torch.optim.Optimizer
-) -> torch.optim.lr_scheduler._LRScheduler:
+def build_lr_scheduler(cfg: CfgNode, optimizer: torch.optim.Optimizer) -> LRScheduler:
     """
     Build a LR scheduler from config.
     """

--- a/projects/DeepLab/deeplab/lr_scheduler.py
+++ b/projects/DeepLab/deeplab/lr_scheduler.py
@@ -3,7 +3,7 @@ import math
 from typing import List
 import torch
 
-from detectron2.solver.lr_scheduler import _get_warmup_factor_at_iter
+from detectron2.solver.lr_scheduler import LRScheduler, _get_warmup_factor_at_iter
 
 # NOTE: PyTorch's LR scheduler interface uses names that assume the LR changes
 # only on epoch boundaries. We typically use iteration based schedules instead.
@@ -14,7 +14,7 @@ from detectron2.solver.lr_scheduler import _get_warmup_factor_at_iter
 # MultiStepLR with WarmupLR but the current LRScheduler design doesn't allow it.
 
 
-class WarmupPolyLR(torch.optim.lr_scheduler._LRScheduler):
+class WarmupPolyLR(LRScheduler):
     """
     Poly learning rate schedule used to train DeepLab.
     Paper: DeepLab: Semantic Image Segmentation with Deep Convolutional Nets,

--- a/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_h_75ep.py
+++ b/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_h_75ep.py
@@ -9,7 +9,9 @@ from .cascade_mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/COCO/cascade_mask_rcnn_vitdet_l_100ep.py
@@ -9,7 +9,9 @@ from .cascade_mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_b_100ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_b_100ep.py
@@ -15,7 +15,9 @@ model = model_zoo.get_config("common/models/mask_rcnn_vitdet.py").model
 train = model_zoo.get_config("common/train.py").train
 train.amp.enabled = True
 train.ddp.fp16_compression = True
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_base.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_base.pth?matching_heuristics=True"
+)
 
 
 # Schedule

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_h_75ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_h_75ep.py
@@ -9,7 +9,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/COCO/mask_rcnn_vitdet_l_100ep.py
@@ -9,7 +9,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     get_vit_lr_decay_rate,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24

--- a/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_h_100ep.py
+++ b/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_h_100ep.py
@@ -10,7 +10,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     optimizer,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_huge_p14to16.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1280
 model.backbone.net.depth = 32

--- a/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_l_100ep.py
+++ b/projects/ViTDet/configs/LVIS/mask_rcnn_vitdet_l_100ep.py
@@ -10,7 +10,9 @@ from .mask_rcnn_vitdet_b_100ep import (
     optimizer,
 )
 
-train.init_checkpoint = "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth"
+train.init_checkpoint = (
+    "detectron2://ImageNetPretrained/MAE/mae_pretrain_vit_large.pth?matching_heuristics=True"
+)
 
 model.backbone.net.embed_dim = 1024
 model.backbone.net.depth = 24


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/88503 introduces the public version `LRScheduler`, however `isinstance(self.scheduler, torch.optim.lr_scheduler._LRScheduler)` doesn't work anymore because of https://github.com/pytorch/pytorch/blob/1ea11ecb2eea99eb552603b7cf5fbfc59659832d/torch/optim/lr_scheduler.py#L166-L169, if the schedule is inherited from the public version.

It's a bit tricky to make it BC compatible for torch version <= 1.13. V1 of this diff uses try catch block to import the `LRScheduler` and make it available in `detectron2.solver`, then the whole D2 uses this version of `LRScheduler`. There're two drawbacks though:
- it adds a little mental burden to figure out what's D2 (https://github.com/facebookresearch/detectron2/commit/11528ce083dc9ff83ee3a8f9086a1ef54d2a402f)'s `LRScheduler`, previously it's clear that the `LRScheduler`/`_LRScheduler` is from `torch`.
- it has a name collision with `hooks.LRScheduler`, eg. in the `hooks.py` I have to do `LRScheduler as _LRScheduler`.

But I couldn't found a better solution, maybe use try catch block in every file?

Differential Revision: D42111273

