### PR TITLE
fix default padding value to zero on mask in FixedSizeCrop

### DIFF
--- a/detectron2/data/transforms/augmentation_impl.py
+++ b/detectron2/data/transforms/augmentation_impl.py
@@ -317,7 +317,7 @@ class FixedSizeCrop(Augmentation):
         crop_size: Tuple[int],
         pad: bool = True,
         pad_value: float = 128.0,
-        seg_pad_value: int = 255,
+        seg_pad_value: int = 0,
     ):
         """
         Args:


### PR DESCRIPTION
The default padding value for the segmentation mask should be set to zero. The prior value of 255 led to unstable training when using LSJ augmentation. Therefore, I've changed the default value from 255 (white) to 0 (black).


