### PR TITLE
Pytorch 2.0, Cuda 11.8 and future 12.0 & 12.1 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,17 @@ select_cuda: &select_cuda
       command: |
         sudo update-alternatives --set cuda /usr/local/cuda-<< parameters.cuda_version >>
 
+build_wheel: &build_wheel
+  - run:
+      name: Build wheel
+      command: |
+        python -m pip install wheel
+        python setup.py bdist_wheel
+
+save_artifact: &save_artifact
+  - store_artifacts:
+      path: ~/detectron2/dist
+      destination: dist
 
 # -------------------------------------------------------------------------------------
 # Jobs to run
@@ -198,6 +209,8 @@ jobs:
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
       - <<: *run_unittests
       - <<: *uninstall_tests
 
@@ -223,6 +236,8 @@ jobs:
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
       - <<: *run_unittests
       - <<: *uninstall_tests
 
@@ -317,6 +332,3 @@ workflows:
       - windows_cpu_build:
           pytorch_version: '1.13.1+cpu'
           torchvision_version: '0.14.1+cpu'
-      - windows_cpu_build:
-          pytorch_version: '2.0.0+cpu'
-          torchvision_version: '0.15.1+cpu'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ version_parameters: &version_parameters
       default: "https://download.pytorch.org/whl/torch_stable.html"
     python_version: # NOTE: only affects linux
       type: string
-      default: '3.10.10'
+      default: '3.10.9'
     cuda_version:
       type: string
       default: '11.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ cpu: &cpu
 gpu118: &gpu118
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
-    image: linux-cuda-11:2023.05.1
+    image: linux-cuda-11:2023.02.1
   resource_class: gpu.nvidia.small
 
 gpu121: &gpu121

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -218,7 +218,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
 
   linux_gpu_tests:
     <<: *gpu
@@ -231,7 +231,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -245,7 +245,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
 
 
   windows_cpu_build:
@@ -259,7 +259,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
 
       - run:
           name: Install Dependencies
@@ -290,7 +290,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -224,7 +224,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
   linux_gpu_tests118:
     <<: *gpu118
@@ -237,7 +237,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -251,7 +251,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
   linux_gpu_tests121:
     <<: *gpu121
@@ -264,7 +264,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -278,7 +278,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
 
   windows_cpu_build:
@@ -292,7 +292,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
       - run:
           name: Install Dependencies
@@ -323,7 +323,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,7 @@ workflows:
           name: linux_cpu_tests_pytorch2.0
           pytorch_version: '2.0.0+cpu'
           torchvision_version: '0.15.1+cpu'
+          python_version: '3.11'
       - linux_gpu_tests:
           name: linux_gpu_tests_pytorch1.12
           pytorch_version: '1.12.1+cu116'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ gpu118: &gpu118
     image: linux-cuda-11:2023.05.1
   resource_class: gpu.nvidia.small
 
-gpu12: &gpu121
+gpu121: &gpu121
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
     image: linux-cuda-12:2023.05.1
@@ -253,32 +253,32 @@ jobs:
             - ~/.torch
           key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
 
-    linux_gpu_tests121:
-      <<: *gpu121
-      <<: *version_parameters
+  linux_gpu_tests121:
+    <<: *gpu121
+    <<: *version_parameters
 
-      working_directory: ~/detectron2
+    working_directory: ~/detectron2
 
-      steps:
-        - checkout
+    steps:
+      - checkout
 
-        - restore_cache:
-            keys:
-              - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
-        - <<: *select_cuda
-        - <<: *install_python
-        - <<: *install_linux_dep
-        - <<: *install_detectron2
-        - <<: *build_wheel
-        - <<: *save_artifact
-        - <<: *run_unittests
-        - <<: *uninstall_tests
+      - restore_cache:
+          keys:
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+      - <<: *select_cuda
+      - <<: *install_python
+      - <<: *install_linux_dep
+      - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
+      - <<: *run_unittests
+      - <<: *uninstall_tests
 
-        - save_cache:
-            paths:
-              - /opt/circleci/.pyenv
-              - ~/.torch
-            key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+      - save_cache:
+          paths:
+            - /opt/circleci/.pyenv
+            - ~/.torch
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
 
 
   windows_cpu_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ workflows:
           cuda_version: '11.8'
           python_version: '3.11'
       - linux_gpu_tests121:
-          name: linux_gpu_tests_pytorch2.0.1
+          name: linux_gpu_tests_pytorch_nightly
           pytorch_version: 'master'
           torchvision_version: 'main'
           cuda_version: '12.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,8 +348,8 @@ workflows:
           cuda_version: '11.6'
       - linux_gpu_tests118:
           name: linux_gpu_tests_pytorch2.0.1
-          pytorch_version: '2.0.1+cu121'
-          torchvision_version: '0.15.2+cu121'
+          pytorch_version: '2.0.1+cu118'
+          torchvision_version: '0.15.2+cu118'
           cuda_version: '11.8'
           python_version: '3.11'
       - linux_gpu_tests121:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,41 +300,29 @@ workflows:
   regular_test:
     jobs:
       - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch1.12
-          pytorch_version: '1.12.1+cpu'
-          torchvision_version: '0.13.1+cpu'
-      - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch1.13
+          name: linux_cpu_tests_pytorch1.13.1
           pytorch_version: '1.13.1+cpu'
           torchvision_version: '0.14.1+cpu'
       - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch2.0
-          pytorch_version: '2.0.0+cpu'
-          torchvision_version: '0.15.1+cpu'
+          name: linux_cpu_tests_pytorch2.0.1
+          pytorch_version: '2.0.1+cpu'
+          torchvision_version: '0.15.2+cpu'
           python_version: '3.11'
       - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.12
-          pytorch_version: '1.12.1+cu116'
-          torchvision_version: '0.13.1+cu116'
-          cuda_version: '11.6'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.13
+          name: linux_gpu_tests_pytorch1.13.1
           pytorch_version: '1.13.1+cu116'
           torchvision_version: '0.14.1+cu116'
           cuda_version: '11.6'
       - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch2.0
-          pytorch_version: '2.0.0+cu118'
-          torchvision_version: '0.15.1+cu118'
+          name: linux_gpu_tests_pytorch2.0.1
+          pytorch_version: '2.0.1+cu118'
+          torchvision_version: '0.15.2+cu118'
           cuda_version: '11.8'
           python_version: '3.11'
-      - windows_cpu_build:
-          pytorch_version: '1.12.1+cpu'
-          torchvision_version: '0.13.1+cpu'
       - windows_cpu_build:
           pytorch_version: '1.13.1+cpu'
           torchvision_version: '0.14.1+cpu'
       - windows_cpu_build:
-          pytorch_version: '2.0.0+cpu'
-          torchvision_version: '0.15.1+cpu'
+          pytorch_version: '2.0.1+cpu'
+          torchvision_version: '0.15.2+cpu'
           python_version: '3.11'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,9 +326,14 @@ workflows:
           pytorch_version: '2.0.0+cu118'
           torchvision_version: '0.15.1+cu118'
           cuda_version: '11.8'
+          python_version: '3.11'
       - windows_cpu_build:
           pytorch_version: '1.12.1+cpu'
           torchvision_version: '0.13.1+cpu'
       - windows_cpu_build:
           pytorch_version: '1.13.1+cpu'
           torchvision_version: '0.14.1+cpu'
+      - windows_cpu_build:
+          pytorch_version: '2.0.0+cpu'
+          torchvision_version: '0.15.1+cpu'
+          python_version: '3.11'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,16 @@ cpu: &cpu
     image: ubuntu-2204:2023.04.2
   resource_class: medium
 
-gpu: &gpu
+gpu118: &gpu118
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
-    image: linux-cuda-11:2023.02.1
+    image: linux-cuda-11:2023.05.1
+  resource_class: gpu.nvidia.small
+
+gpu12: &gpu121
+  machine:
+    # NOTE: use a cuda version that's supported by all our pytorch versions
+    image: linux-cuda-12:2023.05.1
   resource_class: gpu.nvidia.small
 
 windows-cpu: &windows_cpu
@@ -220,8 +226,8 @@ jobs:
             - ~/.torch
           key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
 
-  linux_gpu_tests:
-    <<: *gpu
+  linux_gpu_tests118:
+    <<: *gpu118
     <<: *version_parameters
 
     working_directory: ~/detectron2
@@ -231,7 +237,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -245,7 +251,34 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+
+    linux_gpu_tests121:
+      <<: *gpu121
+      <<: *version_parameters
+
+      working_directory: ~/detectron2
+
+      steps:
+        - checkout
+
+        - restore_cache:
+            keys:
+              - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
+        - <<: *select_cuda
+        - <<: *install_python
+        - <<: *install_linux_dep
+        - <<: *install_detectron2
+        - <<: *build_wheel
+        - <<: *save_artifact
+        - <<: *run_unittests
+        - <<: *uninstall_tests
+
+        - save_cache:
+            paths:
+              - /opt/circleci/.pyenv
+              - ~/.torch
+            key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
 
 
   windows_cpu_build:
@@ -290,7 +323,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230616
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -308,16 +341,16 @@ workflows:
           pytorch_version: '2.0.1+cpu'
           torchvision_version: '0.15.2+cpu'
           python_version: '3.11'
-      - linux_gpu_tests:
+      - linux_gpu_tests118:
           name: linux_gpu_tests_pytorch1.13.1
           pytorch_version: '1.13.1+cu116'
           torchvision_version: '0.14.1+cu116'
           cuda_version: '11.6'
-      - linux_gpu_tests:
+      - linux_gpu_tests121:
           name: linux_gpu_tests_pytorch2.0.1
-          pytorch_version: '2.0.1+cu118'
-          torchvision_version: '0.15.2+cu118'
-          cuda_version: '11.8'
+          pytorch_version: '2.0.1+cu121'
+          torchvision_version: '0.15.2+cu121'
+          cuda_version: '12.1'
           python_version: '3.11'
       - windows_cpu_build:
           pytorch_version: '1.13.1+cpu'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,25 @@ version: 2.1
 # -------------------------------------------------------------------------------------
 cpu: &cpu
   machine:
-    image: ubuntu-2004:202107-02
+    image: ubuntu-2204:2023.02.1
   resource_class: medium
 
 gpu: &gpu
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
-    image: ubuntu-1604-cuda-11.1:202012-01
+    image: linux-cuda-11:2023.02.1
   resource_class: gpu.nvidia.small
 
 windows-cpu: &windows_cpu
   machine:
     resource_class: windows.medium
-    image: windows-server-2019-vs2019:stable
+    image: windows-server-2022-gui:2022.10.1
     shell: powershell.exe
 
 # windows-gpu: &windows_gpu
 #     machine:
-#       resource_class: windows.gpu.nvidia.medium
 #       image: windows-server-2019-nvidia:stable
+#     resource_class: windows.gpu.nvidia.medium
 
 version_parameters: &version_parameters
   parameters:
@@ -36,15 +36,19 @@ version_parameters: &version_parameters
       # use test wheels index to have access to RC wheels
       # https://download.pytorch.org/whl/test/torch_test.html
       default: "https://download.pytorch.org/whl/torch_stable.html"
-    python_version:  # NOTE: only affect linux
+    python_version: # NOTE: only affects linux
       type: string
-      default: '3.8.6'
+      default: '3.10.6'
+    cuda_version:
+      type: string
+      default: '11.6'
 
   environment:
     PYTORCH_VERSION: << parameters.pytorch_version >>
     TORCHVISION_VERSION: << parameters.torchvision_version >>
     PYTORCH_INDEX: << parameters.pytorch_index >>
     PYTHON_VERSION: << parameters.python_version>>
+    CUDA_VERSION: << parameters.cuda_version >>
     # point datasets to ~/.torch so it's cached in CI
     DETECTRON2_DATASETS: ~/.torch/datasets
 
@@ -71,8 +75,8 @@ install_python: &install_python
       name: Install Python
       working_directory: ~/
       command: |
-        # upgrade pyenv
-        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd
+        pyenv install -l
         pyenv install -s $PYTHON_VERSION
         pyenv global $PYTHON_VERSION
         python --version
@@ -115,15 +119,29 @@ install_linux_dep: &install_linux_dep
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
-        pip install --progress-bar off torch==$PYTORCH_VERSION -f $PYTORCH_INDEX
-        if [[ "$TORCHVISION_VERSION" == "master" ]]; then
-          pip install git+https://github.com/pytorch/vision.git
+        if [[ "$PYTORCH_VERSION" == "master" ]]; then
+          echo "Installing torch/torchvision from $PYTORCH_INDEX"
+          # Remove first, in case it's in the CI cache
+          pip uninstall -y torch torchvision
+          pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+          pip install -v --progress-bar off omegaconf==2.1.2   # needed by FCOSE2ETest::test_empty_data
         else
-          pip install --progress-bar off torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
+          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
         fi
 
+        python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+        python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
         python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+        echo "Python packages"
+        python -c "import sys; print(sys.executable)"
+        python --version
+        pip list
+        echo "GCC Compiler"
         gcc --version
+        echo "OS Environment Variables"
+        env
+
 
 install_detectron2: &install_detectron2
   - run:
@@ -152,6 +170,12 @@ uninstall_tests: &uninstall_tests
         # Tests that code is importable without installation
         PYTHONPATH=. ./.circleci/import-tests.sh
 
+select_cuda: &select_cuda
+  - run:
+      name: Select CUDA
+      command: |
+        sudo update-alternatives --set cuda /usr/local/cuda-<< parameters.cuda_version >>
+
 
 # -------------------------------------------------------------------------------------
 # Jobs to run
@@ -170,8 +194,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
-
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -182,8 +205,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
-
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
 
   linux_gpu_tests:
     <<: *gpu
@@ -196,8 +218,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
-
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+      - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -208,7 +230,8 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+
 
   windows_cpu_build:
     <<: *windows_cpu
@@ -221,7 +244,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
 
       - run:
           name: Install Dependencies
@@ -231,12 +254,28 @@ jobs:
             pip install opencv-python-headless pytest-xdist pycocotools tensorboard onnx
             pip install -U git+https://github.com/facebookresearch/iopath
             pip install -U git+https://github.com/facebookresearch/fvcore
-            pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            if($env:PYTORCH_VERSION -eq "master"){
+              Write-Output "Installing torch/torchvision from $env:PYTORCH_INDEX"
+              pip uninstall -y torch torchvision
+              pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
+            }else{
+              Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
+              pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            }
+            python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+            python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+            python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+            Write-Output "Python packages"
+            python -c "import sys; print(sys.executable)"
+            python --version
+            pip list
+            echo "OS Environment Variables"
+            dir env:
 
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -246,26 +285,38 @@ workflows:
   regular_test:
     jobs:
       - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch1.10
-          pytorch_version: '1.10.0+cpu'
-          torchvision_version: '0.11.1+cpu'
+          name: linux_cpu_tests_pytorch1.12
+          pytorch_version: '1.12.1+cpu'
+          torchvision_version: '0.13.1+cpu'
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch1.13
+          pytorch_version: '1.13.1+cpu'
+          torchvision_version: '0.14.1+cpu'
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch2.0
+          pytorch_version: '2.0.0+cpu'
+          torchvision_version: '0.15.1+cpu'
       - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.8
-          pytorch_version: '1.8.1+cu111'
-          torchvision_version: '0.9.1+cu111'
+          name: linux_gpu_tests_pytorch1.12
+          pytorch_version: '1.12.1+cu116'
+          torchvision_version: '0.13.1+cu116'
+          cuda_version: '11.6'
       - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.9
-          pytorch_version: '1.9+cu111'
-          torchvision_version: '0.10+cu111'
+          name: linux_gpu_tests_pytorch1.13
+          pytorch_version: '1.13.1+cu116'
+          torchvision_version: '0.14.1+cu116'
+          cuda_version: '11.6'
       - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10
-          pytorch_version: '1.10+cu111'
-          torchvision_version: '0.11.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10_python39
-          pytorch_version: '1.10+cu111'
-          torchvision_version: '0.11.1+cu111'
-          python_version: '3.9.6'
+          name: linux_gpu_tests_pytorch2.0
+          pytorch_version: '2.0.0+cu118'
+          torchvision_version: '0.15.1+cu118'
+          cuda_version: '11.8'
       - windows_cpu_build:
-          pytorch_version: '1.10+cpu'
-          torchvision_version: '0.11.1+cpu'
+          pytorch_version: '1.12.1+cpu'
+          torchvision_version: '0.13.1+cpu'
+      - windows_cpu_build:
+          pytorch_version: '1.13.1+cpu'
+          torchvision_version: '0.14.1+cpu'
+      - windows_cpu_build:
+          pytorch_version: '2.0.0+cpu'
+          torchvision_version: '0.15.1+cpu'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ version_parameters: &version_parameters
       default: "https://download.pytorch.org/whl/torch_stable.html"
     python_version: # NOTE: only affects linux
       type: string
-      default: '3.10.6'
+      default: '3.10.10'
     cuda_version:
       type: string
       default: '11.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,12 +352,6 @@ workflows:
           torchvision_version: '0.15.2+cu121'
           cuda_version: '11.8'
           python_version: '3.11'
-      - linux_gpu_tests118:
-          name: linux_gpu_tests_pytorch2.0.1
-          pytorch_version: '2.0.1+cu121'
-          torchvision_version: '0.15.2+cu121'
-          cuda_version: '11.8'
-          python_version: '3.11'
       - linux_gpu_tests121:
           name: linux_gpu_tests_pytorch2.0.1
           pytorch_version: 'master'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 # -------------------------------------------------------------------------------------
 cpu: &cpu
   machine:
-    image: ubuntu-2204:2023.02.1
+    image: ubuntu-2204:2023.04.2
   resource_class: medium
 
 gpu: &gpu
@@ -205,7 +205,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -218,7 +218,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
 
   linux_gpu_tests:
     <<: *gpu
@@ -231,7 +231,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -245,7 +245,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
 
 
   windows_cpu_build:
@@ -259,7 +259,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
 
       - run:
           name: Install Dependencies
@@ -290,7 +290,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230327
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230523
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
@@ -205,7 +205,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
 
   linux_gpu_tests:
     <<: *gpu
@@ -218,7 +218,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
       - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
@@ -230,7 +230,7 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
 
 
   windows_cpu_build:
@@ -244,7 +244,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
 
       - run:
           name: Install Dependencies
@@ -275,7 +275,7 @@ jobs:
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230317
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230319
 
       - <<: *install_detectron2
       # TODO: unittest fails for now

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,12 +346,25 @@ workflows:
           pytorch_version: '1.13.1+cu116'
           torchvision_version: '0.14.1+cu116'
           cuda_version: '11.6'
-      - linux_gpu_tests121:
+      - linux_gpu_tests118:
           name: linux_gpu_tests_pytorch2.0.1
           pytorch_version: '2.0.1+cu121'
           torchvision_version: '0.15.2+cu121'
+          cuda_version: '11.8'
+          python_version: '3.11'
+      - linux_gpu_tests118:
+          name: linux_gpu_tests_pytorch2.0.1
+          pytorch_version: '2.0.1+cu121'
+          torchvision_version: '0.15.2+cu121'
+          cuda_version: '11.8'
+          python_version: '3.11'
+      - linux_gpu_tests121:
+          name: linux_gpu_tests_pytorch2.0.1
+          pytorch_version: 'master'
+          torchvision_version: 'main'
           cuda_version: '12.1'
           python_version: '3.11'
+          pytorch_index: 'https://download.pytorch.org/whl/nightly/cu121'
       - windows_cpu_build:
           pytorch_version: '1.13.1+cpu'
           torchvision_version: '0.14.1+cpu'

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
+    # if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python${{ matrix.python }}/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230327
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230523
       - name: Install dependencies macOS
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,7 +3,6 @@ on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -9,17 +9,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python: [ "3.8", "3.9", "3.10", "3.11" ]
-        torch: [ "1.12.1", "1.13.1", "2.0" ]
+        torch: [ "1.13.1", "2.0.1" ]
         include:
-          - torch: "1.12.1"
-            torchvision: "0.13.1"
           - torch: "1.13.1"
             torchvision: "0.14.1"
-          - torch: "2.0"
-            torchvision: "0.15.1"
+          - torch: "2.0.1"
+            torchvision: "0.15.2"
         exclude:
-          - python: "3.11"
-            torch: "1.12.1"
           - python: "3.11"
             torch: "1.13.1"
     env:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,7 +3,7 @@ on: [ push, pull_request ]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    # if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python${{ matrix.python }}/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230317
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230327
       - name: Install dependencies macOS
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,83 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: [ "3.8", "3.9", "3.10", "3.11" ]
+        torch: [ "1.12.1", "1.13.1", "2.0" ]
+        include:
+          - torch: "1.12.1"
+            torchvision: "0.13.1"
+          - torch: "1.13.1"
+            torchvision: "0.14.1"
+          - torch: "2.0"
+            torchvision: "0.15.1"
+        exclude:
+          - python: "3.11"
+            torch: "1.12.1"
+          - python: "3.11"
+            torch: "1.13.1"
+    env:
+      # point datasets to ~/.torch so it's cached by CI
+      DETECTRON2_DATASETS: ~/.torch/datasets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.pythonLocation }}/lib/python${{ matrix.python }}/site-packages
+            ~/.torch
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230317
+      - name: Install dependencies macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m pip install -U pip
+          python -m pip install ninja opencv-python-headless onnx pytest-xdist
+          python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+          # install from github to get latest; install iopath first since fvcore depends on it
+          python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
+          python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+      - name: Install dependencies ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python -m pip install -U pip
+          python -m pip install ninja opencv-python-headless onnx pytest-xdist
+          python -m pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --index-url https://download.pytorch.org/whl/cpu
+          # install from github to get latest; install iopath first since fvcore depends on it
+          python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
+          python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+      - name: Build and install macos
+        if: matrix.os == 'macOS'
+        run: |
+          CC=clang CXX=clang++ python -m pip install -e .[all]
+          python -m detectron2.utils.collect_env
+      - name: Create wheel
+        run: |
+          python -m pip install wheel
+          python setup.py bdist_wheel
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: detectron2-${{ matrix.python }}-pytorch${{ matrix.torch }}-${{matrix.os}}-wheel
+          path: dist/*.whl
+      - name: Build and install linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python -m pip install -e .[all]
+          python -m detectron2.utils.collect_env
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: detectron2-${{ matrix.python }}-pytorch${{ matrix.torch }}-${{matrix.os}}-wheel
+          path: dist/*.whl

--- a/.github/workflows/check-template.yml
+++ b/.github/workflows/check-template.yml
@@ -10,8 +10,8 @@ jobs:
     # comment this out when testing with https://github.com/nektos/act
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/github-script@v3
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - name: Close old issues that need reply
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           # Modified from https://github.com/dwieeb/needs-reply
@@ -90,7 +90,7 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - name: Lock closed issues that have no activity for a while
-        uses: dessant/lock-threads@v2
+        uses: dessant/lock-threads@v4
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: '300'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -66,7 +66,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.10/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230319
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230327
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,17 +37,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: [ "1.12.1", "1.13.1", "2.0" ]
+        torch: [ "1.13.1", "2.0.1" ]
         include:
-          - torch: "1.12.1"
-            torchvision: "0.13.1"
           - torch: "1.13.1"
             torchvision: "0.14.1"
-          - torch: "2.0"
-            torchvision: "0.15.1"
+          - torch: "2.0.1"
+            torchvision: "0.15.2"
         exclude:
-          - python: "3.11"
-            torch: "1.12.1"
           - python: "3.11"
             torch: "1.13.1"
     env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,12 +37,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: [ "1.12", "1.13" ]
+        torch: [ "1.12.1", "1.13.1", "2.0" ]
         include:
-          - torch: "1.12"
-            torchvision: "0.13.0"
-          - torch: "1.13"
-            torchvision: "0.14.0"
+          - torch: "1.12.1"
+            torchvision: "0.13.1"
+          - torch: "1.13.1"
+            torchvision: "0.14.1"
+          - torch: "2.0"
+            torchvision: "0.15.1"
+        exclude:
+          - python: "3.11"
+            torch: "1.12.1"
+          - python: "3.11"
+            torch: "1.13.1"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 # Run linter with github actions for quick feedbacks.
 # Run macos tests with github actions. Linux (CPU & GPU) tests currently runs on CircleCI
@@ -9,22 +9,22 @@ jobs:
     # run on PRs, or commits to facebookresearch (not internal)
     if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         # flake8-bugbear flake8-comprehensions are useful but not available internally
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8==3.8.1 isort==4.3.21
-          python -m pip install black==22.3.0
+          python -m pip install flake8==6.0.0 isort==5.12.0
+          python -m pip install black==23.1.0
           flake8 --version
       - name: Lint
         run: |
           echo "Running isort"
-          isort -c -sp .
+          isort -c --sp . .
           echo "Running black"
           black -l 100 --check .
           echo "Running flake8"
@@ -37,31 +37,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ["1.8", "1.9", "1.10"]
+        torch: [ "1.12", "1.13" ]
         include:
-          - torch: "1.8"
-            torchvision: 0.9
-          - torch: "1.9"
-            torchvision: "0.10"
-          - torch: "1.10"
-            torchvision: "0.11.1"
+          - torch: "1.12"
+            torchvision: "0.13.0"
+          - torch: "1.13"
+            torchvision: "0.14.0"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
-            ${{ env.pythonLocation }}/lib/python3.8/site-packages
+            ${{ env.pythonLocation }}/lib/python3.10/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220119
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230319
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -66,7 +66,7 @@ jobs:
           path: |
             ${{ env.pythonLocation }}/lib/python3.10/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230327
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230523
 
       - name: Install dependencies
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
 ## Installation
 
 ### Requirements
-- Linux or macOS with Python ≥ 3.7
-- PyTorch ≥ 1.8 and [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
+- Linux or macOS with Python ≥ 3.8
+- PyTorch ≥ 1.12 and [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
   Install them together at [pytorch.org](https://pytorch.org) to make sure of this
 - OpenCV is optional but needed by demo and visualization
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ old build first. You often need to rebuild detectron2 after reinstalling PyTorch
 
 ### Install Pre-Built Detectron2 (Linux only)
 
-Choose from this table to install [v0.6 (Oct 2021)](https://github.com/facebookresearch/detectron2/releases):
+Choose from this table to install [v0.7 (June 2023)](https://github.com/facebookresearch/detectron2/releases):
 
 <table class="docutils"><tbody><th width="80"> CUDA </th><th valign="bottom" align="left" width="100">torch 1.13</th><th valign="bottom" align="left" width="100">torch 2.0.1</th><th valign="bottom" align="left" width="100">torch nightly</th> <tr><td align="left">12.1</td><td></td><td></td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
   https://dl.fbaipublicfiles.com/detectron2/wheels/cu121/torchnightly/index.html

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ### Requirements
 - Linux or macOS with Python ≥ 3.8
-- PyTorch ≥ 1.12 and [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
+- PyTorch ≥ 1.13 and [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
   Install them together at [pytorch.org](https://pytorch.org) to make sure of this
 - OpenCV is optional but needed by demo and visualization
 
@@ -30,29 +30,15 @@ old build first. You often need to rebuild detectron2 after reinstalling PyTorch
 
 Choose from this table to install [v0.6 (Oct 2021)](https://github.com/facebookresearch/detectron2/releases):
 
-<table class="docutils"><tbody><th width="80"> CUDA </th><th valign="bottom" align="left" width="100">torch 1.10</th><th valign="bottom" align="left" width="100">torch 1.9</th><th valign="bottom" align="left" width="100">torch 1.8</th> <tr><td align="left">11.3</td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu113/torch1.10/index.html
-</code></pre> </details> </td> <td align="left"> </td> <td align="left"> </td> </tr> <tr><td align="left">11.1</td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch1.10/index.html
+<table class="docutils"><tbody><th width="80"> CUDA </th><th valign="bottom" align="left" width="100">torch 1.13</th><th valign="bottom" align="left" width="100">torch 2.0.1</th><th valign="bottom" align="left" width="100">torch nightly</th> <tr><td align="left">12.1</td><td></td><td></td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
+  https://dl.fbaipublicfiles.com/detectron2/wheels/cu121/torchnightly/index.html
+</code></pre> </details> </td> <td align="left"> </td> <td align="left"> </td> </tr> <tr><td align="left">11.8</td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
+  https://dl.fbaipublicfiles.com/detectron2/wheels/cu118/torch1.13/index.html
 </code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch1.9/index.html
+  https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch2.0/index.html
 </code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu111/torch1.8/index.html
-</code></pre> </details> </td> </tr> <tr><td align="left">10.2</td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu102/torch1.10/index.html
-</code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu102/torch1.9/index.html
-</code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu102/torch1.8/index.html
-</code></pre> </details> </td> </tr> <tr><td align="left">10.1</td><td align="left"> </td> <td align="left"> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cu101/torch1.8/index.html
-</code></pre> </details> </td> </tr> <tr><td align="left">cpu</td><td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.10/index.html
-</code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.9/index.html
-</code></pre> </details> </td> <td align="left"><details><summary> install </summary><pre><code>python -m pip install detectron2 -f \
-  https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.8/index.html
-</code></pre> </details> </td> </tr></tbody></table>
+  https://dl.fbaipublicfiles.com/detectron2/wheels/cu118/torchnightly/index.html
+</tr></tbody></table>
 
 Note that:
 1. The pre-built packages have to be used with corresponding version of CUDA and the official package of PyTorch.

--- a/detectron2/__init__.py
+++ b/detectron2/__init__.py
@@ -7,4 +7,4 @@ setup_environment()
 
 # This line will be programatically read/write by setup.py.
 # Leave them at the bottom of this file and don't touch them.
-__version__ = "0.6"
+__version__ = "0.7"

--- a/detectron2/data/common.py
+++ b/detectron2/data/common.py
@@ -100,7 +100,7 @@ class MapDataset(data.Dataset):
             # _map_func fails for this idx, use a random new index from the pool
             retry_count += 1
             self._fallback_candidates.discard(cur_idx)
-            cur_idx = self._rng.sample(self._fallback_candidates, k=1)[0]
+            cur_idx = self._rng.sample(list(self._fallback_candidates), k=1)[0]
 
             if retry_count >= 3:
                 logger = logging.getLogger(__name__)

--- a/detectron2/utils/testing.py
+++ b/detectron2/utils/testing.py
@@ -274,6 +274,11 @@ skipIfOnCPUCI = unittest.skipIf(
     "The test is too slow on CPUs and will be executed on CircleCI's GPU jobs.",
 )
 
+# SKIP IF PYTORCH VERSION > 1.10
+skipIfOnPytorch1_10 = unittest.skipIf(
+    min_torch_version("1.10"),
+    "The test is not supported on PyTorch 1.10+",
+)
 
 def skipIfUnsupportedMinOpsetVersion(min_opset_version, current_opset_version=None):
     """

--- a/dev/linter.sh
+++ b/dev/linter.sh
@@ -7,20 +7,20 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 {
   black --version | grep -E "22\." > /dev/null
 } || {
-  echo "Linter requires 'black==22.*' !"
+  echo "Linter requires 'black==23.*' !"
   exit 1
 }
 
 ISORT_VERSION=$(isort --version-number)
-if [[ "$ISORT_VERSION" != 4.3* ]]; then
-  echo "Linter requires isort==4.3.21 !"
+if [[ "$ISORT_VERSION" != 5.12* ]]; then
+  echo "Linter requires isort==5.12.0 !"
   exit 1
 fi
 
 set -v
 
 echo "Running isort ..."
-isort -y -sp . --atomic
+isort --apply --sp . . --atomic
 
 echo "Running black ..."
 black -l 100 .

--- a/dev/packaging/build_all_wheels.sh
+++ b/dev/packaging/build_all_wheels.sh
@@ -26,7 +26,7 @@ build_one() {
   echo "Launching container $container_name ..."
   container_id="$container_name"_"$cu"_"$pytorch_ver"
 
-  py_versions=(3.7 3.8 3.9)
+  py_versions=(3.8 3.9 3.10 3.11)
 
   for py in "${py_versions[@]}"; do
     docker run -itd \
@@ -49,17 +49,10 @@ EOF
 if [[ -n "$1" ]] && [[ -n "$2" ]]; then
   build_one "$1" "$2"
 else
-  build_one cu113 1.10
-  build_one cu111 1.10
-  build_one cu102 1.10
-  build_one cpu 1.10
-
-  build_one cu111 1.9
-  build_one cu102 1.9
-  build_one cpu 1.9
-
-  build_one cu111 1.8
-  build_one cu102 1.8
-  build_one cu101 1.8
-  build_one cpu 1.8
+  build_one cu121 2.0
+  build_one cu120 2.0
+  build_one cu118 2.0
+  build_one cu117 1.13
+  build_one cu116 1.12
+  build_one cpu 1.13
 fi

--- a/dev/packaging/build_all_wheels.sh
+++ b/dev/packaging/build_all_wheels.sh
@@ -54,5 +54,7 @@ else
   build_one cu118 2.0
   build_one cu117 1.13
   build_one cu116 1.12
+  build_one cpu 2.0
   build_one cpu 1.13
+  build_one cpu 1.12
 fi

--- a/dev/packaging/gen_install_table.py
+++ b/dev/packaging/gen_install_table.py
@@ -9,6 +9,12 @@ python -m pip install detectron2{d2_version} -f \\
   https://dl.fbaipublicfiles.com/detectron2/wheels/{cuda}/torch{torch}/index.html
 </code></pre> </details>"""
 CUDA_SUFFIX = {
+    "12.1": "cu121",
+    "12.0": "cu120",
+    "11.8": "cu118",
+    "11.7": "cu117",
+    "11.6": "cu116",
+    "11.4": "cu114",
     "11.3": "cu113",
     "11.1": "cu111",
     "11.0": "cu110",
@@ -39,13 +45,17 @@ if __name__ == "__main__":
         [("1.8", k) for k in ["11.1", "10.2", "10.1", "cpu"]]
         + [("1.9", k) for k in ["11.1", "10.2", "cpu"]]
         + [("1.10", k) for k in ["11.3", "11.1", "10.2", "cpu"]]
+        + [("1.13", k) for k in ["11.7", "11.6", "11.4", "cpu"]]
+        + [("2.0", k) for k in ["12.1", "12.0", "11.8", "cpu"]]
     )
 
     torch_versions = sorted(
         {k[0] for k in all_versions}, key=lambda x: int(x.split(".")[1]), reverse=True
     )
     cuda_versions = sorted(
-        {k[1] for k in all_versions}, key=lambda x: float(x) if x != "cpu" else 0, reverse=True
+        {k[1] for k in all_versions},
+        key=lambda x: float(x) if x != "cpu" else 0,
+        reverse=True,
     )
 
     table = gen_header(torch_versions)

--- a/dev/packaging/pkg_helpers.bash
+++ b/dev/packaging/pkg_helpers.bash
@@ -18,41 +18,25 @@ setup_cuda() {
   # and https://github.com/pytorch/vision/blob/main/packaging/pkg_helpers.bash for reference.
   export FORCE_CUDA=1
   case "$CU_VERSION" in
-    cu113)
-      export CUDA_HOME=/usr/local/cuda-11.3/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu121)
+      export CUDA_HOME=/usr/local/cuda-12.1/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu112)
-      export CUDA_HOME=/usr/local/cuda-11.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu120)
+      export CUDA_HOME=/usr/local/cuda-12.0/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu111)
-      export CUDA_HOME=/usr/local/cuda-11.1/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu118)
+      export CUDA_HOME=/usr/local/cuda-11.8/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu110)
-      export CUDA_HOME=/usr/local/cuda-11.0/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0+PTX"
+    cu117)
+      export CUDA_HOME=/usr/local/cuda-11.7/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
       ;;
-    cu102)
-      export CUDA_HOME=/usr/local/cuda-10.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu101)
-      export CUDA_HOME=/usr/local/cuda-10.1/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu100)
-      export CUDA_HOME=/usr/local/cuda-10.0/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu92)
-      export CUDA_HOME=/usr/local/cuda-9.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0+PTX"
-      ;;
-    cpu)
-      unset FORCE_CUDA
-      export CUDA_VISIBLE_DEVICES=
+    cu116)
+      export CUDA_HOME=/usr/local/cuda-11.6/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
       ;;
     *)
       echo "Unrecognized CU_VERSION=$CU_VERSION"
@@ -63,9 +47,10 @@ setup_cuda() {
 
 setup_wheel_python() {
   case "$PYTHON_VERSION" in
-    3.7) python_abi=cp37-cp37m ;;
     3.8) python_abi=cp38-cp38 ;;
     3.9) python_abi=cp39-cp39 ;;
+    3.10) python_abi=cp310-cp310 ;;
+    3.11) python_abi=cp311-cp311 ;;
     *)
       echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
       exit 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
+FROM nvidia/cuda:12.0.1-cudnn8-devel-ubuntu22.04
 # use an older system (18.04) to avoid opencv incompatibility (issue#3524)
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -14,14 +14,14 @@ USER appuser
 WORKDIR /home/appuser
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
+RUN wget https://bootstrap.pypa.io/pip/3.10/get-pip.py && \
 	python3 get-pip.py --user && \
 	rm get-pip.py
 
 # install dependencies
 # See https://pytorch.org/ for other options if you use a different version of CUDA
 RUN pip install --user tensorboard cmake onnx   # cmake from apt-get is too old
-RUN pip install --user torch==1.10 torchvision==0.11.1 -f https://download.pytorch.org/whl/cu111/torch_stable.html
+RUN pip install --user torch==2.0.1 torchvision==0.15.2 -f https://download.pytorch.org/whl/cu118/torch_stable.html
 
 RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'
 # install detectron2
@@ -30,7 +30,7 @@ RUN git clone https://github.com/facebookresearch/detectron2 detectron2_repo
 ENV FORCE_CUDA="1"
 # This will by default build detectron2 for all common cuda architectures and take a lot more time,
 # because inside `docker build`, there is no way to tell which architecture will be used.
-ARG TORCH_CUDA_ARCH_LIST="Kepler;Kepler+Tesla;Maxwell;Maxwell+Tegra;Pascal;Volta;Turing"
+ARG TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
 ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
 
 RUN pip install --user -e detectron2_repo

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,5 @@
 
-## Use the container (with docker ≥ 19.03)
+## Use the container (with docker ≥ 24.0.2)
 
 ```
 cd docker/
@@ -14,7 +14,7 @@ docker run --gpus all -it \
 xhost +local:`docker inspect --format='{{ .Config.Hostname }}' detectron2`
 ```
 
-## Use the container (with docker-compose ≥ 1.28.0)
+## Use the container (with docker-compose ≥ 2.18.1)
 
 Install docker-compose and nvidia-docker-toolkit, then run:
 ```

--- a/docker/deploy.Dockerfile
+++ b/docker/deploy.Dockerfile
@@ -10,12 +10,12 @@ ENV HOME=/home/appuser
 WORKDIR $HOME
 
 # Let torchvision find libtorch
-ENV CMAKE_PREFIX_PATH=$HOME/.local/lib/python3.6/site-packages/torch/
+ENV CMAKE_PREFIX_PATH=$HOME/.local/lib/python3.8/site-packages/torch/
 
 RUN sudo apt-get update && sudo apt-get install libopencv-dev --yes
 
 # install libtorchvision
-RUN git clone --branch v0.11.1 https://github.com/pytorch/vision/
+RUN git clone --branch v0.15.2 https://github.com/pytorch/vision/
 RUN mkdir vision/build && cd vision/build && \
 	cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_BUILD_TYPE=Release -DWITH_CUDA=on -DTORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST && \
 	make -j && make install

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.3"
+version: '3.1'
 services:
   detectron2:
     build:

--- a/docs/notes/benchmarks.md
+++ b/docs/notes/benchmarks.md
@@ -8,7 +8,7 @@ with some other popular open source Mask R-CNN implementations.
 ### Settings
 
 * Hardware: 8 NVIDIA V100s with NVLink.
-* Software: Python 3.7, CUDA 10.1, cuDNN 7.6.5, PyTorch 1.5,
+* Software: Python 3.8, CUDA 11.6, cuDNN 8, PyTorch 1.12,
   TensorFlow 1.15.0rc2, Keras 2.2.5, MxNet 1.6.0b20190820.
 * Model: an end-to-end R-50-FPN Mask-RCNN model, using the same hyperparameter as the
   [Detectron baseline config](https://github.com/facebookresearch/Detectron/blob/master/configs/12_2017_baselines/e2e_mask_rcnn_R-50-FPN_1x.yaml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
---extra-index-url https://download.pytorch.org/whl/cu118
-onnx==1.14.0
-torch==2.0.1+cu118; sys_platform != 'darwin'
-torch==2.0.1; sys_platform == 'darwin'
-onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'
-onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
-onnxruntime-gpu==1.15.0; sys_platform != 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/cu118
+onnx==1.14.0
+torch==2.0.1+cu118; sys_platform != 'darwin'
+torch==2.0.1; sys_platform == 'darwin'
+onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'
+onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+onnxruntime-gpu==1.15.0; sys_platform != 'darwin'

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,11 @@ skip_glob=*/__init__.py,**/configs/**,**/tests/config/**
 known_myself=detectron2
 known_third_party=fvcore,matplotlib,cv2,torch,torchvision,PIL,pycocotools,yacs,termcolor,cityscapesscripts,tabulate,tqdm,scipy,lvis,psutil,pkg_resources,caffe2,onnx,panopticapi,black,isort,av,iopath,omegaconf,hydra,yaml,pydoc,submitit,cloudpickle,packaging,timm,pandas,fairscale,pytorch3d,pytorch_lightning
 no_lines_before=STDLIB,THIRDPARTY
-sections=FUTURE,STDLIB,THIRDPARTY,myself,FIRSTPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,MYSELF,FIRSTPARTY,LOCALFOLDER
 default_section=FIRSTPARTY
 
 [mypy]
-python_version=3.7
+python_version=3.8.16
 ignore_missing_imports = True
 warn_unused_configs = True
 disallow_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,12 @@ setup(
         # These dependencies are not pure-python.
         # In general, avoid adding dependencies that are not pure-python because they are not
         # guaranteed to be installable by `pip install` on all platforms.
+        "onnx==1.14.0",
+        "torch==2.0.1+cu118; sys_platform != 'darwin'",
+        "torch==2.0.1; sys_platform == 'darwin'",
+        "onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'",
+        "onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+        "onnxruntime-gpu==1.15.0; sys_platform != 'darwin'",
         "Pillow>=7.1",  # or use pillow-simd for better performance
         "matplotlib",  # TODO move it to optional after we add opencv visualization
         "pycocotools>=2.0.2",  # corresponds to https://github.com/ppwwyyxx/cocoapi

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from os import path
 from typing import List
 
 torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-assert torch_ver >= [1, 12], "Requires PyTorch >= 1.12"
+assert torch_ver >= [1, 13], "Requires PyTorch >= 1.13"
 
 
 def get_version():
@@ -51,7 +51,7 @@ def get_extensions():
         True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
     )
     if is_rocm_pytorch:
-        assert torch_ver >= [1, 8], "ROCM support requires PyTorch >= 1.8!"
+        assert torch_ver >= [1, 13], "ROCM support requires PyTorch >= 1.13!"
 
     # common code between cuda and rocm platforms, for hipify version [1,0,0] and later.
     source_cuda = glob.glob(path.join(extensions_dir, "**", "*.cu")) + glob.glob(
@@ -212,7 +212,7 @@ setup(
             "isort==5.12.0",
             "flake8-bugbear",
             "flake8-comprehensions",
-            "black==23.1.0",
+            "black==23.3.0",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+from setuptools import find_packages, setup
+import torch
+from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
+
 import glob
 import os
 import shutil
 from os import path
-from setuptools import find_packages, setup
 from typing import List
-import torch
-from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
 
 torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-assert torch_ver >= [1, 8], "Requires PyTorch >= 1.8"
+assert torch_ver >= [1, 12], "Requires PyTorch >= 1.12"
 
 
 def get_version():
@@ -154,7 +155,7 @@ setup(
     packages=find_packages(exclude=("configs", "tests*")) + list(PROJECTS.keys()),
     package_dir=PROJECTS,
     package_data={"detectron2.model_zoo": get_model_zoo_configs()},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         # These dependencies are not pure-python.
         # In general, avoid adding dependencies that are not pure-python because they are not
@@ -203,11 +204,11 @@ setup(
         ],
         # dev dependencies. Install them by `pip install 'detectron2[dev]'`
         "dev": [
-            "flake8==3.8.1",
-            "isort==4.3.21",
+            "flake8==6.0.0",
+            "isort==5.12.0",
             "flake8-bugbear",
             "flake8-comprehensions",
-            "black==22.3.0",
+            "black==23.1.0",
         ],
     },
     ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def get_extensions():
         if nvcc_flags_env != "":
             extra_compile_args["nvcc"].extend(nvcc_flags_env.split(" "))
 
-        if torch_ver < [1, 7]:
+        if torch_ver < [1, 12]:
             # supported by https://github.com/pytorch/pytorch/pull/43931
             CC = os.environ.get("CC", None)
             if CC is not None:
@@ -164,12 +164,6 @@ setup(
         # These dependencies are not pure-python.
         # In general, avoid adding dependencies that are not pure-python because they are not
         # guaranteed to be installable by `pip install` on all platforms.
-        "onnx==1.14.0",
-        "torch==2.0.1+cu118; sys_platform != 'darwin'",
-        "torch==2.0.1; sys_platform == 'darwin'",
-        "onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'",
-        "onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
-        "onnxruntime-gpu==1.15.0; sys_platform != 'darwin'",
         "Pillow>=7.1",  # or use pillow-simd for better performance
         "matplotlib",  # TODO move it to optional after we add opencv visualization
         "pycocotools>=2.0.2",  # corresponds to https://github.com/ppwwyyxx/cocoapi

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -87,7 +87,7 @@ class TestMapDataset(unittest.TestCase):
     def test_pickleability(self):
         ds = DatasetFromList([1, 2, 3])
         ds = MapDataset(ds, lambda x: x * 2)
-        ds = pickle.loads(pickle.dumps(ds))
+        ds = pickle.loads(pickle.dumps(list(ds)))
         self.assertEqual(ds[0], 2)
 
 

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -23,6 +23,7 @@ from detectron2.utils.testing import (
     random_boxes,
     register_custom_op_onnx_export,
     skipIfOnCPUCI,
+    skipIfOnPytorch1_10,
     skipIfUnsupportedMinOpsetVersion,
     skipIfUnsupportedMinTorchVersion,
     unregister_custom_op_onnx_export,
@@ -30,7 +31,7 @@ from detectron2.utils.testing import (
 
 
 @unittest.skipIf(not _check_module_exists("onnx"), "ONNX not installed.")
-@skipIfUnsupportedMinTorchVersion("1.12")
+@skipIfOnPytorch1_10
 class TestONNXTracingExport(unittest.TestCase):
     opset_version = STABLE_ONNX_OPSET_VERSION
 
@@ -46,7 +47,7 @@ class TestONNXTracingExport(unittest.TestCase):
         )
 
     @skipIfOnCPUCI
-    @skipIfUnsupportedMinTorchVersion("1.12")
+    @skipIfOnPytorch1_10
     def testMaskRCNNC4(self):
         def inference_func(model, image):
             inputs = [{"image": image}]

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -30,7 +30,7 @@ from detectron2.utils.testing import (
 
 
 @unittest.skipIf(not _check_module_exists("onnx"), "ONNX not installed.")
-@skipIfUnsupportedMinTorchVersion("1.10")
+@skipIfUnsupportedMinTorchVersion("1.11")
 class TestONNXTracingExport(unittest.TestCase):
     opset_version = STABLE_ONNX_OPSET_VERSION
 
@@ -46,6 +46,7 @@ class TestONNXTracingExport(unittest.TestCase):
         )
 
     @skipIfOnCPUCI
+    @skipIfUnsupportedMinTorchVersion("1.11")
     def testMaskRCNNC4(self):
         def inference_func(model, image):
             inputs = [{"image": image}]

--- a/tests/test_export_onnx.py
+++ b/tests/test_export_onnx.py
@@ -30,7 +30,7 @@ from detectron2.utils.testing import (
 
 
 @unittest.skipIf(not _check_module_exists("onnx"), "ONNX not installed.")
-@skipIfUnsupportedMinTorchVersion("1.11")
+@skipIfUnsupportedMinTorchVersion("1.12")
 class TestONNXTracingExport(unittest.TestCase):
     opset_version = STABLE_ONNX_OPSET_VERSION
 
@@ -46,7 +46,7 @@ class TestONNXTracingExport(unittest.TestCase):
         )
 
     @skipIfOnCPUCI
-    @skipIfUnsupportedMinTorchVersion("1.11")
+    @skipIfUnsupportedMinTorchVersion("1.12")
     def testMaskRCNNC4(self):
         def inference_func(model, image):
             inputs = [{"image": image}]

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -28,7 +28,7 @@ from detectron2.utils.testing import (
     convert_scripted_instances,
     get_sample_coco_image,
     random_boxes,
-    skipIfOnCPUCI,
+    skipIfOnCPUCI, skipIfUnsupportedMinTorchVersion,
 )
 
 
@@ -43,6 +43,7 @@ class TestScripting(unittest.TestCase):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")
 
     @skipIfOnCPUCI
+    @skipIfUnsupportedMinTorchVersion("1.11")
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -28,7 +28,7 @@ from detectron2.utils.testing import (
     convert_scripted_instances,
     get_sample_coco_image,
     random_boxes,
-    skipIfOnCPUCI, skipIfUnsupportedMinTorchVersion,
+    skipIfOnCPUCI, skipIfOnPytorch1_10,
 )
 
 
@@ -43,7 +43,7 @@ class TestScripting(unittest.TestCase):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")
 
     @skipIfOnCPUCI
-    @skipIfUnsupportedMinTorchVersion("1.12")
+    @skipIfOnPytorch1_10
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 
@@ -112,7 +112,7 @@ class TestTracing(unittest.TestCase):
         self._test_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml", inference_func)
 
     @skipIfOnCPUCI
-    @skipIfUnsupportedMinTorchVersion("1.12")
+    @skipIfOnPytorch1_10
     def testMaskRCNNC4(self):
         def inference_func(model, image):
             inputs = [{"image": image}]

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -43,7 +43,7 @@ class TestScripting(unittest.TestCase):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml")
 
     @skipIfOnCPUCI
-    @skipIfUnsupportedMinTorchVersion("1.11")
+    @skipIfUnsupportedMinTorchVersion("1.12")
     def testMaskRCNNC4(self):
         self._test_rcnn_model("COCO-InstanceSegmentation/mask_rcnn_R_50_C4_3x.yaml")
 
@@ -112,6 +112,7 @@ class TestTracing(unittest.TestCase):
         self._test_model("COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml", inference_func)
 
     @skipIfOnCPUCI
+    @skipIfUnsupportedMinTorchVersion("1.12")
     def testMaskRCNNC4(self):
         def inference_func(model, image):
             inputs = [{"image": image}]


### PR DESCRIPTION
I have been able to compile with CUDA 11.8 and CUDA 12.0 & 12.1 using PyTorch 1.13.1, PyTorch dev 2.0 and python 3.10.6(In local)
- [X] Python <3.8 versions deleted (Deprecated 27 Jun 2023)
- [X] Python 3.10.6 (added as default) (CircleCI images have 3.10.6 & 3.11)
- [X] PyTorch <1.12 delete. Deprecated (https://pytorch.org/blog/deprecation-cuda-python-support/)
- [X] Updated ubuntu-2204:2023.02.1 CPU
- [X] Updated linux-cuda-11:2023.02.1 GPU https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/3
- [X] New image CircleCI CUDA 11.8, and they are working to CUDA 12. https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/4
- [X] Windows image 2022: windows-server-2022-gui:2022.10.1
- [X] Updated test compatible with CUDA and PyTorch > 1.10
- [X] Unified workflow GitHub and CircleCI python versions: Python 3.10.6
- [X] Added CUDA variable on CircleCI: You now can select CUDA VERSION.
- [X] Added PyTorch 2.0 and CUDA 11.8. 12.0/12.1 CircleCI (CircleCI working to release CUDA 12 images at the end of the month)
- [X] Fixed tests for PyTorch 1.10+ and Python 3.10
- [X] New versions and lint compatible with Python 3.10 [isort, black, flake8]
![image](https://user-images.githubusercontent.com/22727137/212372894-48219145-469a-49e1-9e91-291191695f77.png)
![image](https://user-images.githubusercontent.com/22727137/212377228-d7ed3be1-0d09-4d3f-ace1-1a7b287dfd7a.png)



