### PR TITLE
replace hcc with correct macro for rocm platforms

### DIFF
--- a/detectron2/layers/csrc/cuda_version.cu
+++ b/detectron2/layers/csrc/cuda_version.cu
@@ -6,7 +6,7 @@ namespace detectron2 {
 int get_cudart_version() {
 // Not a ROCM platform: Either HIP is not used, or
 // it is used, but platform is not ROCM (i.e. it is CUDA)
-#if !defined(__HIP_PLATFORM_HCC__)
+#if !defined(__HIP_PLATFORM_AMD__)
   return CUDART_VERSION;
 #else
   int version = 0;


### PR DESCRIPTION
Summary:  `__HIP_PLATFORM_HCC__` is now removed from rocm-6.0 and should be `__HIP_PLATFORM_AMD__`.

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

