### PR TITLE
Lazy initialize tensorboard

### DIFF
--- a/tests/utils/test_tensorboardx.py
+++ b/tests/utils/test_tensorboardx.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+import unittest
+
+from detectron2.utils.events import TensorboardXWriter
+
+
+# TODO Fix up capitalization
+class TestTensorboardXWriter(unittest.TestCase):
+    def test_no_files_created(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            writer = TensorboardXWriter(tmp_dir)
+            writer.close()
+
+            self.assertFalse(os.listdir(tmp_dir))
+
+    def test_single_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            writer = TensorboardXWriter(tmp_dir)
+            writer._writer.add_scalar("testing", 1, 1)
+            writer.close()
+
+            self.assertTrue(os.listdir(tmp_dir))


### PR DESCRIPTION
Summary:
Every time a summary writer object is created it'll end up creating a file in the passed in logdir with just metadata of 40 bytes. This will cause a lot of spam with every rank initializing the file aggressively (I've done this myself when adding support for Adhoc logging to PyPer to a lot of angry complaints).

Report at https://fb.workplace.com/groups/723537759122220/posts/745046770304652/

Sample code that accesses "_writer" directly: https://www.internalfb.com/code/fbsource/[6b39948cd8e179fcc49f08526efa5dc26fc00843]/fbcode/mobile-vision/d2go/d2go/utils/visualization.py?lines=180

Reviewed By: Reubend

Differential Revision: D43863071

