### PR TITLE
Allow async write metrics to speed up training

### DIFF
--- a/detectron2/utils/events.py
+++ b/detectron2/utils/events.py
@@ -340,7 +340,7 @@ class EventStorage:
         """
         self._vis_data.append((img_name, img_tensor, self._iter))
 
-    def put_scalar(self, name, value, smoothing_hint=True):
+    def put_scalar(self, name, value, smoothing_hint=True, cur_iter=None):
         """
         Add a scalar `value` to the `HistoryBuffer` associated with `name`.
 
@@ -352,14 +352,17 @@ class EventStorage:
 
                 It defaults to True because most scalars we save need to be smoothed to
                 provide any useful signal.
+            cur_iter (int): an iteration number to set explicitly instead of current iteration
         """
         name = self._current_prefix + name
+        cur_iter = self._iter if cur_iter is None else cur_iter
         history = self._history[name]
         value = float(value)
-        history.update(value, self._iter)
-        self._latest_scalars[name] = (value, self._iter)
+        history.update(value, cur_iter)
+        self._latest_scalars[name] = (value, cur_iter)
 
         existing_hint = self._smoothing_hints.get(name)
+
         if existing_hint is not None:
             assert (
                 existing_hint == smoothing_hint
@@ -367,7 +370,7 @@ class EventStorage:
         else:
             self._smoothing_hints[name] = smoothing_hint
 
-    def put_scalars(self, *, smoothing_hint=True, **kwargs):
+    def put_scalars(self, *, smoothing_hint=True, cur_iter=None, **kwargs):
         """
         Put multiple scalars from keyword arguments.
 
@@ -376,7 +379,7 @@ class EventStorage:
             storage.put_scalars(loss=my_loss, accuracy=my_accuracy, smoothing_hint=True)
         """
         for k, v in kwargs.items():
-            self.put_scalar(k, v, smoothing_hint=smoothing_hint)
+            self.put_scalar(k, v, smoothing_hint=smoothing_hint, cur_iter=cur_iter)
 
     def put_histogram(self, hist_name, hist_tensor, bins=1000):
         """

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,6 +132,39 @@ class TestTrainer(unittest.TestCase):
                         gt = data[i][key]
                         self.assertEqual(gt, (logged1 + logged2) / 2.0)
 
+    def test_async_write_metrics(self):
+        writer_period = 1
+
+        model = _SimpleModel(sleep_sec=0.1)
+        trainer = SimpleTrainer(
+            model,
+            self._data_loader("cpu"),
+            torch.optim.SGD(model.parameters(), 0.1),
+            async_write_metrics=True,
+        )
+
+        max_iter = 50
+        with tempfile.TemporaryDirectory(prefix="detectron2_test") as d:
+            json_file = os.path.join(d, "metrics.json")
+            writers = [JSONWriter(json_file, window_size=writer_period)]
+
+            trainer.register_hooks(
+                [
+                    hooks.IterationTimer(),
+                    hooks.PeriodicWriter(writers, period=writer_period),
+                ]
+            )
+            trainer.train(0, max_iter)
+
+            with open(json_file, "r") as f:
+                data = [json.loads(line.strip()) for line in f]
+                self.assertEqual([x["iteration"] for x in data], list(range(50)))
+            self.assertEqual(len(trainer.storage.history("time").values()), 48)
+            for key in ["data_time", "total_loss"]:
+                history = trainer.storage.history(key).values()
+                history_iters = [h[1] for h in history]
+                self.assertEqual(history_iters, list(range(50)))
+
     def test_default_trainer(self):
         # TODO: this test requires manifold access, so changed device to CPU. see: T88318502
         cfg = get_cfg()


### PR DESCRIPTION
Summary:
This change is a follow up on D43098985 which reduce the frequency on metrics collection calls due to the issue that its involve gather logic which slows down training.
The downside of that solution is that it impacts the granularity of metrics and loss graphs which reduce visablity and debuggibility of the training progress.

This diff provide a solution that will avoid the slowness of gather logic in the training loop while keep the fine granulariy of the metrics and graphs.
The solution moves the write_metrics call (that include the copy from gpu to cpu, the gather, and the storate event write) to be async in a separate thread.
We introduce a thread pool executor with a single worker (thread) that will execute all the logic that will be submitted to its queue in order.

Reviewed By: sf-wind

Differential Revision: D44305165

