### PR TITLE
Fix SimpleWriter.write_metrics arguments in lightning_train_net.py - Fixes related to Issue #5076

### DIFF
--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -90,7 +90,7 @@ class TrainingModule(LightningModule):
             )
 
         loss_dict = self.model(batch)
-        SimpleTrainer.write_metrics(loss_dict, data_time)
+        SimpleTrainer.write_metrics(loss_dict, data_time, cur_item=self.storage.iter)
 
         opt = self.optimizers()
         self.storage.put_scalar(
@@ -235,5 +235,5 @@ def setup(args):
 if __name__ == "__main__":
     parser = default_argument_parser()
     args = parser.parse_args()
-    logger.info("Command Line Args:", args)
+    logger.info("Command Line Args:", vars(args))
     main(args)


### PR DESCRIPTION
Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Fixes related to Issue https://github.com/facebookresearch/detectron2/issues/5076

Before submitting a PR, please run `dev/linter.sh` to lint the code.

Output of `dev/linter.sh`

```
echo "Running isort ..."
Running isort ...
isort -y -sp . --atomic
Skipped 143 files

echo "Running black ..."
Running black ...
black -l 100 .
All done! ✨ 🍰 ✨
496 files left unchanged.

echo "Running flake8 ..."
Running flake8 ...
if [ -x "$(command -v flake8)" ]; then
  flake8 .
else
  python3 -m flake8 .
fi
./detectron2/evaluation/rotated_coco_evaluation.py:18:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/evaluation/rotated_coco_evaluation.py:20:14: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/evaluation/rotated_coco_evaluation.py:26:47: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/evaluation/rotated_coco_evaluation.py:35:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/evaluation/rotated_coco_evaluation.py:37:14: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/evaluation/sem_seg_evaluation.py:107:101: E501 line too long (107 > 100 characters)
./detectron2/export/shared.py:228:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/export/shared.py:249:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./detectron2/structures/instances.py:133:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./projects/DensePose/densepose/data/image_list_dataset.py:34:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./projects/DensePose/densepose/data/video/video_keyframe_dataset.py:247:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./projects/DensePose/densepose/evaluation/densepose_coco_evaluation.py:196:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./projects/PointSup/tools/prepare_coco_point_annotations_without_masks.py:33:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./projects/PointSup/tools/prepare_coco_point_annotations_without_masks.py:38:14: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

Fixes related to Issue https://github.com/facebookresearch/detectron2/issues/5076