### PR TITLE
fix scripting

### DIFF
--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -28,6 +28,7 @@ from detectron2.utils.testing import (
     convert_scripted_instances,
     get_sample_coco_image,
     random_boxes,
+    reload_script_model,
     skipIfOnCPUCI,
 )
 
@@ -62,6 +63,7 @@ class TestScripting(unittest.TestCase):
             "pred_masks": Tensor,
         }
         script_model = scripting_with_instances(model, fields)
+        script_model = reload_script_model(script_model)
 
         # Test that batch inference with different shapes are supported
         image = get_sample_coco_image()


### PR DESCRIPTION
36a65a0907d90ed591479b2ebaa8b61cfa0b4ef0 causes model to be not scriptable (cannot be saved after scripting).

This PR fixed it and added unittest.

Fix #4915