### PR TITLE
fix: rename load method to __load

### DIFF
--- a/detectron2/checkpoint/detection_checkpoint.py
+++ b/detectron2/checkpoint/detection_checkpoint.py
@@ -31,7 +31,7 @@ class DetectionCheckpointer(Checkpointer):
         self.path_manager = PathManager
         self._parsed_url_during_load = None
 
-    def load(self, path, *args, **kwargs):
+    def __load(self, path, *args, **kwargs):
         assert self._parsed_url_during_load is None
         need_sync = False
         logger = logging.getLogger(__name__)

--- a/detectron2/engine/defaults.py
+++ b/detectron2/engine/defaults.py
@@ -285,7 +285,7 @@ class DefaultPredictor:
             self.metadata = MetadataCatalog.get(cfg.DATASETS.TEST[0])
 
         checkpointer = DetectionCheckpointer(self.model)
-        checkpointer.load(cfg.MODEL.WEIGHTS)
+        checkpointer.__load(cfg.MODEL.WEIGHTS)
 
         self.aug = T.ResizeShortestEdge(
             [cfg.INPUT.MIN_SIZE_TEST, cfg.INPUT.MIN_SIZE_TEST], cfg.INPUT.MAX_SIZE_TEST

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -59,11 +59,11 @@ class TestCheckpointer(unittest.TestCase):
                 model.block1.layer1.weight.fill_(1)
 
             # load checkpoint without matching_heuristics
-            checkpointer.load(os.path.join(d, "checkpoint.pth"))
+            checkpointer._load(os.path.join(d, "checkpoint.pth"))
             self.assertTrue(model.block1.layer1.weight.equal(torch.ones(3, 2)))
 
             # load checkpoint with matching_heuristics
-            checkpointer.load(os.path.join(d, "checkpoint.pth?matching_heuristics=True"))
+            checkpointer._load(os.path.join(d, "checkpoint.pth?matching_heuristics=True"))
             self.assertFalse(model.block1.layer1.weight.equal(torch.ones(3, 2)))
 
     def test_custom_path_manager_handler(self):
@@ -89,8 +89,8 @@ class TestCheckpointer(unittest.TestCase):
             torch.save({"model": state_dict}, os.path.join(d, "checkpoint.pth"))
             checkpointer = DetectionCheckpointer(model, save_dir=d)
             checkpointer.path_manager = pathmgr
-            checkpointer.load("detectron2_test://checkpoint.pth")
-            checkpointer.load("detectron2_test://checkpoint.pth?matching_heuristics=True")
+            checkpointer._load("detectron2_test://checkpoint.pth")
+            checkpointer._load("detectron2_test://checkpoint.pth?matching_heuristics=True")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
rename the method to fix a name collision bug between Classes "DetectionCheckpointer" and "Checkpointer"

resolves: https://github.com/Layout-Parser/layout-parser/issues/168