### PR TITLE
added indexing to meshgrid in anchor_generator

### DIFF
--- a/detectron2/modeling/anchor_generator.py
+++ b/detectron2/modeling/anchor_generator.py
@@ -49,7 +49,7 @@ def _create_grid_offsets(
         target_device_tensor,
     )
 
-    shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
+    shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x, indexing='ij')
     shift_x = shift_x.reshape(-1)
     shift_y = shift_y.reshape(-1)
     return shift_x, shift_y


### PR DESCRIPTION
Otherwise a torch gives the following warning (will need to specify it in the future because the default is going to change).

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

