### PR TITLE
Let Detectron2Handler.open open the URL directly without downloading

### DIFF
--- a/detectron2/utils/file_io.py
+++ b/detectron2/utils/file_io.py
@@ -29,7 +29,7 @@ class Detectron2Handler(PathHandler):
         return PathManager.get_local_path(self.S3_DETECTRON2_PREFIX + name, **kwargs)
 
     def _open(self, path, mode="r", **kwargs):
-        return PathManager.open(self._get_local_path(path), mode, **kwargs)
+        return PathManager.open(self.S3_DETECTRON2_PREFIX + path[len(self.PREFIX):], mode, **kwargs)
 
 
 PathManager.register_handler(HTTPURLHandler())

--- a/detectron2/utils/file_io.py
+++ b/detectron2/utils/file_io.py
@@ -29,7 +29,9 @@ class Detectron2Handler(PathHandler):
         return PathManager.get_local_path(self.S3_DETECTRON2_PREFIX + name, **kwargs)
 
     def _open(self, path, mode="r", **kwargs):
-        return PathManager.open(self.S3_DETECTRON2_PREFIX + path[len(self.PREFIX):], mode, **kwargs)
+        return PathManager.open(
+            self.S3_DETECTRON2_PREFIX + path[len(self.PREFIX) :], mode, **kwargs
+        )
 
 
 PathManager.register_handler(HTTPURLHandler())


### PR DESCRIPTION
This is currently a no-op, because `S3_DETECTRON2_PREFIX` is on http and `open()` of http URL will download anyway.

However, our internal version uses an env module (similar to `detecton2.fb.env:setup_environment()`) that sets `S3_DETECTRON2_PREFIX` to something not on http. In that case this change would help.