### PR TITLE
Exclude tools from packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     url="https://github.com/facebookresearch/detectron2",
     description="Detectron2 is FAIR's next-generation research "
     "platform for object detection and segmentation.",
-    packages=find_packages(exclude=("configs", "tests*")) + list(PROJECTS.keys()),
+    packages=find_packages(exclude=("configs", "tests*", "tools")) + list(PROJECTS.keys()),
     package_dir=PROJECTS,
     package_data={"detectron2.model_zoo": get_model_zoo_configs()},
     python_requires=">=3.7",


### PR DESCRIPTION
current packaging includes `tools`, this cause namespace pollution such that user can't import their own `tools` module normally in their project.

this patch exclude `tools`, but only works for `pip install` without `-e`. it's better to move tools or setup.py into detectron2 subfolder.

related:
https://github.com/facebookresearch/detectron2/issues/5205
https://github.com/facebookresearch/detectron2/issues/3934
https://github.com/pytorch/benchmark/commit/a599b49b9229522f67d42a8b3265e9a32ef9dcd0