### PR TITLE
Remove unused onnx.optimizer

### DIFF
--- a/detectron2/export/caffe2_export.py
+++ b/detectron2/export/caffe2_export.py
@@ -6,7 +6,6 @@ import logging
 import numpy as np
 from typing import List
 import onnx
-import onnx.optimizer
 import torch
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core


### PR DESCRIPTION
onnx.optimizer import is currently unused in this file. Optimizer API was recently removed from ONNX, so this unused import blocks migration to newer ONNX versions.