### PR TITLE
Modify iter loop around BufferList

### DIFF
--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -196,7 +196,7 @@ class Caffe2RPN(Caffe2Compatible, rpn.RPN):
         for scores, bbox_deltas, cell_anchors_tensor, feat_stride in zip(
             objectness_logits_pred,
             anchor_deltas_pred,
-            iter(self.anchor_generator.cell_anchors),
+            [b for (n, b) in self.anchor_generator.cell_anchors.named_buffers()],
             self.anchor_generator.strides,
         ):
             scores = scores.detach()


### PR DESCRIPTION
Summary:
Dynamo is currently unable to handle user defined dunder functions
like __iter__ and __setattr__. This is one option as a workaround, but another
workaround would be to change BufferList to directly be a list, which I
attempted in D43414324, but ran into issues with missing registration,
resulting in the device change to not be recursively applied to the tensors in
the list (previously BufferList).

Differential Revision: D43577846

