### PR TITLE
Color tuple forced to stay within 0.0 - 1.0 range

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -875,6 +875,9 @@ class Visualizer:
             font_size = self._default_font_size
 
         # since the text background is dark, we don't want the text to be dark
+        color = np.array(color)
+        color = tuple(np.where(color > 1.0, 1.0, color))
+
         color = np.maximum(list(mplc.to_rgb(color)), 0.2)
         color[np.argmax(color)] = max(0.8, np.max(color))
 


### PR DESCRIPTION
Earlier, values in the `color` tuple were being greater than 1.0:
![image](https://user-images.githubusercontent.com/52484751/210384371-58fb07e7-8392-4d01-a5f7-4190257ee7ca.png)
This was leading to the following error:
![image](https://user-images.githubusercontent.com/52484751/210384805-c4507858-9d65-4110-806f-40818fd09ea2.png)
This minor fix did the trick!