### PR TITLE
Refactor test cases to improve unit test quality

### DIFF
--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -47,7 +47,7 @@ class TestCheckpointer(unittest.TestCase):
             model.load_state_dict(sd_to_load)
             for loaded, stored in zip(model_sd.values(), state_dict.values()):
                 # different tensor references
-                self.assertFalse(id(loaded) == id(stored))
+                self.assertNotEqual(id(loaded), id(stored))
                 # same content
                 self.assertTrue(loaded.to(stored).equal(stored))
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -28,7 +28,7 @@ class TestEventWriter(unittest.TestCase):
             writer.close()
             with open(json_file) as f:
                 data = [json.loads(l) for l in f]
-                self.assertTrue([int(k["key"]) for k in data] == [19, 39, 59])
+                self.assertEqual([int(k["key"]) for k in data], [19, 39, 59])
 
     def testScalarMismatchedPeriod(self):
         with tempfile.TemporaryDirectory(
@@ -47,9 +47,9 @@ class TestEventWriter(unittest.TestCase):
             writer.close()
             with open(json_file) as f:
                 data = [json.loads(l) for l in f]
-                self.assertTrue([int(k.get("key2", 0)) for k in data] == [17, 0, 34, 0, 51, 0])
-                self.assertTrue([int(k.get("key", 0)) for k in data] == [0, 19, 0, 39, 0, 59])
-                self.assertTrue([int(k["iteration"]) for k in data] == [17, 19, 34, 39, 51, 59])
+                self.assertEqual([int(k.get("key2", 0)) for k in data], [17, 0, 34, 0, 51, 0])
+                self.assertEqual([int(k.get("key", 0)) for k in data], [0, 19, 0, 39, 0, 59])
+                self.assertEqual([int(k["iteration"]) for k in data], [17, 19, 34, 39, 51, 59])
 
     def testPrintETA(self):
         with EventStorage() as s:

--- a/tests/test_export_torchscript.py
+++ b/tests/test_export_torchscript.py
@@ -267,7 +267,8 @@ class TestTorchscriptUtils(unittest.TestCase):
             # check that the files are created
             for name in ["model_ts_code", "model_ts_IR", "model_ts_IR_inlined", "model"]:
                 fname = os.path.join(d, name + ".txt")
-                self.assertTrue(os.stat(fname).st_size > 0, fname)
+                self.assertTrue(os.path.exists(fname), f"{fname} does not exist")
+                self.assertGreater(os.stat(fname).st_size, 0, fname)
 
     def test_dump_IR_function(self):
         @torch.jit.script


### PR DESCRIPTION
Hello, first-time submitting PR here. I've read through the contributor guide and figured it's a minor update, hence this PR.

This PR improves the readability of the assert statements in some of the unit tests by using more expressive assert methods from the unittest module. These changes improve code quality (avoid test smells) by:

- Making the assert statements more readable, e.g., assertNotEqual, assertEqual.

- Check if the file exists before visiting the actual file (known as the Resource Optimism test smell).


Happy to update more related issues in the test code if needed :)
