### PR TITLE
Add check for start_iter and max_iter

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -147,6 +147,10 @@ class TrainerBase:
         self.iter = self.start_iter = start_iter
         self.max_iter = max_iter
 
+        assert (
+            self.max_iter > self.start_iter
+        ), f"Training starts at {start_iter} MAX_ITER = {max_iter}. The model will not train!"
+
         with EventStorage(start_iter) as self.storage:
             try:
                 self.before_train()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -49,6 +49,14 @@ class TestTrainer(unittest.TestCase):
         )
         trainer.train(0, 10)
 
+    def test_simple_trainer_start_iter_beyond_max_iter(self, device="cpu"):
+        model = _SimpleModel().to(device=device)
+        trainer = SimpleTrainer(
+            model, self._data_loader(device), torch.optim.SGD(model.parameters(), 0.1)
+        )
+        with self.assertRaises(AssertionError):
+            trainer.train(42, 21)
+
     def test_simple_trainer_reset_dataloader(self, device="cpu"):
         model = _SimpleModel().to(device=device)
         trainer = SimpleTrainer(


### PR DESCRIPTION
Summary:
Fail the training if the start iteration is greater than max_iter.
This can happen when fine-tuning models or resuming with modified config file.

Differential Revision: D44501680

