### PR TITLE
Fixed error in matplotlib when color > 1.0 due to numerical errors

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -1200,7 +1200,7 @@ class Visualizer:
         modified_lightness = 0.0 if modified_lightness < 0.0 else modified_lightness
         modified_lightness = 1.0 if modified_lightness > 1.0 else modified_lightness
         modified_color = colorsys.hls_to_rgb(polygon_color[0], modified_lightness, polygon_color[2])
-        return modified_color
+        return tuple(np.clip(modified_color, 0.0, 1.0))
 
     def _convert_boxes(self, boxes):
         """


### PR DESCRIPTION
Fixed rare error below that comes from matplotlib. In my case color was 1.001.

```ValueError: RGBA values should be within 0-1 range```


