### PR TITLE
make build_batch_data_loader work better when dataset size is not multiple of batch size and num_workers

### DIFF
--- a/detectron2/data/common.py
+++ b/detectron2/data/common.py
@@ -18,14 +18,44 @@ __all__ = ["MapDataset", "DatasetFromList", "AspectRatioGroupedDataset", "ToIter
 logger = logging.getLogger(__name__)
 
 
-def _shard_iterator_dataloader_worker(iterable):
+# copied from: https://docs.python.org/3/library/itertools.html#recipes
+def _roundrobin(*iterables):
+    "roundrobin('ABC', 'D', 'EF') --> A D E B F C"
+    # Recipe credited to George Sakkis
+    num_active = len(iterables)
+    nexts = itertools.cycle(iter(it).__next__ for it in iterables)
+    while num_active:
+        try:
+            for next in nexts:
+                yield next()
+        except StopIteration:
+            # Remove the iterator we just exhausted from the cycle.
+            num_active -= 1
+            nexts = itertools.cycle(itertools.islice(nexts, num_active))
+
+
+def _shard_iterator_dataloader_worker(iterable, chunk_size=1):
     # Shard the iterable if we're currently inside pytorch dataloader worker.
     worker_info = data.get_worker_info()
     if worker_info is None or worker_info.num_workers == 1:
         # do nothing
         yield from iterable
     else:
-        yield from itertools.islice(iterable, worker_info.id, None, worker_info.num_workers)
+        # worker0: 0, 1, ..., chunk_size-1, num_workers*chunk_size, num_workers*chunk_size+1, ...
+        # worker1: chunk_size, chunk_size+1, ...
+        # worker2: 2*chunk_size, 2*chunk_size+1, ...
+        # ...
+        yield from _roundrobin(
+            *[
+                itertools.islice(
+                    iterable,
+                    worker_info.id * chunk_size + chunk_i,
+                    None,
+                    worker_info.num_workers * chunk_size,
+                )
+                for chunk_i in range(chunk_size)
+            ]
+        )
 
 
 class _MapIterableDataset(data.IterableDataset):
@@ -224,7 +254,13 @@ class ToIterableDataset(data.IterableDataset):
     to an iterable-style dataset.
     """
 
-    def __init__(self, dataset: data.Dataset, sampler: Sampler, shard_sampler: bool = True):
+    def __init__(
+        self,
+        dataset: data.Dataset,
+        sampler: Sampler,
+        shard_sampler: bool = True,
+        shard_chunk_size: int = 1,
+    ):
         """
         Args:
             dataset: an old-style dataset with ``__getitem__``
@@ -237,12 +273,14 @@ class ToIterableDataset(data.IterableDataset):
                 Most samplers (like our TrainingSampler) do not shard based on dataloader worker id
                 and this argument should be set to True. But certain samplers may be already
                 sharded, in that case this argument should be set to False.
+            shard_chunk_size: when sharding the sampler, each worker will
         """
         assert not isinstance(dataset, data.IterableDataset), dataset
         assert isinstance(sampler, Sampler), sampler
         self.dataset = dataset
         self.sampler = sampler
         self.shard_sampler = shard_sampler
+        self.shard_chunk_size = shard_chunk_size
 
     def __iter__(self):
         if not self.shard_sampler:
@@ -253,7 +291,7 @@ class ToIterableDataset(data.IterableDataset):
             # will run sampler in every of the N worker. So we should only keep 1/N of the ids on
             # each worker. The assumption is that sampler is cheap to iterate so it's fine to
             # discard ids in workers.
-            sampler = _shard_iterator_dataloader_worker(self.sampler)
+            sampler = _shard_iterator_dataloader_worker(self.sampler, self.shard_chunk_size)
         for idx in sampler:
             yield self.dataset[idx]
 

--- a/projects/DensePose/densepose/modeling/losses/cycle_pix2shape.py
+++ b/projects/DensePose/densepose/modeling/losses/cycle_pix2shape.py
@@ -147,8 +147,6 @@ class PixToShapeCycleLoss(nn.Module):
         return torch.stack(losses, dim=0).mean()
 
     def fake_value(self, densepose_predictor_outputs: Any, embedder: nn.Module):
-        losses = [
-            embedder(mesh_name).sum() * 0 for mesh_name in embedder.mesh_names
-        ]
+        losses = [embedder(mesh_name).sum() * 0 for mesh_name in embedder.mesh_names]
         losses.append(densepose_predictor_outputs.embedding.sum() * 0)
         return torch.mean(torch.stack(losses))

--- a/projects/DensePose/densepose/structures/mesh.py
+++ b/projects/DensePose/densepose/structures/mesh.py
@@ -137,9 +137,7 @@ def load_mesh_data(
     with PathManager.open(mesh_fpath, "rb") as hFile:
         # pyre-fixme[7]: Expected `Tuple[Optional[Tensor], Optional[Tensor]]` but
         #  got `Tensor`.
-        return torch.as_tensor(pickle.load(hFile)[field], dtype=torch.float).to(
-            device
-        )
+        return torch.as_tensor(pickle.load(hFile)[field], dtype=torch.float).to(device)
     return None
 
 


### PR DESCRIPTION
Summary:
Previously `ToIterableDataset` shards the dataset for each worker in round robin fashion without considering batch size. This combined with `drop_last=True` can cause issue that more than 1 iteration is dropped, i.e. the number of iterations is less than `len(data_loader)`. Let's say the dataset size is 46 and batch size is 8, when there're 3 DL workers, the dataset would be shared into:
- worker 0: [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45]
- worker 1: [1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 40, 43]
- worker 2: [2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35, 38, 41, 44]

Since the batching is per worker, the loaded data would be: [0, 3, 6, 9, 12, 15, 18, 21], [1, 4, 7, 10, 13, 16, 19, 22], [2, 5, 8, 11, 14, 17, 20, 23], [24, 27, 30, 33, 36, 39, 42, 45]. It has a few issues:
- the data is not loaded in sequence
- it potentially wastes data, eg. here it has 46 images, so it can have 5 full batches.
- `len(dl)` returns 5, but it only runs 4 iterations. Although `len` can be inaccurate for iterable dataset, but it still causes confusion.

This diff changes the shard pattern, so that in the same case, different workers would get:
- worker 0: [0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31]
- worker 1: [8, 9, 10, 11, 12, 13, 14, 15, 32, 33, 34, 35, 36, 37, 38, 39]
- worker 2: [16, 17, 18, 19, 20, 21, 22, 23, 40, 41, 42, 43, 44, 45]

This would solves the issues above, the loaded data now become: [0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15], [16, 17, 18, 19, 20, 21, 22, 23], [24, 25, 26, 27, 28, 29, 30, 31], [32, 33, 34, 35, 36, 37, 38, 39]

Differential Revision: D47529917

