### PR TITLE
fix: torch 2.0 doesn't have is_compiling module in torch._dynamo

### DIFF
--- a/detectron2/layers/wrappers.py
+++ b/detectron2/layers/wrappers.py
@@ -39,7 +39,7 @@ def shapes_to_tensor(x: List[int], device: Optional[torch.device] = None) -> tor
 
 
 def check_if_dynamo_compiling():
-    if TORCH_VERSION >= (1, 14):
+    if TORCH_VERSION > (2, 0):
         from torch._dynamo import is_compiling
 
         return is_compiling()


### PR DESCRIPTION
Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

