### PR TITLE
New Workflow + Pytorch 2.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,25 +5,31 @@ version: 2.1
 # -------------------------------------------------------------------------------------
 cpu: &cpu
   machine:
-    image: ubuntu-2004:202107-02
+    image: ubuntu-2204:2023.04.2
   resource_class: medium
 
-gpu: &gpu
+gpu118: &gpu118
   machine:
     # NOTE: use a cuda version that's supported by all our pytorch versions
-    image: ubuntu-1604-cuda-11.1:202012-01
+    image: linux-cuda-11:2023.02.1
+  resource_class: gpu.nvidia.small
+
+gpu121: &gpu121
+  machine:
+    # NOTE: use a cuda version that's supported by all our pytorch versions
+    image: linux-cuda-12:2023.05.1
   resource_class: gpu.nvidia.small
 
 windows-cpu: &windows_cpu
   machine:
     resource_class: windows.medium
-    image: windows-server-2019-vs2019:stable
+    image: windows-server-2022-gui:2022.10.1
     shell: powershell.exe
 
 # windows-gpu: &windows_gpu
 #     machine:
-#       resource_class: windows.gpu.nvidia.medium
 #       image: windows-server-2019-nvidia:stable
+#     resource_class: windows.gpu.nvidia.medium
 
 version_parameters: &version_parameters
   parameters:
@@ -36,15 +42,19 @@ version_parameters: &version_parameters
       # use test wheels index to have access to RC wheels
       # https://download.pytorch.org/whl/test/torch_test.html
       default: "https://download.pytorch.org/whl/torch_stable.html"
-    python_version:  # NOTE: only affect linux
+    python_version: # NOTE: only affects linux
       type: string
-      default: '3.8.6'
+      default: "3.10.9"
+    cuda_version:
+      type: string
+      default: "11.6"
 
   environment:
     PYTORCH_VERSION: << parameters.pytorch_version >>
     TORCHVISION_VERSION: << parameters.torchvision_version >>
     PYTORCH_INDEX: << parameters.pytorch_index >>
     PYTHON_VERSION: << parameters.python_version>>
+    CUDA_VERSION: << parameters.cuda_version >>
     # point datasets to ~/.torch so it's cached in CI
     DETECTRON2_DATASETS: ~/.torch/datasets
 
@@ -60,8 +70,7 @@ version_parameters: &version_parameters
 #         sudo /bin/bash ./NVIDIA-Linux-x86_64-430.40.run -s --no-drm
 #         nvidia-smi
 
-add_ssh_keys: &add_ssh_keys
-  # https://circleci.com/docs/2.0/add-ssh-key/
+add_ssh_keys: &add_ssh_keys # https://circleci.com/docs/2.0/add-ssh-key/
   - add_ssh_keys:
       fingerprints:
         - "e4:13:f2:22:d4:49:e8:e4:57:5a:ac:20:2f:3f:1f:ca"
@@ -71,8 +80,8 @@ install_python: &install_python
       name: Install Python
       working_directory: ~/
       command: |
-        # upgrade pyenv
-        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
+        cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd
+        pyenv install -l
         pyenv install -s $PYTHON_VERSION
         pyenv global $PYTHON_VERSION
         python --version
@@ -115,15 +124,28 @@ install_linux_dep: &install_linux_dep
         # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
         # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
         pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
-        pip install --progress-bar off torch==$PYTORCH_VERSION -f $PYTORCH_INDEX
-        if [[ "$TORCHVISION_VERSION" == "master" ]]; then
-          pip install git+https://github.com/pytorch/vision.git
+        if [[ "$PYTORCH_VERSION" == "master" ]]; then
+          echo "Installing torch/torchvision from $PYTORCH_INDEX"
+          # Remove first, in case it's in the CI cache
+          pip uninstall -y torch torchvision
+          pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+          pip install -v --progress-bar off omegaconf==2.1.2   # needed by FCOSE2ETest::test_empty_data
         else
-          pip install --progress-bar off torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
+          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
         fi
 
+        python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+        python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
         python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+        echo "Python packages"
+        python -c "import sys; print(sys.executable)"
+        python --version
+        pip list
+        echo "GCC Compiler"
         gcc --version
+        echo "OS Environment Variables"
+        env
 
 install_detectron2: &install_detectron2
   - run:
@@ -152,6 +174,23 @@ uninstall_tests: &uninstall_tests
         # Tests that code is importable without installation
         PYTHONPATH=. ./.circleci/import-tests.sh
 
+select_cuda: &select_cuda
+  - run:
+      name: Select CUDA
+      command: |
+        sudo update-alternatives --set cuda /usr/local/cuda-<< parameters.cuda_version >>
+
+build_wheel: &build_wheel
+  - run:
+      name: Build wheel
+      command: |
+        python -m pip install wheel
+        python setup.py bdist_wheel
+
+save_artifact: &save_artifact
+  - store_artifacts:
+      path: ~/detectron2/dist
+      destination: dist
 
 # -------------------------------------------------------------------------------------
 # Jobs to run
@@ -170,11 +209,12 @@ jobs:
       # Refresh the key when dependencies should be updated (e.g. when pytorch releases)
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
-
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
       - <<: *run_unittests
       - <<: *uninstall_tests
 
@@ -182,11 +222,10 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
-
-  linux_gpu_tests:
-    <<: *gpu
+  linux_gpu_tests118:
+    <<: *gpu118
     <<: *version_parameters
 
     working_directory: ~/detectron2
@@ -196,11 +235,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
-
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
+      - <<: *select_cuda
       - <<: *install_python
       - <<: *install_linux_dep
       - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
       - <<: *run_unittests
       - <<: *uninstall_tests
 
@@ -208,7 +249,34 @@ jobs:
           paths:
             - /opt/circleci/.pyenv
             - ~/.torch
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210827
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
+
+  linux_gpu_tests121:
+    <<: *gpu121
+    <<: *version_parameters
+
+    working_directory: ~/detectron2
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
+      - <<: *select_cuda
+      - <<: *install_python
+      - <<: *install_linux_dep
+      - <<: *install_detectron2
+      - <<: *build_wheel
+      - <<: *save_artifact
+      - <<: *run_unittests
+      - <<: *uninstall_tests
+
+      - save_cache:
+          paths:
+            - /opt/circleci/.pyenv
+            - ~/.torch
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
   windows_cpu_build:
     <<: *windows_cpu
@@ -221,7 +289,7 @@ jobs:
       # Cache the env directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+            - cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
       - run:
           name: Install Dependencies
@@ -231,12 +299,28 @@ jobs:
             pip install opencv-python-headless pytest-xdist pycocotools tensorboard onnx
             pip install -U git+https://github.com/facebookresearch/iopath
             pip install -U git+https://github.com/facebookresearch/fvcore
-            pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            if($env:PYTORCH_VERSION -eq "master"){
+              Write-Output "Installing torch/torchvision from $env:PYTORCH_INDEX"
+              pip uninstall -y torch torchvision
+              pip install --progress-bar off --pre torch torchvision --extra-index-url $env:PYTORCH_INDEX
+            }else{
+              Write-Output "Installing torch==$env:PYTORCH_VERSION and torchvision==$env:TORCHVISION_VERSION from $env:PYTORCH_INDEX"
+              pip install torch==$env:PYTORCH_VERSION torchvision==$env:TORCHVISION_VERSION -f $env:PYTORCH_INDEX
+            }
+            python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+            python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+            python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+            Write-Output "Python packages"
+            python -c "import sys; print(sys.executable)"
+            python --version
+            pip list
+            echo "OS Environment Variables"
+            dir env:
 
       - save_cache:
           paths:
             - env
-          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20210404
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230617
 
       - <<: *install_detectron2
       # TODO: unittest fails for now
@@ -246,26 +330,36 @@ workflows:
   regular_test:
     jobs:
       - linux_cpu_tests:
-          name: linux_cpu_tests_pytorch1.10
-          pytorch_version: '1.10.0+cpu'
-          torchvision_version: '0.11.1+cpu'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.8
-          pytorch_version: '1.8.1+cu111'
-          torchvision_version: '0.9.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.9
-          pytorch_version: '1.9+cu111'
-          torchvision_version: '0.10+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10
-          pytorch_version: '1.10+cu111'
-          torchvision_version: '0.11.1+cu111'
-      - linux_gpu_tests:
-          name: linux_gpu_tests_pytorch1.10_python39
-          pytorch_version: '1.10+cu111'
-          torchvision_version: '0.11.1+cu111'
-          python_version: '3.9.6'
+          name: linux_cpu_tests_pytorch1.13.1
+          pytorch_version: "1.13.1+cpu"
+          torchvision_version: "0.14.1+cpu"
+      - linux_cpu_tests:
+          name: linux_cpu_tests_pytorch2.0.1
+          pytorch_version: "2.0.1+cpu"
+          torchvision_version: "0.15.2+cpu"
+          python_version: "3.11"
+      - linux_gpu_tests118:
+          name: linux_gpu_tests_pytorch1.13.1
+          pytorch_version: "1.13.1+cu116"
+          torchvision_version: "0.14.1+cu116"
+          cuda_version: "11.6"
+      - linux_gpu_tests118:
+          name: linux_gpu_tests_pytorch2.0.1
+          pytorch_version: "2.0.1+cu118"
+          torchvision_version: "0.15.2+cu118"
+          cuda_version: "11.8"
+          python_version: "3.11"
+      - linux_gpu_tests121:
+          name: linux_gpu_tests_pytorch_nightly
+          pytorch_version: "master"
+          torchvision_version: "main"
+          cuda_version: "12.1"
+          python_version: "3.11"
+          pytorch_index: "https://download.pytorch.org/whl/nightly/cu121"
       - windows_cpu_build:
-          pytorch_version: '1.10+cpu'
-          torchvision_version: '0.11.1+cpu'
+          pytorch_version: "1.13.1+cpu"
+          torchvision_version: "0.14.1+cpu"
+      - windows_cpu_build:
+          pytorch_version: "2.0.1+cpu"
+          torchvision_version: "0.15.2+cpu"
+          python_version: "3.11"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,78 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: [ "3.9", "3.10", "3.11" ]
+        torch: [ "1.13.1", "2.0.1" ]
+        include:
+          - torch: "1.13.1"
+            torchvision: "0.14.1"
+          - torch: "2.0.1"
+            torchvision: "0.15.2"
+        exclude:
+          - python: "3.11"
+            torch: "1.13.1"
+    env:
+      # point datasets to ~/.torch so it's cached by CI
+      DETECTRON2_DATASETS: ~/.torch/datasets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.pythonLocation }}/lib/python${{ matrix.python }}/site-packages
+            ~/.torch
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230523
+      - name: Install dependencies macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m pip install -U pip
+          python -m pip install ninja opencv-python-headless onnx pytest-xdist
+          python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+          # install from github to get latest; install iopath first since fvcore depends on it
+          python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
+          python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+      - name: Install dependencies ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python -m pip install -U pip
+          python -m pip install ninja opencv-python-headless onnx pytest-xdist
+          python -m pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --index-url https://download.pytorch.org/whl/cpu
+          # install from github to get latest; install iopath first since fvcore depends on it
+          python -m pip install -U 'git+https://github.com/facebookresearch/iopath'
+          python -m pip install -U 'git+https://github.com/facebookresearch/fvcore'
+      - name: Build and install macos
+        if: matrix.os == 'macOS'
+        run: |
+          CC=clang CXX=clang++ python -m pip install -e .[all]
+          python -m detectron2.utils.collect_env
+      - name: Create wheel
+        run: |
+          python -m pip install wheel
+          python setup.py bdist_wheel
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: detectron2-${{ matrix.python }}-pytorch${{ matrix.torch }}-${{matrix.os}}-wheel
+          path: dist/*.whl
+      - name: Build and install linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python -m pip install -e .[all]
+          python -m detectron2.utils.collect_env
+      - name: Upload wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: detectron2-${{ matrix.python }}-pytorch${{ matrix.torch }}-${{matrix.os}}-wheel
+          path: dist/*.whl

--- a/.github/workflows/check-template.yml
+++ b/.github/workflows/check-template.yml
@@ -10,8 +10,8 @@ jobs:
     # comment this out when testing with https://github.com/nektos/act
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/github-script@v3
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/needs-reply.yml
+++ b/.github/workflows/needs-reply.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - name: Close old issues that need reply
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           # Modified from https://github.com/dwieeb/needs-reply
@@ -90,7 +90,7 @@ jobs:
     if: ${{ github.repository_owner == 'facebookresearch' }}
     steps:
       - name: Lock closed issues that have no activity for a while
-        uses: dessant/lock-threads@v2
+        uses: dessant/lock-threads@v4
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: '300'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 # Run linter with github actions for quick feedbacks.
 # Run macos tests with github actions. Linux (CPU & GPU) tests currently runs on CircleCI
@@ -9,22 +9,22 @@ jobs:
     # run on PRs, or commits to facebookresearch (not internal)
     if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         # flake8-bugbear flake8-comprehensions are useful but not available internally
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8==3.8.1 isort==4.3.21
-          python -m pip install black==22.3.0
+          python -m pip install flake8==6.0.0 isort==5.12.0
+          python -m pip install black==23.1.0
           flake8 --version
       - name: Lint
         run: |
           echo "Running isort"
-          isort -c -sp .
+          isort -c --sp . .
           echo "Running black"
           black -l 100 --check .
           echo "Running flake8"
@@ -37,31 +37,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        torch: ["1.8", "1.9", "1.10"]
+        torch: [ "1.13.1", "2.0.1" ]
         include:
-          - torch: "1.8"
-            torchvision: 0.9
-          - torch: "1.9"
-            torchvision: "0.10"
-          - torch: "1.10"
-            torchvision: "0.11.1"
+          - torch: "1.13.1"
+            torchvision: "0.14.1"
+          - torch: "2.0.1"
+            torchvision: "0.15.2"
+        exclude:
+          - python: "3.11"
+            torch: "1.13.1"
     env:
       # point datasets to ~/.torch so it's cached by CI
       DETECTRON2_DATASETS: ~/.torch/datasets
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
-            ${{ env.pythonLocation }}/lib/python3.8/site-packages
+            ${{ env.pythonLocation }}/lib/python3.10/site-packages
             ~/.torch
-          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20220119
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20230523
 
       - name: Install dependencies
         run: |

--- a/detectron2/modeling/backbone/backbone.py
+++ b/detectron2/modeling/backbone/backbone.py
@@ -56,7 +56,7 @@ class Backbone(nn.Module, metaclass=ABCMeta):
         square padding size if `square_size` > 0.
 
         TODO: use type of Dict[str, int] to avoid torchscipt issues. The type of padding_constraints
-        could be generalized as TypedDict (Python 3.8+) to support more types in the future.
+        could be generalized as TypedDict (Python 3.9+) to support more types in the future.
         """
         return {}
 

--- a/dev/linter.sh
+++ b/dev/linter.sh
@@ -7,20 +7,20 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 {
   black --version | grep -E "22\." > /dev/null
 } || {
-  echo "Linter requires 'black==22.*' !"
+  echo "Linter requires 'black==23.*' !"
   exit 1
 }
 
 ISORT_VERSION=$(isort --version-number)
-if [[ "$ISORT_VERSION" != 4.3* ]]; then
-  echo "Linter requires isort==4.3.21 !"
+if [[ "$ISORT_VERSION" != 5.12* ]]; then
+  echo "Linter requires isort==5.12.0 !"
   exit 1
 fi
 
 set -v
 
 echo "Running isort ..."
-isort -y -sp . --atomic
+isort --apply --sp . . --atomic
 
 echo "Running black ..."
 black -l 100 .

--- a/dev/packaging/build_all_wheels.sh
+++ b/dev/packaging/build_all_wheels.sh
@@ -26,7 +26,7 @@ build_one() {
   echo "Launching container $container_name ..."
   container_id="$container_name"_"$cu"_"$pytorch_ver"
 
-  py_versions=(3.7 3.8 3.9)
+  py_versions=(3.8 3.9 3.10 3.11)
 
   for py in "${py_versions[@]}"; do
     docker run -itd \
@@ -49,17 +49,12 @@ EOF
 if [[ -n "$1" ]] && [[ -n "$2" ]]; then
   build_one "$1" "$2"
 else
-  build_one cu113 1.10
-  build_one cu111 1.10
-  build_one cu102 1.10
-  build_one cpu 1.10
-
-  build_one cu111 1.9
-  build_one cu102 1.9
-  build_one cpu 1.9
-
-  build_one cu111 1.8
-  build_one cu102 1.8
-  build_one cu101 1.8
-  build_one cpu 1.8
+  build_one cu121 2.0
+  build_one cu120 2.0
+  build_one cu118 2.0
+  build_one cu117 1.13
+  build_one cu116 1.12
+  build_one cpu 2.0
+  build_one cpu 1.13
+  build_one cpu 1.12
 fi

--- a/dev/packaging/pkg_helpers.bash
+++ b/dev/packaging/pkg_helpers.bash
@@ -18,41 +18,25 @@ setup_cuda() {
   # and https://github.com/pytorch/vision/blob/main/packaging/pkg_helpers.bash for reference.
   export FORCE_CUDA=1
   case "$CU_VERSION" in
-    cu113)
-      export CUDA_HOME=/usr/local/cuda-11.3/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu121)
+      export CUDA_HOME=/usr/local/cuda-12.1/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu112)
-      export CUDA_HOME=/usr/local/cuda-11.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu120)
+      export CUDA_HOME=/usr/local/cuda-12.0/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu111)
-      export CUDA_HOME=/usr/local/cuda-11.1/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+    cu118)
+      export CUDA_HOME=/usr/local/cuda-11.8/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
       ;;
-    cu110)
-      export CUDA_HOME=/usr/local/cuda-11.0/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0+PTX"
+    cu117)
+      export CUDA_HOME=/usr/local/cuda-11.7/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
       ;;
-    cu102)
-      export CUDA_HOME=/usr/local/cuda-10.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu101)
-      export CUDA_HOME=/usr/local/cuda-10.1/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu100)
-      export CUDA_HOME=/usr/local/cuda-10.0/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
-      ;;
-    cu92)
-      export CUDA_HOME=/usr/local/cuda-9.2/
-      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0+PTX"
-      ;;
-    cpu)
-      unset FORCE_CUDA
-      export CUDA_VISIBLE_DEVICES=
+    cu116)
+      export CUDA_HOME=/usr/local/cuda-11.6/
+      export TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6"
       ;;
     *)
       echo "Unrecognized CU_VERSION=$CU_VERSION"
@@ -63,9 +47,9 @@ setup_cuda() {
 
 setup_wheel_python() {
   case "$PYTHON_VERSION" in
-    3.7) python_abi=cp37-cp37m ;;
-    3.8) python_abi=cp38-cp38 ;;
     3.9) python_abi=cp39-cp39 ;;
+    3.10) python_abi=cp310-cp310 ;;
+    3.11) python_abi=cp311-cp311 ;;
     *)
       echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
       exit 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
+FROM nvidia/cuda:12.0.1-cudnn8-devel-ubuntu22.04
 # use an older system (18.04) to avoid opencv incompatibility (issue#3524)
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -14,14 +14,14 @@ USER appuser
 WORKDIR /home/appuser
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
+RUN wget https://bootstrap.pypa.io/pip/3.10/get-pip.py && \
 	python3 get-pip.py --user && \
 	rm get-pip.py
 
 # install dependencies
 # See https://pytorch.org/ for other options if you use a different version of CUDA
 RUN pip install --user tensorboard cmake onnx   # cmake from apt-get is too old
-RUN pip install --user torch==1.10 torchvision==0.11.1 -f https://download.pytorch.org/whl/cu111/torch_stable.html
+RUN pip install --user torch==2.0.1 torchvision==0.15.2 -f https://download.pytorch.org/whl/cu118/torch_stable.html
 
 RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'
 # install detectron2
@@ -30,7 +30,7 @@ RUN git clone https://github.com/facebookresearch/detectron2 detectron2_repo
 ENV FORCE_CUDA="1"
 # This will by default build detectron2 for all common cuda architectures and take a lot more time,
 # because inside `docker build`, there is no way to tell which architecture will be used.
-ARG TORCH_CUDA_ARCH_LIST="Kepler;Kepler+Tesla;Maxwell;Maxwell+Tegra;Pascal;Volta;Turing"
+ARG TORCH_CUDA_ARCH_LIST="3.7+PTX;5.0;6.0;6.1;7.0;7.5;8.0;8.6;9.0"
 ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
 
 RUN pip install --user -e detectron2_repo

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,5 @@
 
-## Use the container (with docker ≥ 19.03)
+## Use the container (with docker ≥ 24.0.2)
 
 ```
 cd docker/
@@ -14,7 +14,7 @@ docker run --gpus all -it \
 xhost +local:`docker inspect --format='{{ .Config.Hostname }}' detectron2`
 ```
 
-## Use the container (with docker-compose ≥ 1.28.0)
+## Use the container (with docker-compose ≥ 2.18.1)
 
 Install docker-compose and nvidia-docker-toolkit, then run:
 ```

--- a/docker/deploy.Dockerfile
+++ b/docker/deploy.Dockerfile
@@ -10,12 +10,12 @@ ENV HOME=/home/appuser
 WORKDIR $HOME
 
 # Let torchvision find libtorch
-ENV CMAKE_PREFIX_PATH=$HOME/.local/lib/python3.6/site-packages/torch/
+ENV CMAKE_PREFIX_PATH=$HOME/.local/lib/python3.10/site-packages/torch/
 
 RUN sudo apt-get update && sudo apt-get install libopencv-dev --yes
 
 # install libtorchvision
-RUN git clone --branch v0.11.1 https://github.com/pytorch/vision/
+RUN git clone --branch v0.15.2 https://github.com/pytorch/vision/
 RUN mkdir vision/build && cd vision/build && \
 	cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_BUILD_TYPE=Release -DWITH_CUDA=on -DTORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST && \
 	make -j && make install

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.3"
+version: '3.1'
 services:
   detectron2:
     build:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,11 @@ skip_glob=*/__init__.py,**/configs/**,**/tests/config/**
 known_myself=detectron2
 known_third_party=fvcore,matplotlib,cv2,torch,torchvision,PIL,pycocotools,yacs,termcolor,cityscapesscripts,tabulate,tqdm,scipy,lvis,psutil,pkg_resources,caffe2,onnx,panopticapi,black,isort,av,iopath,omegaconf,hydra,yaml,pydoc,submitit,cloudpickle,packaging,timm,pandas,fairscale,pytorch3d,pytorch_lightning
 no_lines_before=STDLIB,THIRDPARTY
-sections=FUTURE,STDLIB,THIRDPARTY,myself,FIRSTPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,MYSELF,FIRSTPARTY,LOCALFOLDER
 default_section=FIRSTPARTY
 
 [mypy]
-python_version=3.7
+python_version=3.9
 ignore_missing_imports = True
 warn_unused_configs = True
 disallow_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+from setuptools import find_packages, setup
+import torch
+from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
+
 import glob
 import os
 import shutil
 from os import path
-from setuptools import find_packages, setup
 from typing import List
-import torch
-from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
 
 torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]
-assert torch_ver >= [1, 8], "Requires PyTorch >= 1.8"
+assert torch_ver >= [1, 13], "Requires PyTorch >= 1.13"
 
 
 def get_version():
@@ -50,7 +51,7 @@ def get_extensions():
         True if ((torch.version.hip is not None) and (ROCM_HOME is not None)) else False
     )
     if is_rocm_pytorch:
-        assert torch_ver >= [1, 8], "ROCM support requires PyTorch >= 1.8!"
+        assert torch_ver >= [1, 13], "ROCM support requires PyTorch >= 1.13!"
 
     # common code between cuda and rocm platforms, for hipify version [1,0,0] and later.
     source_cuda = glob.glob(path.join(extensions_dir, "**", "*.cu")) + glob.glob(
@@ -86,7 +87,7 @@ def get_extensions():
         if nvcc_flags_env != "":
             extra_compile_args["nvcc"].extend(nvcc_flags_env.split(" "))
 
-        if torch_ver < [1, 7]:
+        if torch_ver < [1, 12]:
             # supported by https://github.com/pytorch/pytorch/pull/43931
             CC = os.environ.get("CC", None)
             if CC is not None:
@@ -158,7 +159,7 @@ setup(
     packages=find_packages(exclude=("configs", "tests*")) + list(PROJECTS.keys()),
     package_dir=PROJECTS,
     package_data={"detectron2.model_zoo": get_model_zoo_configs()},
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=[
         # These dependencies are not pure-python.
         # In general, avoid adding dependencies that are not pure-python because they are not
@@ -207,11 +208,11 @@ setup(
         ],
         # dev dependencies. Install them by `pip install 'detectron2[dev]'`
         "dev": [
-            "flake8==3.8.1",
-            "isort==4.3.21",
+            "flake8==6.0.0",
+            "isort==5.12.0",
             "flake8-bugbear",
             "flake8-comprehensions",
-            "black==22.3.0",
+            "black==23.3.0",
         ],
     },
     ext_modules=get_extensions(),


### PR DESCRIPTION
I have been able to compile with CUDA 11.8 and CUDA 12.0 & 12.1 using PyTorch 1.13.1, PyTorch dev 2.0 and python 3.10.6(In local)
- [X] Python <3.8 versions deleted (Deprecated 27 Jun 2023)
- [X] Python 3.10.6 (added as default) (CircleCI images have 3.10.6 & 3.11)
- [X] PyTorch <1.12 delete. Deprecated (https://pytorch.org/blog/deprecation-cuda-python-support/)
- [X] Updated ubuntu-2204:2023.02.1 CPU
- [X] Updated linux-cuda-11:2023.02.1 GPU https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/3
- [X] New image CircleCI CUDA 11.8, and they are working to CUDA 12. https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/4
- [X] Windows image 2022: windows-server-2022-gui:2022.10.1
- [X] Updated test compatible with CUDA and PyTorch > 1.10
- [X] Unified workflow GitHub and CircleCI python versions: Python 3.10.6
- [X] Added CUDA variable on CircleCI: You now can select CUDA VERSION.
- [X] Added PyTorch 2.0 and CUDA 11.8. 12.0/12.1 CircleCI (CircleCI working to release CUDA 12 images at the end of the month)
- [X] Fixed tests for PyTorch 1.10+ and Python 3.10
- [X] New versions and lint compatible with Python 3.10 [isort, black, flake8]
![image](https://user-images.githubusercontent.com/22727137/212372894-48219145-469a-49e1-9e91-291191695f77.png)
![image](https://user-images.githubusercontent.com/22727137/212377228-d7ed3be1-0d09-4d3f-ace1-1a7b287dfd7a.png)



