### PR TITLE
Add an option to specify the period of metric aggregating and writing in Trainer

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -232,13 +232,15 @@ class SimpleTrainer(TrainerBase):
     or write your own training loop.
     """
 
-    def __init__(self, model, data_loader, optimizer):
+    def __init__(self, model, data_loader, optimizer, gather_metric_period=1):
         """
         Args:
             model: a torch Module. Takes a data from data_loader and returns a
                 dict of losses.
             data_loader: an iterable. Contains data to be used to call model.
             optimizer: a torch optimizer.
+            gather_metric_period: an int. Every gather_metric_period iterations
+                the metrics are gathered from all the ranks to rank 0 and logged.
         """
         super().__init__()
 
@@ -255,6 +257,7 @@ class SimpleTrainer(TrainerBase):
         # to access the data loader iterator, call `self._data_loader_iter`
         self._data_loader_iter_obj = None
         self.optimizer = optimizer
+        self.gather_metric_period = gather_metric_period
 
     def run_step(self):
         """
@@ -317,7 +320,8 @@ class SimpleTrainer(TrainerBase):
         data_time: float,
         prefix: str = "",
     ) -> None:
-        SimpleTrainer.write_metrics(loss_dict, data_time, prefix)
+        if (self.iter + 1) % self.gather_metric_period == 0:
+            SimpleTrainer.write_metrics(loss_dict, data_time, prefix)
 
     @staticmethod
     def write_metrics(
@@ -383,6 +387,7 @@ class AMPTrainer(SimpleTrainer):
         model,
         data_loader,
         optimizer,
+        gather_metric_period=1,
         grad_scaler=None,
         precision: torch.dtype = torch.float16,
     ):
@@ -397,7 +402,7 @@ class AMPTrainer(SimpleTrainer):
             assert not (model.device_ids and len(model.device_ids) > 1), unsupported
         assert not isinstance(model, DataParallel), unsupported
 
-        super().__init__(model, data_loader, optimizer)
+        super().__init__(model, data_loader, optimizer, gather_metric_period)
 
         if grad_scaler is None:
             from torch.cuda.amp import GradScaler

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -93,6 +93,45 @@ class TestTrainer(unittest.TestCase):
 
             self.assertIn("eta: 0:00:00", logs.output[-1], "Last ETA must be 0!")
 
+    def test_metric_gather_and_write(self):
+        gather_metric_period = 5
+        writer_period = 10
+
+        model = _SimpleModel(sleep_sec=0.1)
+        trainer = SimpleTrainer(
+            model,
+            self._data_loader("cpu"),
+            torch.optim.SGD(model.parameters(), 0.1),
+            gather_metric_period=gather_metric_period,
+        )
+
+        max_iter = 50
+        with tempfile.TemporaryDirectory(prefix="detectron2_test") as d:
+            json_file = os.path.join(d, "metrics.json")
+            writers = [JSONWriter(json_file, window_size=writer_period)]
+
+            trainer.register_hooks(
+                [
+                    hooks.IterationTimer(),
+                    hooks.PeriodicWriter(writers, period=writer_period),
+                ]
+            )
+            trainer.train(0, max_iter)
+
+            with open(json_file, "r") as f:
+                data = [json.loads(line.strip()) for line in f]
+                self.assertEqual([x["iteration"] for x in data], [9, 19, 29, 39, 49])
+                self.assertEqual(len(trainer.storage.history("time")._data), 48)
+                for key in ["data_time", "total_loss"]:
+                    history = trainer.storage.history(key)._data
+                    history_iters = [h[1] for h in history]
+                    self.assertEqual(history_iters, [4, 9, 14, 19, 24, 29, 34, 39, 44, 49])
+                    for i in range(len(data)):
+                        # written metric should equal to the median of 2 most recent logged metrics
+                        logged1, logged2 = history[2 * i][0], history[2 * i + 1][0]
+                        gt = data[i][key]
+                        self.assertEqual(gt, (logged1 + logged2) / 2.0)
+
     def test_default_trainer(self):
         # TODO: this test requires manifold access, so changed device to CPU. see: T88318502
         cfg = get_cfg()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -62,3 +62,28 @@ class TestEventWriter(unittest.TestCase):
             with self.assertLogs("detectron2.utils.events") as logs:
                 p2.write()
             self.assertNotIn("eta", logs.output[0])
+
+    def testSmoothingWithWindowSize(self):
+        with tempfile.TemporaryDirectory(
+            prefix="detectron2_tests"
+        ) as dir, EventStorage() as storage:
+            json_file = os.path.join(dir, "test.json")
+            writer = JSONWriter(json_file, window_size=10)
+            for k in range(20):
+                storage.put_scalar("key1", k, smoothing_hint=True)
+                if (k + 1) % 2 == 0:
+                    storage.put_scalar("key2", k, smoothing_hint=True)
+                if (k + 1) % 5 == 0:
+                    storage.put_scalar("key3", k, smoothing_hint=True)
+                if (k + 1) % 10 == 0:
+                    writer.write()
+                storage.step()
+
+            window_sizes = storage.histories_window_sizes(window_size=10)
+            self.assertEqual(window_sizes, {"key1": 10, "key2": 5, "key3": 2})
+            writer.close()
+            with open(json_file) as f:
+                data = [json.loads(l) for l in f]
+                self.assertEqual([k["key1"] for k in data], [4.5, 14.5])
+                self.assertEqual([k["key2"] for k in data], [5, 15])
+                self.assertEqual([k["key3"] for k in data], [6.5, 16.5])


### PR DESCRIPTION
Summary:
Add an option to specify the period of metric aggregating and writing in Trainer.

This feature is needed to optimize training speed for large-scale training jobs like generative AI. The reason is that the all_gather call for metric aggregation at every iteration is time-consuming when using hundreds of gpus, takes ~10% of the total training time. With this feature we can set the metric writing period as the same as cfg.WRITER_PERIOD=20 to reduce training time while still keeping metric logging the same to users

Reviewed By: raghuramank100

Differential Revision:
D43098985

Privacy Context Container: 2011691122555468

