### PR TITLE
Add gpu linux tests in github actions

### DIFF
--- a/.github/actions/install_detectron2/action.yml
+++ b/.github/actions/install_detectron2/action.yml
@@ -1,0 +1,13 @@
+name: "Install Detectron2"
+runs:
+  using: composite
+  steps:
+  - name: Install Detectron2
+    shell: bash
+    run: |
+      # Remove first, in case it's in the CI cache
+      pip uninstall -y detectron2
+
+      pip install --progress-bar off -e .[all]
+      python -m detectron2.utils.collect_env
+      ./datasets/prepare_for_tests.sh

--- a/.github/actions/install_linux_dep/action.yml
+++ b/.github/actions/install_linux_dep/action.yml
@@ -1,0 +1,40 @@
+name: "Install Dependencies"
+inputs:
+  torch-version:
+    description: torch version to install
+  torchvision-version:
+    description: torch vision version to install, version number or "master"
+  pytorch-index:
+    description: where to install torch from
+    required: false
+    default: "https://download.pytorch.org/whl/torch_stable.html"
+    # use test wheels index to have access to RC wheels
+    # https://download.pytorch.org/whl/test/torch_test.html
+runs:
+  using: composite
+  steps:
+  - name: Install Dependencies
+    shell: bash
+    run: |
+      # disable crash coredump, so unittests fail fast
+      sudo systemctl stop apport.service
+
+      pip install -U pip
+
+      # install from github to get latest; install iopath first since fvcore depends on it
+      pip install --progress-bar off -U 'git+https://github.com/facebookresearch/iopath'
+      pip install --progress-bar off -U 'git+https://github.com/facebookresearch/fvcore'
+
+      # Don't use pytest-xdist: cuda tests are unstable under multi-process workers.
+      # Don't use opencv 4.7.0.68: https://github.com/opencv/opencv-python/issues/765
+      pip install --progress-bar off ninja opencv-python-headless!=4.7.0.68 pytest tensorboard pycocotools onnx
+      pip install --progress-bar off torch==${{inputs.torch-version}} -f ${{inputs.pytorch-index}}
+      if [[ "${{inputs.torchvision-version}}" == "master" ]]; then
+        pip install git+https://github.com/pytorch/vision.git
+      else
+        pip install --progress-bar off torchvision==${{inputs.torchvision-version}} -f ${{inputs.pytorch-index}}
+      fi
+
+      echo python install path: $pythonLocation
+      python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
+      gcc --version

--- a/.github/actions/install_linux_gpu_dep/action.yml
+++ b/.github/actions/install_linux_gpu_dep/action.yml
@@ -1,0 +1,18 @@
+name: "Install GPU Dependencies"
+inputs:
+  cuda-version:
+    description: version of cuda to install, ie "12-5" for 12.5
+runs:
+  using: composite
+  steps:
+  - name: Install GPU Dependencies
+    shell: bash
+    run: |
+      uname -r
+
+      # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#network-repo-installation-for-ubuntu
+      # Installing the keyring seems to be unnecessary
+
+      sudo apt-get update
+      sudo apt-get --yes install cuda-toolkit-${{inputs.cuda-version}}
+      sudo apt-get --yes install nvidia-gds-${{inputs.cuda-version}}

--- a/.github/actions/run_unittests/action.yml
+++ b/.github/actions/run_unittests/action.yml
@@ -1,0 +1,8 @@
+name: "Run Unit Tests"
+runs:
+  using: composite
+  steps:
+  - name: Run Unit Tests
+    shell: bash
+    run: |
+      python -m pytest -sv --durations=15 tests  # parallel causes some random failures

--- a/.github/actions/uninstall_tests/action.yml
+++ b/.github/actions/uninstall_tests/action.yml
@@ -1,0 +1,12 @@
+name: "Run Tests After Uninstalling"
+runs:
+  using: composite
+  steps:
+  - name: "Run Tests After Uninstalling"
+    shell: bash
+    run: |
+      pip uninstall -y detectron2
+      # Remove built binaries
+      rm -rf build/ detectron2/*.so
+      # Tests that code is importable without installation
+      PYTHONPATH=. ./.circleci/import-tests.sh

--- a/.github/actions/uninstall_tests/action.yml
+++ b/.github/actions/uninstall_tests/action.yml
@@ -9,4 +9,4 @@ runs:
       # Remove built binaries
       rm -rf build/ detectron2/*.so
       # Tests that code is importable without installation
-      PYTHONPATH=. ./.circleci/import-tests.sh
+      . ./.github/import-tests.sh

--- a/.github/import-tests.sh
+++ b/.github/import-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# Test that import works without building detectron2.
+
+# Check that _C is not importable
+python -c "from detectron2 import _C" > /dev/null 2>&1 && {
+  echo "This test should be run without building detectron2."
+  exit 1
+}
+
+# Check that other modules are still importable, even when _C is not importable
+python -c "from detectron2 import modeling"
+python -c "from detectron2 import modeling, data"
+python -c "from detectron2 import evaluation, export, checkpoint"
+python -c "from detectron2 import utils, engine"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -82,3 +82,54 @@ jobs:
           ./datasets/prepare_for_tests.sh
       - name: Run unittests
         run: python -m pytest -n 4 --durations=15 -sv tests/
+
+  linux_gpu_tests:
+    runs-on: 4-core-ubuntu-gpu-t4
+    # run on PRs, or commits to facebookresearch (not internal)
+    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        torch: ["1.13.1", "2.2.2"]
+        include:
+          - torch: "1.13.1"
+            torchvision: "0.14.1"
+          - torch: "2.2.2"
+            torchvision: "0.17.2"
+    env:
+      PYTORCH_INDEX: "https://download.pytorch.org/whl/torch_stable.html"
+      DETECTRON2_DATASETS: ~/.torch/datasets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: load-cache
+        with:
+          path: |
+            ${{ env.pythonLocation }}/lib/python3.8/site-packages
+            ~/.torch
+          key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20210827
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install_linux_dep
+        if: steps.load-cache.outputs.cache-hit != 'true'
+        with:
+          torch-version: ${{matrix.torch}}
+          torchvision-version: ${{matrix.torchvision}}
+          pytorch-index: $PYTORCH_INDEX
+
+      - name: Install Detectron2
+        uses: ./.github/actions/install_detectron2
+
+      - name: Run Unit Tests
+        uses: ./.github/actions/run_unittests
+
+      - name: Run Tests After Uninstalling
+        uses: ./.github/actions/uninstall_tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -94,10 +94,12 @@ jobs:
         include:
           - torch: "1.13.1"
             torchvision: "0.14.1"
+            cuda: "11-7"
           - torch: "2.2.2"
             torchvision: "0.17.2"
+            cuda: "12-5"
     env:
-      PYTORCH_INDEX: "https://download.pytorch.org/whl/torch_stable.html"
+      PYTORCH_INDEX: "https://download.pytorch.org/whl/cu118"
       DETECTRON2_DATASETS: ~/.torch/datasets
     steps:
       - name: Checkout
@@ -116,6 +118,11 @@ jobs:
             ${{ env.pythonLocation }}/lib/python3.8/site-packages
             ~/.torch
           key: ${{ runner.os }}-torch${{ matrix.torch }}-${{ hashFiles('setup.py') }}-20210827
+
+      - name: Install GPU Dependencies
+        uses: ./.github/actions/install_linux_gpu_dep
+        with:
+          cuda-version: ${{matrix.cuda}}
 
       - name: Install Dependencies
         uses: ./.github/actions/install_linux_dep


### PR DESCRIPTION
Summary:
Migrate circleci gpu test to github actions
the rocm version of torch was being installed earlier, now torch should be the cuda version

Differential Revision: D57598325


