### PR TITLE
add font_size_scale argument to Visualizer

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -354,7 +354,9 @@ class Visualizer:
 
     # TODO implement a fast, rasterized version using OpenCV
 
-    def __init__(self, img_rgb, metadata=None, scale=1.0, instance_mode=ColorMode.IMAGE):
+    def __init__(
+        self, img_rgb, metadata=None, scale=1.0, instance_mode=ColorMode.IMAGE, font_size_scale=1.0
+    ):
         """
         Args:
             img_rgb: a numpy array of shape (H, W, C), where H and W correspond to
@@ -365,6 +367,7 @@ class Visualizer:
             metadata (Metadata): dataset metadata (e.g. class names and colors)
             instance_mode (ColorMode): defines one of the pre-defined style for drawing
                 instances on an image.
+            font_size_scale: extra scaling of font size on top of default font size
         """
         self.img = np.asarray(img_rgb).clip(0, 255).astype(np.uint8)
         if metadata is None:
@@ -376,7 +379,7 @@ class Visualizer:
         # too small texts are useless, therefore clamp to 9
         self._default_font_size = max(
             np.sqrt(self.output.height * self.output.width) // 90, 10 // scale
-        )
+        ) * font_size_scale
         self._instance_mode = instance_mode
         self.keypoint_threshold = _KEYPOINT_THRESHOLD
 

--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -380,7 +380,7 @@ class Visualizer:
         self._instance_mode = instance_mode
         self.keypoint_threshold = _KEYPOINT_THRESHOLD
 
-    def draw_instance_predictions(self, predictions):
+    def draw_instance_predictions(self, predictions, jittering: bool = True):
         """
         Draw instance-level prediction results on an image.
 
@@ -388,6 +388,8 @@ class Visualizer:
             predictions (Instances): the output of an instance detection/segmentation
                 model. Following fields will be used to draw:
                 "pred_boxes", "pred_classes", "scores", "pred_masks" (or "pred_masks_rle").
+            jittering: if True, in color mode SEGMENTATION, randomly jitter the colors per class
+                to distinguish instances from the same class
 
         Returns:
             output (VisImage): image object with visualizations.
@@ -407,7 +409,10 @@ class Visualizer:
         if self._instance_mode == ColorMode.SEGMENTATION and self.metadata.get("thing_colors"):
             colors = [
                 self._jitter([x / 255 for x in self.metadata.thing_colors[c]]) for c in classes
+            ] if jittering else [
+                tuple(mplc.to_rgb([x / 255 for x in self.metadata.thing_colors[c]])) for c in classes
             ]
+
             alpha = 0.8
         else:
             colors = None


### PR DESCRIPTION
Summary: For small image, such as QVGA 320 * 256, default font size is too large. Thus, we add an optional argument **font_size_scale** to allow more control over font size

Differential Revision: D54528350


