### PR TITLE
Fix DensePose vertex visualization.

### DIFF
--- a/projects/DensePose/densepose/vis/densepose_outputs_vertex.py
+++ b/projects/DensePose/densepose/vis/densepose_outputs_vertex.py
@@ -90,7 +90,7 @@ class DensePoseOutputsVertexVisualizer:
                 self.device,
             )
             embed_map = get_xyz_vertex_embedding(mesh_name, self.device)
-            vis = (embed_map[closest_vertices].clip(0, 1) * 255.0).cpu().numpy()
+            vis = (embed_map[closest_vertices.cpu()].clip(0, 1) * 255.0).cpu().numpy()
             mask_numpy = mask.cpu().numpy().astype(dtype=np.uint8)
             image_bgr = self.mask_visualizer.visualize(image_bgr, mask_numpy, vis, [x, y, w, h])
 


### PR DESCRIPTION
This commit fixes a RuntimeError by explicitly copying an index array to the CPU:

```
Traceback (most recent call last):
  File "/home/piero/tmp/detectron2/projects/DensePose/apply_net.py", line 353, in <module>
    main()
  File "/home/piero/tmp/detectron2/projects/DensePose/apply_net.py", line 349, in main
    args.func(args)
  File "/home/piero/tmp/detectron2/projects/DensePose/apply_net.py", line 105, in execute
    cls.execute_on_outputs(context, {"file_name": file_name, "image": img}, outputs)
  File "/home/piero/tmp/detectron2/projects/DensePose/apply_net.py", line 284, in execute_on_outputs
    image_vis = visualizer.visualize(image, data)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piero/tmp/detectron2/projects/DensePose/densepose/vis/base.py", line 188, in visualize
    image = visualizer.visualize(image, data[i])
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piero/tmp/detectron2/projects/DensePose/densepose/vis/densepose_outputs_vertex.py", line 93, in visualize
    vis = (embed_map[closest_vertices].clip(0, 1) * 255.0).cpu().numpy()
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

My command line was:

```shell
python apply_net.py show configs/cse/densepose_rcnn_R_50_FPN_s1x.yaml .../model_final_c4ea5f.pkl .../00000.jpg dp_vertex,bbox -v
```