### PR TITLE
Coco evaluator ar

### DIFF
--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -326,18 +326,54 @@ class COCOEvaluator(DatasetEvaluator):
 
         Args:
             coco_eval (None or COCOEval): None represents no predictions from model.
-            iou_type (str):
+            iou_type (str): one of "bbox", "segm", or "keypoints".
             class_names (None or list[str]): if provided, will use it to predict
-                per-category AP.
+                per-category AP and AR.
 
         Returns:
             a dict of {metric name: score}
         """
-
         metrics = {
-            "bbox": ["AP", "AP50", "AP75", "APs", "APm", "APl"],
-            "segm": ["AP", "AP50", "AP75", "APs", "APm", "APl"],
-            "keypoints": ["AP", "AP50", "AP75", "APm", "APl"],
+            "bbox": [
+                "AP",
+                "AP50",
+                "AP75",
+                "APs",
+                "APm",
+                "APl",
+                "AR1",
+                "AR10",
+                "AR100",
+                "ARs",
+                "ARm",
+                "ARl",
+            ],
+            "segm": [
+                "AP",
+                "AP50",
+                "AP75",
+                "APs",
+                "APm",
+                "APl",
+                "AR1",
+                "AR10",
+                "AR100",
+                "ARs",
+                "ARm",
+                "ARl",
+            ],
+            "keypoints": [
+                "AP",
+                "AP50",
+                "AP75",
+                "APm",
+                "APl",
+                "AR",
+                "AR50",
+                "AR75",
+                "ARm",
+                "ARl",
+            ],
         }[iou_type]
 
         if coco_eval is None:

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -393,35 +393,42 @@ class COCOEvaluator(DatasetEvaluator):
 
         if class_names is None or len(class_names) <= 1:
             return results
-        # Compute per-category AP
+        # Compute per-category AP and AR
         # from https://github.com/facebookresearch/Detectron/blob/a6a835f5b8208c45d0dce217ce9bbda915f44df7/detectron/datasets/json_dataset_evaluator.py#L222-L252 # noqa
         precisions = coco_eval.eval["precision"]
+        recalls = coco_eval.eval["recall"]
         # precision has dims (iou, recall, cls, area range, max dets)
+        # recall has dims (iou, cls, area range, max dets)
         assert len(class_names) == precisions.shape[2]
+        assert len(class_names) == recalls.shape[1]
 
         results_per_category = []
         for idx, name in enumerate(class_names):
             # area range index 0: all area ranges
             # max dets index -1: typically 100 per image
             precision = precisions[:, :, idx, 0, -1]
+            recall = recalls[:, idx, 0, -1]
             precision = precision[precision > -1]
+            recall = recall[recall > -1]
             ap = np.mean(precision) if precision.size else float("nan")
-            results_per_category.append(("{}".format(name), float(ap * 100)))
+            ar = np.mean(recall) if recall.size else float("nan")
+            results_per_category.append(("{}".format(name), float(ap * 100), float(ar * 100)))
 
         # tabulate it
-        N_COLS = min(6, len(results_per_category) * 2)
+        N_COLS = min(9, len(results_per_category) * 3)
         results_flatten = list(itertools.chain(*results_per_category))
         results_2d = itertools.zip_longest(*[results_flatten[i::N_COLS] for i in range(N_COLS)])
         table = tabulate(
             results_2d,
             tablefmt="pipe",
             floatfmt=".3f",
-            headers=["category", "AP"] * (N_COLS // 2),
+            headers=["category", "AP", "AR"] * (N_COLS // 3),
             numalign="left",
         )
-        self._logger.info("Per-category {} AP: \n".format(iou_type) + table)
+        self._logger.info("Per-category {} AP and AR: \n".format(iou_type) + table)
 
-        results.update({"AP-" + name: ap for name, ap in results_per_category})
+        results.update({"AP-" + name: ap for name, ap, _ in results_per_category})
+        results.update({"AR-" + name: ar for name, _, ar in results_per_category})
         return results
 
 


### PR DESCRIPTION
This PR adds AR metrics to the results of `COCOEvaluator`.  This was requested on the discussion of issue #1296 to which the reply was to submit a PR:

_Originally posted by @ppwwyyxx in https://github.com/facebookresearch/detectron2/issues/1296#issuecomment-619626547_:
>> does not contain the AR,
>
> AR is not commonly used, and is therefore not included in results. You can send a PR to add it.
>
>> or any of the stats from above the line "Evaluation results for bbox".
>
> everything except for AR are included.

Here's that PR.

I split this into two commits. The first commit adds the "global" AR metrics only (effectively the value displayed by `COCOEval.summarize()`). The second commit adds the per-class AR.

