### PR TITLE
simple: logging per-category frequency and weights in repeat_factors_from_category_frequency()

### DIFF
--- a/detectron2/data/samplers/distributed_sampler.py
+++ b/detectron2/data/samplers/distributed_sampler.py
@@ -190,6 +190,10 @@ class RepeatFactorTrainingSampler(Sampler):
             cat_id: max(1.0, math.sqrt(repeat_thresh / cat_freq))
             for cat_id, cat_freq in category_freq.items()
         }
+        for cat_id in sorted(category_rep.keys()):
+            logger.info(
+                f"Cat ID {cat_id}: freq={category_freq[cat_id]:.2f}, rep={category_rep[cat_id]:.2f}"
+            )
 
         # 3. For each image I, compute the image-level repeat factor:
         #    r(I) = max_{c in I} r(c)


### PR DESCRIPTION
Summary:
When we do weighted sampling based on per-category frequency, we would like to know the actual per-category frequency and weights.

So we add logging to print those out.

Differential Revision: D54671306


