### PR TITLE
data: common: MapDataset: Fix `random.sample()` usage for Python 3.11

### DIFF
--- a/detectron2/data/common.py
+++ b/detectron2/data/common.py
@@ -130,7 +130,7 @@ class MapDataset(data.Dataset):
             # _map_func fails for this idx, use a random new index from the pool
             retry_count += 1
             self._fallback_candidates.discard(cur_idx)
-            cur_idx = self._rng.sample(self._fallback_candidates, k=1)[0]
+            cur_idx = self._rng.sample(list(self._fallback_candidates), k=1)[0]
 
             if retry_count >= 3:
                 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Sampling from a set has been [deprecated since Python 3.9](url) and was [removed in 3.11](https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11).
Fix buy converting the set to a list before passing it to `sample()` (this is essentially what `sample()` was doing internally before).