### PR TITLE
CI: Pin protobuf to latest 3.20 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ install_linux_dep: &install_linux_dep
         # install from github to get latest; install iopath first since fvcore depends on it
         pip install --progress-bar off -U 'git+https://github.com/facebookresearch/iopath'
         pip install --progress-bar off -U 'git+https://github.com/facebookresearch/fvcore'
+        # pytorch ships proto files which are incompatible with protobuf >=4,
+        # see https://github.com/pytorch/pytorch/issues/78362
+        pip install --progress-bar off protobuf~=3.20.3
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx


### PR DESCRIPTION
PyTorch ships proto files which are incompatible with protobuf >=4 but there is no dependency version specification limiting that.
For it doesn't seem that pytorch intends to support 4.* python protobuf (see https://github.com/pytorch/pytorch/issues/78362, as well as protobuf versions are pinned in CI).
