### PR TITLE
Sort entries from the directory

### DIFF
--- a/projects/DensePose/apply_net.py
+++ b/projects/DensePose/apply_net.py
@@ -122,11 +122,13 @@ class InferenceAction(Action):
     @classmethod
     def _get_input_file_list(cls: type, input_spec: str):
         if os.path.isdir(input_spec):
-            file_list = [
-                os.path.join(input_spec, fname)
-                for fname in os.listdir(input_spec)
-                if os.path.isfile(os.path.join(input_spec, fname))
-            ]
+            file_list = sorted(
+                [
+                    os.path.join(input_spec, fname)
+                    for fname in os.listdir(input_spec)
+                    if os.path.isfile(os.path.join(input_spec, fname))
+                ]
+            )
         elif os.path.isfile(input_spec):
             file_list = [input_spec]
         else:

--- a/projects/DensePose/apply_net.py
+++ b/projects/DensePose/apply_net.py
@@ -132,7 +132,7 @@ class InferenceAction(Action):
         elif os.path.isfile(input_spec):
             file_list = [input_spec]
         else:
-            file_list = glob.glob(input_spec)
+            file_list = sorted(glob.glob(input_spec))
         return file_list
 
 


### PR DESCRIPTION
You may want to process images sequentially as determined by a string sort.

```bash
# generate images at 16fps with 4 digit sequence numbers
input_path=...
ffmpeg -hide_banner -loglevel error -i ${input_path} -vf fps=16 /tmp/test/seq.%04d.jpg

python apply_net.py show configs/densepose_rcnn_R_101_FPN_DL_s1x.yaml  \
    https://dl.fbaipublicfiles.com/densepose/densepose_rcnn_R_101_FPN_DL_s1x/165712116/model_final_844d15.pkl \
    /tmp/test dp_contour,bbox -v \
    --output /tmp/test/seq.jpg \
    >& output.log

ffmpeg -y -hide_banner -loglevel error \
    -i /tmp/test/seq.%04d.jpg \
    -c:v libx264 \
    -framerate 16 \
    /tmp/test.mp4
```

The order by the `apply_net.py` script is not deterministic and can cause frames to interleave in time.
This patch sorts the input so it renders properly.
