### PR TITLE
fix tracing issue of DenseDetector

### DIFF
--- a/detectron2/modeling/meta_arch/dense_detector.py
+++ b/detectron2/modeling/meta_arch/dense_detector.py
@@ -214,7 +214,12 @@ class DenseDetector(nn.Module):
         topk_idxs = torch.nonzero(keep_idxs)  # Kx2
 
         # 2. Keep top k top scoring boxes only
-        num_topk = min(topk_candidates, topk_idxs.size(0))
+        topk_idxs_size = topk_idxs.shape[0]
+        if isinstance(topk_idxs_size, Tensor):
+            # It's a tensor in tracing
+            num_topk = torch.clamp(topk_idxs_size, max=topk_candidates)
+        else:
+            num_topk = min(topk_idxs_size, topk_candidates)
         pred_scores, idxs = pred_scores.topk(num_topk)
         topk_idxs = topk_idxs[idxs]
 


### PR DESCRIPTION
Summary: As titled, `_decode_per_level_predictions` cannot be traced due to certain implementation.  Follow D25705655 (https://github.com/facebookresearch/detectron2/commit/5cb34b174d5a6d64de88a836e4638492a16a4a2d) to address this issue. Specifically, using `torch.clamp` instead of `min()` when tracing.

Differential Revision: D43677517

