### PR TITLE
Fix unused vars in _decode_multi_level_predictions

### DIFF
--- a/detectron2/modeling/meta_arch/dense_detector.py
+++ b/detectron2/modeling/meta_arch/dense_detector.py
@@ -249,8 +249,8 @@ class DenseDetector(nn.Module):
                 anchors_i,
                 box_cls_i,
                 box_reg_i,
-                self.test_score_thresh,
-                self.test_topk_candidates,
+                score_thresh,
+                topk_candidates,
                 image_size,
             )
             # Iterate over every feature level


### PR DESCRIPTION
This is a simple PR that fixes two unused arguments in `_decode_multi_level_predictions` which may lead to confusion:
- `score_thresh`
- `topk_candidates`

https://github.com/facebookresearch/detectron2/blob/2254a10de3a06536fb1d18b55417cd5ece192f59/detectron2/modeling/meta_arch/dense_detector.py#L235-L255

This hasn't been an issue because, luckily, both concrete `DenseDetector`s available in detectron2 (FCOS and RetinaNet) pass the `self.test_*` as arguments when calling it. This is misleading, nonetheless.

An alternative approach would be to remove these arguments, but that would breaking change.
