### PR TITLE
add publication pages and conference book titles to the latest paper state

### DIFF
--- a/projects/MViTv2/README.md
+++ b/projects/MViTv2/README.md
@@ -133,10 +133,11 @@ Model evaluation can be done similarly:
 If you use MViTv2, please use the following BibTeX entry.
 
 ```BibTeX
-@inproceedings{li2021improved,
-  title={MViTv2: Improved multiscale vision transformers for classification and detection},
-  author={Li, Yanghao and Wu, Chao-Yuan and Fan, Haoqi and Mangalam, Karttikeya and Xiong, Bo and Malik, Jitendra and Feichtenhofer, Christoph},
-  booktitle={CVPR},
+@inproceedings{li2022mvitv2,
+  title={MViTv2: Improved Multiscale Vision Transformers for Classification and Detection},
+  author={Li, Yanghao and Wu, Chao-Yan and Fan, Haoqi and Mangalam, Karttikeya and Xiong, Bo and Malik, Jitendra and Feichtenhofer, Christoph},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={4804--4814},
   year={2022}
 }
 ```

--- a/projects/Panoptic-DeepLab/README.md
+++ b/projects/Panoptic-DeepLab/README.md
@@ -158,7 +158,8 @@ If you use Panoptic-DeepLab, please use the following BibTeX entry.
 @inproceedings{cheng2020panoptic,
   title={Panoptic-DeepLab: A Simple, Strong, and Fast Baseline for Bottom-Up Panoptic Segmentation},
   author={Cheng, Bowen and Collins, Maxwell D and Zhu, Yukun and Liu, Ting and Huang, Thomas S and Adam, Hartwig and Chen, Liang-Chieh},
-  booktitle={CVPR},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={12475--12485},
   year={2020}
 }
 ```

--- a/projects/PointRend/README.md
+++ b/projects/PointRend/README.md
@@ -145,11 +145,12 @@ Cityscapes model is trained with ImageNet pretraining.
 If you use PointRend, please use the following BibTeX entry.
 
 ```BibTeX
-@InProceedings{kirillov2019pointrend,
-  title={{PointRend}: Image Segmentation as Rendering},
-  author={Alexander Kirillov and Yuxin Wu and Kaiming He and Ross Girshick},
-  journal={ArXiv:1912.08193},
-  year={2019}
+@inproceedings{kirillov2020pointrend,
+  title={Pointrend: Image Segmentation as Rendering},
+  author={Kirillov, Alexander and Wu, Yuxin and He, Kaiming and Girshick, Ross},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={9799--9808},
+  year={2020}
 }
 ```
 
@@ -158,10 +159,11 @@ If you use PointRend, please use the following BibTeX entry.
 If you use Implicit PointRend, please use the following BibTeX entry.
 
 ```BibTeX
-@InProceedings{cheng2021pointly,
-  title={Pointly-Supervised Instance Segmentation,
-  author={Bowen Cheng and Omkar Parkhi and Alexander Kirillov},
-  journal={ArXiv},
-  year={2021}
+@inproceedings{cheng2022pointly,
+  title={Pointly-Supervised Instance Segmentation},
+  author={Cheng, Bowen and Parkhi, Omkar and Kirillov, Alexander},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={2617--2626},
+  year={2022}
 }
 ```

--- a/projects/PointSup/README.md
+++ b/projects/PointSup/README.md
@@ -32,10 +32,11 @@ python train_net.py --config-file configs/mask_rcnn_R_50_FPN_3x_point_sup_point_
 If you use PointSup, please use the following BibTeX entry.
 
 ```BibTeX
-@article{cheng2021pointly,
+@inproceedings{cheng2022pointly,
   title={Pointly-Supervised Instance Segmentation},
-  author={Bowen Cheng and Omkar Parkhi and Alexander Kirillov},
-  journal={arXiv},
-  year={2021}
+  author={Cheng, Bowen and Parkhi, Omkar and Kirillov, Alexander},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  pages={2617--2626},
+  year={2022}
 }
 ```

--- a/projects/ViTDet/README.md
+++ b/projects/ViTDet/README.md
@@ -355,10 +355,12 @@ Model evaluation can be done similarly:
 If you use ViTDet, please use the following BibTeX entry.
 
 ```BibTeX
-@article{li2022exploring,
-  title={Exploring plain vision transformer backbones for object detection},
+@inproceedings{li2022exploring,
+  title={Exploring Plain Vision Transformer Backbones for Object Detection},
   author={Li, Yanghao and Mao, Hanzi and Girshick, Ross and He, Kaiming},
-  journal={arXiv preprint arXiv:2203.16527},
-  year={2022}
+  booktitle={European Conference on Computer Vision (ECCV)},
+  pages={280--296},
+  year={2022},
+  organization={Springer}
 }
 ```


### PR DESCRIPTION
add publication pages and conference book titles to the latest paper state (e.g., from arxiv to CVPR) for publication citation purposes