### PR TITLE
Fix for numpy deprecation of `np.str`

### DIFF
--- a/detectron2/data/datasets/pascal_voc.py
+++ b/detectron2/data/datasets/pascal_voc.py
@@ -32,7 +32,7 @@ def load_voc_instances(dirname: str, split: str, class_names: Union[List[str], T
         class_names: list or tuple of class names
     """
     with PathManager.open(os.path.join(dirname, "ImageSets", "Main", split + ".txt")) as f:
-        fileids = np.loadtxt(f, dtype=np.str)
+        fileids = np.loadtxt(f, dtype=str)
 
     # Needs to read many small annotation files. Makes sense at local
     annotation_dirname = PathManager.get_local_path(os.path.join(dirname, "Annotations/"))


### PR DESCRIPTION
`np.str` has been deprecated in favor of `str` from numpy 1.20.0 onwards [release note](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

