### PR TITLE
fix typo in docstring

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -537,7 +537,7 @@ class Visualizer:
 
     def draw_dataset_dict(self, dic):
         """
-        Draw annotations/segmenations in Detectron2 Dataset format.
+        Draw annotations/segmentations in Detectron2 Dataset format.
 
         Args:
             dic (dict): annotation/segmentation data of one image, in Detectron2 Dataset format.

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -537,7 +537,7 @@ class Visualizer:
 
     def draw_dataset_dict(self, dic):
         """
-        Draw annotations/segmentaions in Detectron2 Dataset format.
+        Draw annotations/segmenations in Detectron2 Dataset format.
 
         Args:
             dic (dict): annotation/segmentation data of one image, in Detectron2 Dataset format.


### PR DESCRIPTION
Fix a simply typo in the doc string of Visualizer.draw_dataset_dict