### PR TITLE
Convert mock_torch_nn_functional_interpolate to decorator

### DIFF
--- a/detectron2/export/shared.py
+++ b/detectron2/export/shared.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import collections
-import contextlib
 import copy
 import functools
 import logging
@@ -112,15 +111,21 @@ def onnx_compatibale_interpolate(
     return interp(input, size, scale_factor, mode, align_corners)
 
 
-@contextlib.contextmanager
 def mock_torch_nn_functional_interpolate():
-    if torch.onnx.is_in_onnx_export():
-        with mock.patch(
-            "torch.nn.functional.interpolate", side_effect=onnx_compatibale_interpolate
-        ):
-            yield
-    else:
-        yield
+    def decorator(func):
+        @functools.wraps(func)
+        def _mock_torch_nn_functional_interpolate(*args, **kwargs):
+            if torch.onnx.is_in_onnx_export():
+                with mock.patch(
+                    "torch.nn.functional.interpolate", side_effect=onnx_compatibale_interpolate
+                ):
+                    return func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+
+        return _mock_torch_nn_functional_interpolate
+
+    return decorator
 
 
 # ==== torch/utils_caffe2/ws_utils.py ==========================================


### PR DESCRIPTION
Summary:
We're working on onboarding Stinson models onto Executorch, the next generation runtime. In order to do so we must first export models by tracing it with Torch Dynamo. However, as Dynamo is actively being developed, it doesn't handle all features, such as tracing generators, which was encountered when exporting the Keyboard Tracking model.

However, it looks like the `mock_torch_nn_functional_interpolate` function might also work as a decorator rather than
a generator, which dynamo is able to trace through.

Differential Revision:
D43400473

Privacy Context Container: L1124100

