### PR TITLE
Return type fix

### DIFF
--- a/detectron2/data/transforms/augmentation.py
+++ b/detectron2/data/transforms/augmentation.py
@@ -261,7 +261,7 @@ class AugmentationList(Augmentation):
         super().__init__()
         self.augs = [_transform_to_aug(x) for x in augs]
 
-    def __call__(self, aug_input) -> Transform:
+    def __call__(self, aug_input) -> TransformList:
         tfms = []
         for x in self.augs:
             tfm = x(aug_input)


### PR DESCRIPTION
Summary: AugmentationList call explicitly returns an AugmentationList, but typehint is set to Augmentation, triggering dowstream errors

Differential Revision: D43358064

