### PR TITLE
Use `torch.amax` instead of `torch.max`

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -86,7 +86,7 @@ class ImageList:
 
         image_sizes = [(im.shape[-2], im.shape[-1]) for im in tensors]
         image_sizes_tensor = [shapes_to_tensor(x) for x in image_sizes]
-        max_size = torch.stack(image_sizes_tensor).max(0).values
+        max_size = torch.stack(image_sizes_tensor).amax(0)
 
         if padding_constraints is not None:
             square_size = padding_constraints.get("square_size", 0)


### PR DESCRIPTION
In torch 1.12.1, torch.max(input, dim, ...) operation on cpu causes unintended cpu overhead which is not the case for torch.amax.