### PR TITLE
skip opencv version 4.7.0.68 in for linux circleCI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ install_linux_dep: &install_linux_dep
         pip install --progress-bar off -U 'git+https://github.com/facebookresearch/iopath'
         pip install --progress-bar off -U 'git+https://github.com/facebookresearch/fvcore'
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
-        pip install --progress-bar off ninja opencv-python-headless pytest tensorboard pycocotools onnx
+        # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
+        pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
         pip install --progress-bar off torch==$PYTORCH_VERSION -f $PYTORCH_INDEX
         if [[ "$TORCHVISION_VERSION" == "master" ]]; then
           pip install git+https://github.com/pytorch/vision.git


### PR DESCRIPTION
Summary:
Related issue: https://github.com/opencv/opencv-python/issues/765

It seems that the fix won't add to the regular pypi release very soon (https://pypi.org/project/opencv-python/#history), skip this version in our config.

Differential Revision: D42859319

