### PR TITLE
allow print non loss metrics.

### DIFF
--- a/detectron2/utils/events.py
+++ b/detectron2/utils/events.py
@@ -260,7 +260,7 @@ class CommonMetricPrinter(EventWriter):
         # NOTE: max_mem is parsed by grep in "dev/parse_results.sh"
         self.logger.info(
             str.format(
-                " {eta}iter: {iter}  {losses}  {avg_time}{last_time}"
+                " {eta}iter: {iter}  {losses}  {non_losses}  {avg_time}{last_time}"
                 + "{avg_data_time}{last_data_time} lr: {lr}  {memory}",
                 eta=f"eta: {eta_string}  " if eta_string else "",
                 iter=iteration,
@@ -271,6 +271,15 @@ class CommonMetricPrinter(EventWriter):
                         )
                         for k, v in storage.histories().items()
                         if "loss" in k
+                    ]
+                ),
+                non_losses="  ".join(
+                    [
+                        "{}: {:.4g}".format(
+                            k, v.median(storage.count_samples(k, self._window_size))
+                        )
+                        for k, v in storage.histories().items()
+                        if "[metric]" in k
                     ]
                 ),
                 avg_time="time: {:.4f}  ".format(avg_iter_time)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -63,6 +63,26 @@ class TestEventWriter(unittest.TestCase):
                 p2.write()
             self.assertNotIn("eta", logs.output[0])
 
+    def testPrintNonLosses(self):
+        with EventStorage() as s:
+            p1 = CommonMetricPrinter(10)
+            p2 = CommonMetricPrinter()
+
+            s.put_scalar("time", 1.0)
+            s.put_scalar("[metric]bn_stat", 1.0)
+            s.step()
+            s.put_scalar("time", 1.0)
+            s.put_scalar("[metric]bn_stat", 1.0)
+            s.step()
+
+            with self.assertLogs("detectron2.utils.events") as logs:
+                p1.write()
+            self.assertIn("[metric]bn_stat", logs.output[0])
+
+            with self.assertLogs("detectron2.utils.events") as logs:
+                p2.write()
+            self.assertIn("[metric]bn_stat", logs.output[0])
+
     def testSmoothingWithWindowSize(self):
         with tempfile.TemporaryDirectory(
             prefix="detectron2_tests"


### PR DESCRIPTION
Summary:
allow print non loss metrics.
* If the metric name contains `[metric]`.
* Non-loss metrics have to be passed as numbers (not tensors) and they will not be used to compute the overall loss.

Differential Revision: D43531600

