### PR TITLE
Fix ValueError: Unable to avoid copy while creating an array as requested (numpy 2.0.0)

### DIFF
--- a/detectron2/evaluation/sem_seg_evaluation.py
+++ b/detectron2/evaluation/sem_seg_evaluation.py
@@ -1,11 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-import itertools
-import json
-import logging
 import numpy as np
-import os
-from collections import OrderedDict
-from typing import Optional, Union
 import pycocotools.mask as mask_util
 import torch
 from PIL import Image
@@ -13,6 +7,13 @@ from PIL import Image
 from detectron2.data import DatasetCatalog, MetadataCatalog
 from detectron2.utils.comm import all_gather, is_main_process, synchronize
 from detectron2.utils.file_io import PathManager
+
+import itertools
+import json
+import logging
+import os
+from collections import OrderedDict
+from typing import Optional, Union
 
 from .evaluator import DatasetEvaluator
 
@@ -26,11 +27,10 @@ except ImportError:
 
 def load_image_into_numpy_array(
     filename: str,
-    copy: bool = False,
     dtype: Optional[Union[np.dtype, str]] = None,
 ) -> np.ndarray:
     with PathManager.open(filename, "rb") as f:
-        array = np.array(Image.open(f), copy=copy, dtype=dtype)
+        array = np.asarray(Image.open(f), dtype=dtype)
     return array
 
 
@@ -61,13 +61,9 @@ class SemSegEvaluator(DatasetEvaluator):
         """
         self._logger = logging.getLogger(__name__)
         if num_classes is not None:
-            self._logger.warn(
-                "SemSegEvaluator(num_classes) is deprecated! It should be obtained from metadata."
-            )
+            self._logger.warn("SemSegEvaluator(num_classes) is deprecated! It should be obtained from metadata.")
         if ignore_label is not None:
-            self._logger.warn(
-                "SemSegEvaluator(ignore_label) is deprecated! It should be obtained from metadata."
-            )
+            self._logger.warn("SemSegEvaluator(ignore_label) is deprecated! It should be obtained from metadata.")
         self._dataset_name = dataset_name
         self._distributed = distributed
         self._output_dir = output_dir
@@ -113,9 +109,7 @@ class SemSegEvaluator(DatasetEvaluator):
 
     def reset(self):
         self._conf_matrix = np.zeros((self._num_classes + 1, self._num_classes + 1), dtype=np.int64)
-        self._b_conf_matrix = np.zeros(
-            (self._num_classes + 1, self._num_classes + 1), dtype=np.int64
-        )
+        self._b_conf_matrix = np.zeros((self._num_classes + 1, self._num_classes + 1), dtype=np.int64)
         self._predictions = []
 
     def process(self, inputs, outputs):
@@ -238,18 +232,16 @@ class SemSegEvaluator(DatasetEvaluator):
         json_list = []
         for label in np.unique(sem_seg):
             if self._contiguous_id_to_dataset_id is not None:
-                assert (
-                    label in self._contiguous_id_to_dataset_id
-                ), "Label {} is not in the metadata info for {}".format(label, self._dataset_name)
+                assert label in self._contiguous_id_to_dataset_id, "Label {} is not in the metadata info for {}".format(
+                    label, self._dataset_name
+                )
                 dataset_id = self._contiguous_id_to_dataset_id[label]
             else:
                 dataset_id = int(label)
             mask = (sem_seg == label).astype(np.uint8)
             mask_rle = mask_util.encode(np.array(mask[:, :, None], order="F"))[0]
             mask_rle["counts"] = mask_rle["counts"].decode("utf-8")
-            json_list.append(
-                {"file_name": input_file_name, "category_id": dataset_id, "segmentation": mask_rle}
-            )
+            json_list.append({"file_name": input_file_name, "category_id": dataset_id, "segmentation": mask_rle})
         return json_list
 
     def _mask_to_boundary(self, mask: np.ndarray, dilation_ratio=0.02):

--- a/detectron2/layers/mask_ops.py
+++ b/detectron2/layers/mask_ops.py
@@ -1,10 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import numpy as np
+from typing import Tuple
 import torch
 from PIL import Image
 from torch.nn import functional as F
-
-from typing import Tuple
 
 __all__ = ["paste_masks_in_image"]
 
@@ -37,7 +36,9 @@ def _do_paste_mask(masks, boxes, img_h: int, img_w: int, skip_empty: bool = True
     device = masks.device
 
     if skip_empty and not torch.jit.is_scripting():
-        x0_int, y0_int = torch.clamp(boxes.min(dim=0).values.floor()[:2] - 1, min=0).to(dtype=torch.int32)
+        x0_int, y0_int = torch.clamp(boxes.min(dim=0).values.floor()[:2] - 1, min=0).to(
+            dtype=torch.int32
+        )
         x1_int = torch.clamp(boxes[:, 2].max().ceil() + 1, max=img_w).to(dtype=torch.int32)
         y1_int = torch.clamp(boxes[:, 3].max().ceil() + 1, max=img_h).to(dtype=torch.int32)
     else:
@@ -70,7 +71,9 @@ def _do_paste_mask(masks, boxes, img_h: int, img_w: int, skip_empty: bool = True
 
 # Annotate boxes as Tensor (but not Boxes) in order to use scripting
 @torch.jit.script_if_tracing
-def paste_masks_in_image(masks: torch.Tensor, boxes: torch.Tensor, image_shape: Tuple[int, int], threshold: float = 0.5):
+def paste_masks_in_image(
+    masks: torch.Tensor, boxes: torch.Tensor, image_shape: Tuple[int, int], threshold: float = 0.5
+):
     """
     Paste a set of masks that are of a fixed resolution (e.g., 28 x 28) into an image.
     The location, height, and width for pasting each mask is determined by their
@@ -118,10 +121,14 @@ def paste_masks_in_image(masks: torch.Tensor, boxes: torch.Tensor, image_shape: 
         # GPU benefits from parallelism for larger chunks, but may have memory issue
         # int(img_h) because shape may be tensors in tracing
         num_chunks = int(np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
-        assert num_chunks <= N, "Default GPU_MEM_LIMIT in mask_ops.py is too small; try increasing it"
+        assert (
+            num_chunks <= N
+        ), "Default GPU_MEM_LIMIT in mask_ops.py is too small; try increasing it"
     chunks = torch.chunk(torch.arange(N, device=device), num_chunks)
 
-    img_masks = torch.zeros(N, img_h, img_w, device=device, dtype=torch.bool if threshold >= 0 else torch.uint8)
+    img_masks = torch.zeros(
+        N, img_h, img_w, device=device, dtype=torch.bool if threshold >= 0 else torch.uint8
+    )
     for inds in chunks:
         masks_chunk, spatial_inds = _do_paste_mask(
             masks[inds, None, :, :], boxes[inds], img_h, img_w, skip_empty=device.type == "cpu"
@@ -194,7 +201,9 @@ def paste_mask_in_image_old(mask, box, img_h, img_w, threshold):
     y_0 = max(box[1], 0)
     y_1 = min(box[3] + 1, img_h)
 
-    im_mask[y_0:y_1, x_0:x_1] = mask[(y_0 - box[1]) : (y_1 - box[1]), (x_0 - box[0]) : (x_1 - box[0])]
+    im_mask[y_0:y_1, x_0:x_1] = mask[
+        (y_0 - box[1]) : (y_1 - box[1]), (x_0 - box[0]) : (x_1 - box[0])
+    ]
     return im_mask
 
 


### PR DESCRIPTION
This pull request fixes a ValueError that occurs when creating an array (changed in numpy 2.0.0) The issue is resolved by replacing np.array with np.asarray. As copy was always set to False anyways. See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword