### PR TITLE
Fix typo - size_divisiblity -> size_divisibility

### DIFF
--- a/detectron2/modeling/backbone/vit.py
+++ b/detectron2/modeling/backbone/vit.py
@@ -470,7 +470,7 @@ class SimpleFeaturePyramid(Backbone):
     @property
     def padding_constraints(self):
         return {
-            "size_divisiblity": self._size_divisibility,
+            "size_divisibility": self._size_divisibility,
             "square_size": self._square_pad,
         }
 


### PR DESCRIPTION
Hi, 

There is a typo in the ViT backbone, which causes the ImageList.from_tensors(...) to not pad the input, even though a `size_divisibility` is supposed to exist.
