### PR TITLE
Fix data dependent flow

### DIFF
--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -376,150 +376,177 @@ class Caffe2ROIPooler(Caffe2Compatible, poolers.ROIPooler):
         return roi_feat
 
 
+def caffe2_fast_rcnn_outputs_inference(tensor_mode, box_predictor, predictions, proposals):
+    """equivalent to FastRCNNOutputLayers.inference"""
+    num_classes = box_predictor.num_classes
+    score_thresh = box_predictor.test_score_thresh
+    nms_thresh = box_predictor.test_nms_thresh
+    topk_per_image = box_predictor.test_topk_per_image
+    is_rotated = len(box_predictor.box2box_transform.weights) == 5
+
+    if is_rotated:
+        box_dim = 5
+        assert box_predictor.box2box_transform.weights[4] == 1, (
+            "The weights for Rotated BBoxTransform in C2 have only 4 dimensions,"
+            + " thus enforcing the angle weight to be 1 for now"
+        )
+        box2box_transform_weights = box_predictor.box2box_transform.weights[:4]
+    else:
+        box_dim = 4
+        box2box_transform_weights = box_predictor.box2box_transform.weights
+
+    class_logits, box_regression = predictions
+    if num_classes + 1 == class_logits.shape[1]:
+        class_prob = F.softmax(class_logits, -1)
+    else:
+        assert num_classes == class_logits.shape[1]
+        class_prob = F.sigmoid(class_logits)
+        # BoxWithNMSLimit will infer num_classes from the shape of the class_prob
+        # So append a zero column as placeholder for the background class
+        class_prob = torch.cat((class_prob, torch.zeros(class_prob.shape[0], 1)), dim=1)
+
+    assert box_regression.shape[1] % box_dim == 0
+    cls_agnostic_bbox_reg = box_regression.shape[1] // box_dim == 1
+
+    input_tensor_mode = proposals[0].proposal_boxes.tensor.shape[1] == box_dim + 1
+
+    rois = type(proposals[0].proposal_boxes).cat([p.proposal_boxes for p in proposals])
+    device, dtype = rois.tensor.device, rois.tensor.dtype
+    if input_tensor_mode:
+        im_info = proposals[0].image_size
+        rois = rois.tensor
+    else:
+        im_info = torch.tensor([[sz[0], sz[1], 1.0] for sz in [x.image_size for x in proposals]])
+        batch_ids = cat(
+            [
+                torch.full((b, 1), i, dtype=dtype, device=device)
+                for i, b in enumerate(len(p) for p in proposals)
+            ],
+            dim=0,
+        )
+        rois = torch.cat([batch_ids, rois.tensor], dim=1)
+
+    roi_pred_bbox, roi_batch_splits = torch.ops._caffe2.BBoxTransform(
+        to_device(rois, "cpu"),
+        to_device(box_regression, "cpu"),
+        to_device(im_info, "cpu"),
+        weights=box2box_transform_weights,
+        apply_scale=True,
+        rotated=is_rotated,
+        angle_bound_on=True,
+        angle_bound_lo=-180,
+        angle_bound_hi=180,
+        clip_angle_thresh=1.0,
+        legacy_plus_one=False,
+    )
+    roi_pred_bbox = to_device(roi_pred_bbox, device)
+    roi_batch_splits = to_device(roi_batch_splits, device)
+
+    nms_outputs = torch.ops._caffe2.BoxWithNMSLimit(
+        to_device(class_prob, "cpu"),
+        to_device(roi_pred_bbox, "cpu"),
+        to_device(roi_batch_splits, "cpu"),
+        score_thresh=float(score_thresh),
+        nms=float(nms_thresh),
+        detections_per_im=int(topk_per_image),
+        soft_nms_enabled=False,
+        soft_nms_method="linear",
+        soft_nms_sigma=0.5,
+        soft_nms_min_score_thres=0.001,
+        rotated=is_rotated,
+        cls_agnostic_bbox_reg=cls_agnostic_bbox_reg,
+        input_boxes_include_bg_cls=False,
+        output_classes_include_bg_cls=False,
+        legacy_plus_one=False,
+    )
+    roi_score_nms = to_device(nms_outputs[0], device)
+    roi_bbox_nms = to_device(nms_outputs[1], device)
+    roi_class_nms = to_device(nms_outputs[2], device)
+    roi_batch_splits_nms = to_device(nms_outputs[3], device)
+    roi_keeps_nms = to_device(nms_outputs[4], device)
+    roi_keeps_size_nms = to_device(nms_outputs[5], device)
+    if not tensor_mode:
+        roi_class_nms = roi_class_nms.to(torch.int64)
+
+    roi_batch_ids = cat(
+        [
+            torch.full((b, 1), i, dtype=dtype, device=device)
+            for i, b in enumerate(int(x.item()) for x in roi_batch_splits_nms)
+        ],
+        dim=0,
+    )
+
+    roi_class_nms = alias(roi_class_nms, "class_nms")
+    roi_score_nms = alias(roi_score_nms, "score_nms")
+    roi_bbox_nms = alias(roi_bbox_nms, "bbox_nms")
+    roi_batch_splits_nms = alias(roi_batch_splits_nms, "batch_splits_nms")
+    roi_keeps_nms = alias(roi_keeps_nms, "keeps_nms")
+    roi_keeps_size_nms = alias(roi_keeps_size_nms, "keeps_size_nms")
+
+    results = InstancesList(
+        im_info=im_info,
+        indices=roi_batch_ids[:, 0],
+        extra_fields={
+            "pred_boxes": Caffe2Boxes(roi_bbox_nms),
+            "scores": roi_score_nms,
+            "pred_classes": roi_class_nms,
+        },
+    )
+
+    if not tensor_mode:
+        results = InstancesList.to_d2_instances_list(results)
+        batch_splits = roi_batch_splits_nms.int().tolist()
+        kept_indices = list(roi_keeps_nms.to(torch.int64).split(batch_splits))
+    else:
+        results = [results]
+        kept_indices = [roi_keeps_nms]
+
+    return results, kept_indices
+
+
 class Caffe2FastRCNNOutputsInference:
     def __init__(self, tensor_mode):
         self.tensor_mode = tensor_mode  # whether the output is caffe2 tensor mode
 
     def __call__(self, box_predictor, predictions, proposals):
-        """equivalent to FastRCNNOutputLayers.inference"""
-        num_classes = box_predictor.num_classes
-        score_thresh = box_predictor.test_score_thresh
-        nms_thresh = box_predictor.test_nms_thresh
-        topk_per_image = box_predictor.test_topk_per_image
-        is_rotated = len(box_predictor.box2box_transform.weights) == 5
-
-        if is_rotated:
-            box_dim = 5
-            assert box_predictor.box2box_transform.weights[4] == 1, (
-                "The weights for Rotated BBoxTransform in C2 have only 4 dimensions,"
-                + " thus enforcing the angle weight to be 1 for now"
-            )
-            box2box_transform_weights = box_predictor.box2box_transform.weights[:4]
-        else:
-            box_dim = 4
-            box2box_transform_weights = box_predictor.box2box_transform.weights
-
-        class_logits, box_regression = predictions
-        if num_classes + 1 == class_logits.shape[1]:
-            class_prob = F.softmax(class_logits, -1)
-        else:
-            assert num_classes == class_logits.shape[1]
-            class_prob = F.sigmoid(class_logits)
-            # BoxWithNMSLimit will infer num_classes from the shape of the class_prob
-            # So append a zero column as placeholder for the background class
-            class_prob = torch.cat((class_prob, torch.zeros(class_prob.shape[0], 1)), dim=1)
-
-        assert box_regression.shape[1] % box_dim == 0
-        cls_agnostic_bbox_reg = box_regression.shape[1] // box_dim == 1
-
-        input_tensor_mode = proposals[0].proposal_boxes.tensor.shape[1] == box_dim + 1
-
-        rois = type(proposals[0].proposal_boxes).cat([p.proposal_boxes for p in proposals])
-        device, dtype = rois.tensor.device, rois.tensor.dtype
-        if input_tensor_mode:
-            im_info = proposals[0].image_size
-            rois = rois.tensor
-        else:
-            im_info = torch.tensor(
-                [[sz[0], sz[1], 1.0] for sz in [x.image_size for x in proposals]]
-            )
-            batch_ids = cat(
-                [
-                    torch.full((b, 1), i, dtype=dtype, device=device)
-                    for i, b in enumerate(len(p) for p in proposals)
-                ],
-                dim=0,
-            )
-            rois = torch.cat([batch_ids, rois.tensor], dim=1)
-
-        roi_pred_bbox, roi_batch_splits = torch.ops._caffe2.BBoxTransform(
-            to_device(rois, "cpu"),
-            to_device(box_regression, "cpu"),
-            to_device(im_info, "cpu"),
-            weights=box2box_transform_weights,
-            apply_scale=True,
-            rotated=is_rotated,
-            angle_bound_on=True,
-            angle_bound_lo=-180,
-            angle_bound_hi=180,
-            clip_angle_thresh=1.0,
-            legacy_plus_one=False,
-        )
-        roi_pred_bbox = to_device(roi_pred_bbox, device)
-        roi_batch_splits = to_device(roi_batch_splits, device)
-
-        nms_outputs = torch.ops._caffe2.BoxWithNMSLimit(
-            to_device(class_prob, "cpu"),
-            to_device(roi_pred_bbox, "cpu"),
-            to_device(roi_batch_splits, "cpu"),
-            score_thresh=float(score_thresh),
-            nms=float(nms_thresh),
-            detections_per_im=int(topk_per_image),
-            soft_nms_enabled=False,
-            soft_nms_method="linear",
-            soft_nms_sigma=0.5,
-            soft_nms_min_score_thres=0.001,
-            rotated=is_rotated,
-            cls_agnostic_bbox_reg=cls_agnostic_bbox_reg,
-            input_boxes_include_bg_cls=False,
-            output_classes_include_bg_cls=False,
-            legacy_plus_one=False,
-        )
-        roi_score_nms = to_device(nms_outputs[0], device)
-        roi_bbox_nms = to_device(nms_outputs[1], device)
-        roi_class_nms = to_device(nms_outputs[2], device)
-        roi_batch_splits_nms = to_device(nms_outputs[3], device)
-        roi_keeps_nms = to_device(nms_outputs[4], device)
-        roi_keeps_size_nms = to_device(nms_outputs[5], device)
-        if not self.tensor_mode:
-            roi_class_nms = roi_class_nms.to(torch.int64)
-
-        roi_batch_ids = cat(
-            [
-                torch.full((b, 1), i, dtype=dtype, device=device)
-                for i, b in enumerate(int(x.item()) for x in roi_batch_splits_nms)
-            ],
-            dim=0,
+        return caffe2_fast_rcnn_outputs_inference(
+            self.tensor_mode, box_predictor, predictions, proposals
         )
 
-        roi_class_nms = alias(roi_class_nms, "class_nms")
-        roi_score_nms = alias(roi_score_nms, "score_nms")
-        roi_bbox_nms = alias(roi_bbox_nms, "bbox_nms")
-        roi_batch_splits_nms = alias(roi_batch_splits_nms, "batch_splits_nms")
-        roi_keeps_nms = alias(roi_keeps_nms, "keeps_nms")
-        roi_keeps_size_nms = alias(roi_keeps_size_nms, "keeps_size_nms")
 
-        results = InstancesList(
-            im_info=im_info,
-            indices=roi_batch_ids[:, 0],
-            extra_fields={
-                "pred_boxes": Caffe2Boxes(roi_bbox_nms),
-                "scores": roi_score_nms,
-                "pred_classes": roi_class_nms,
-            },
-        )
-
-        if not self.tensor_mode:
-            results = InstancesList.to_d2_instances_list(results)
-            batch_splits = roi_batch_splits_nms.int().tolist()
-            kept_indices = list(roi_keeps_nms.to(torch.int64).split(batch_splits))
-        else:
-            results = [results]
-            kept_indices = [roi_keeps_nms]
-
-        return results, kept_indices
+def caffe2_mask_rcnn_inference(pred_mask_logits, pred_instances):
+    """equivalent to mask_head.mask_rcnn_inference"""
+    if all(isinstance(x, InstancesList) for x in pred_instances):
+        assert len(pred_instances) == 1
+        mask_probs_pred = pred_mask_logits.sigmoid()
+        mask_probs_pred = alias(mask_probs_pred, "mask_fcn_probs")
+        pred_instances[0].set("pred_masks", mask_probs_pred)
+    else:
+        mask_rcnn_inference(pred_mask_logits, pred_instances)
 
 
 class Caffe2MaskRCNNInference:
     def __call__(self, pred_mask_logits, pred_instances):
-        """equivalent to mask_head.mask_rcnn_inference"""
-        if all(isinstance(x, InstancesList) for x in pred_instances):
-            assert len(pred_instances) == 1
-            mask_probs_pred = pred_mask_logits.sigmoid()
-            mask_probs_pred = alias(mask_probs_pred, "mask_fcn_probs")
-            pred_instances[0].set("pred_masks", mask_probs_pred)
-        else:
-            mask_rcnn_inference(pred_mask_logits, pred_instances)
+        return caffe2_mask_rcnn_inference(pred_mask_logits, pred_instances)
+
+
+def caffe2_keypoint_rcnn_inference(use_heatmap_max_keypoint, pred_keypoint_logits, pred_instances):
+    # just return the keypoint heatmap for now,
+    # there will be option to call HeatmapMaxKeypointOp
+    output = alias(pred_keypoint_logits, "kps_score")
+    if all(isinstance(x, InstancesList) for x in pred_instances):
+        assert len(pred_instances) == 1
+        if use_heatmap_max_keypoint:
+            device = output.device
+            output = torch.ops._caffe2.HeatmapMaxKeypoint(
+                to_device(output, "cpu"),
+                pred_instances[0].pred_boxes.tensor,
+                should_output_softmax=True,  # worth make it configerable?
+            )
+            output = to_device(output, device)
+            output = alias(output, "keypoints_out")
+        pred_instances[0].set("pred_keypoints", output)
+    return pred_keypoint_logits
 
 
 class Caffe2KeypointRCNNInference:
@@ -527,19 +554,6 @@ class Caffe2KeypointRCNNInference:
         self.use_heatmap_max_keypoint = use_heatmap_max_keypoint
 
     def __call__(self, pred_keypoint_logits, pred_instances):
-        # just return the keypoint heatmap for now,
-        # there will be option to call HeatmapMaxKeypointOp
-        output = alias(pred_keypoint_logits, "kps_score")
-        if all(isinstance(x, InstancesList) for x in pred_instances):
-            assert len(pred_instances) == 1
-            if self.use_heatmap_max_keypoint:
-                device = output.device
-                output = torch.ops._caffe2.HeatmapMaxKeypoint(
-                    to_device(output, "cpu"),
-                    pred_instances[0].pred_boxes.tensor,
-                    should_output_softmax=True,  # worth make it configerable?
-                )
-                output = to_device(output, device)
-                output = alias(output, "keypoints_out")
-            pred_instances[0].set("pred_keypoints", output)
-        return pred_keypoint_logits
+        return caffe2_keypoint_rcnn_inference(
+            self.use_heatmap_max_keypoint, pred_keypoint_logits, pred_instances
+        )

--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -469,13 +469,8 @@ def caffe2_fast_rcnn_outputs_inference(tensor_mode, box_predictor, predictions, 
     if not tensor_mode:
         roi_class_nms = roi_class_nms.to(torch.int64)
 
-    roi_batch_ids = cat(
-        [
-            torch.full((b, 1), i, dtype=dtype, device=device)
-            for i, b in enumerate(int(x.item()) for x in roi_batch_splits_nms)
-        ],
-        dim=0,
-    )
+    b = roi_batch_splits.size(0)
+    roi_batch_ids = cat([torch.full((b, 1), 0, dtype=dtype, device=device)], dim=0)
 
     roi_class_nms = alias(roi_class_nms, "class_nms")
     roi_score_nms = alias(roi_score_nms, "score_nms")

--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -196,7 +196,7 @@ class Caffe2RPN(Caffe2Compatible, rpn.RPN):
         for scores, bbox_deltas, cell_anchors_tensor, feat_stride in zip(
             objectness_logits_pred,
             anchor_deltas_pred,
-            iter(self.anchor_generator.cell_anchors),
+            iter(self.anchor_generator.cell_anchors._buffers.values()),
             self.anchor_generator.strides,
         ):
             scores = scores.detach()

--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -410,7 +410,8 @@ def caffe2_fast_rcnn_outputs_inference(tensor_mode, box_predictor, predictions, 
 
     input_tensor_mode = proposals[0].proposal_boxes.tensor.shape[1] == box_dim + 1
 
-    rois = type(proposals[0].proposal_boxes).cat([p.proposal_boxes for p in proposals])
+    assert isinstance(proposals[0].proposal_boxes, Caffe2Boxes)
+    rois = Caffe2Boxes.cat([p.proposal_boxes for p in proposals])
     device, dtype = rois.tensor.device, rois.tensor.dtype
     if input_tensor_mode:
         im_info = proposals[0].image_size

--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -89,12 +89,6 @@ class InstancesList(object):
             ), "Adding a field of length {} to a Instances of length {}".format(data_len, len(self))
         self.batch_extra_fields[name] = value
 
-    def __setattr__(self, name, val):
-        if name in ["im_info", "indices", "batch_extra_fields", "image_size"]:
-            super().__setattr__(name, val)
-        else:
-            self.set(name, val)
-
     def __getattr__(self, name):
         if name not in self.batch_extra_fields:
             raise AttributeError("Cannot find field '{}' in the given Instances!".format(name))
@@ -523,7 +517,7 @@ class Caffe2MaskRCNNInference:
             assert len(pred_instances) == 1
             mask_probs_pred = pred_mask_logits.sigmoid()
             mask_probs_pred = alias(mask_probs_pred, "mask_fcn_probs")
-            pred_instances[0].pred_masks = mask_probs_pred
+            pred_instances[0].set("pred_masks", mask_probs_pred)
         else:
             mask_rcnn_inference(pred_mask_logits, pred_instances)
 
@@ -547,5 +541,5 @@ class Caffe2KeypointRCNNInference:
                 )
                 output = to_device(output, device)
                 output = alias(output, "keypoints_out")
-            pred_instances[0].pred_keypoints = output
+            pred_instances[0].set("pred_keypoints", output)
         return pred_keypoint_logits

--- a/detectron2/export/shared.py
+++ b/detectron2/export/shared.py
@@ -1,7 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import collections
-import contextlib
 import copy
 import functools
 import logging
@@ -112,15 +111,21 @@ def onnx_compatibale_interpolate(
     return interp(input, size, scale_factor, mode, align_corners)
 
 
-@contextlib.contextmanager
 def mock_torch_nn_functional_interpolate():
-    if torch.onnx.is_in_onnx_export():
-        with mock.patch(
-            "torch.nn.functional.interpolate", side_effect=onnx_compatibale_interpolate
-        ):
-            yield
-    else:
-        yield
+    def decorator(func):
+        @functools.wraps(func)
+        def _mock_torch_nn_functional_interpolate(*args, **kwargs):
+            if torch.onnx.is_in_onnx_export():
+                with mock.patch(
+                    "torch.nn.functional.interpolate", side_effect=onnx_compatibale_interpolate
+                ):
+                    return func(*args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+
+        return _mock_torch_nn_functional_interpolate
+
+    return decorator
 
 
 # ==== torch/utils_caffe2/ws_utils.py ==========================================

--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -103,12 +103,11 @@ class Conv2d(torch.nn.Conv2d):
         # 2. features needed by exporting module to torchscript are added in PyTorch 1.6 or
         # later version, `Conv2d` in these PyTorch versions has already supported empty inputs.
         if not torch.jit.is_scripting():
-            with warnings.catch_warnings(record=True):
-                if x.numel() == 0 and self.training:
-                    # https://github.com/pytorch/pytorch/issues/12013
-                    assert not isinstance(
-                        self.norm, torch.nn.SyncBatchNorm
-                    ), "SyncBatchNorm does not support empty inputs!"
+            if x.numel() == 0 and self.training:
+                # https://github.com/pytorch/pytorch/issues/12013
+                assert not isinstance(
+                    self.norm, torch.nn.SyncBatchNorm
+                ), "SyncBatchNorm does not support empty inputs!"
 
         x = F.conv2d(
             x, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups


### PR DESCRIPTION
Summary:
Dynamo is unable to handle the data dependent flow that is using values within a tensor as the shape to create another tensor. It is unable to infer the value of the tensor since that value could be different depending on inputs.

However, looking at the code, it seems this might not be needed. This is an implementation detail of [torch.ops._caffe2.BoxWithNMSLimit](https://fburl.com/code/mxmrwqv5), but the value inside nms_outputs[4] is just the size of `roi_batch_splits` which is a single integer. So, we can just use the size of `roi_batch_splits` to create the batch ids

Differential Revision: D43641703

