### PR TITLE
Remove pytorch floordiv deprecation messages 

### DIFF
--- a/detectron2/structures/keypoints.py
+++ b/detectron2/structures/keypoints.py
@@ -217,7 +217,7 @@ def heatmaps_to_keypoints(maps: torch.Tensor, rois: torch.Tensor) -> torch.Tenso
         pos = roi_map.view(num_keypoints, -1).argmax(1)
 
         x_int = pos % w
-        y_int = (pos - x_int) // w
+        y_int = (pos - x_int).div(w, rounding_mode="floor")
 
         assert (
             roi_map_scores[keypoints_idx, y_int, x_int]


### PR DESCRIPTION
This change should remove the following pytorch deprecation message:
```
detectron2/structures/keypoints.py:220: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor'). 
```

This change is presuming that the value of `y_int` is positive, hence of use of `rounding_method="floor" ` instead of `rounding_method="trunc"`

This specific fix is mentioned in https://github.com/facebookresearch/detectron2/issues/3983