### PR TITLE
remove opencv in setup.py for DensePose

### DIFF
--- a/projects/DensePose/setup.py
+++ b/projects/DensePose/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         "av>=8.0.3",
         "detectron2@git+https://github.com/facebookresearch/detectron2.git",
-        "opencv-python-headless>=4.5.3.56",
         "scipy>=1.5.4",
     ],
 )


### PR DESCRIPTION
Including opencv in setup.py can ignore already installed opencv versions.

The setup.py file in the detectron2 main repository  [recommends to not include opencv](https://github.com/facebookresearch/detectron2/blob/0df924ce6066fb97d5413244614b12fbabaf65c8/setup.py#L169) to prevent this issue. I think DensePose should follow this. 