### PR TITLE
Focal Loss

### DIFF
--- a/configs/common/models/mask_rcnn_fpn.py
+++ b/configs/common/models/mask_rcnn_fpn.py
@@ -75,6 +75,8 @@ model = L(GeneralizedRCNN)(
             test_score_thresh=0.05,
             box2box_transform=L(Box2BoxTransform)(weights=(10, 10, 5, 5)),
             num_classes="${..num_classes}",
+            test_topk_per_image = 2000,
+            use_focal = False  
         ),
         mask_in_features=["p2", "p3", "p4", "p5"],
         mask_pooler=L(ROIPooler)(

--- a/configs/common/models/mask_rcnn_fpn.py
+++ b/configs/common/models/mask_rcnn_fpn.py
@@ -76,7 +76,7 @@ model = L(GeneralizedRCNN)(
             box2box_transform=L(Box2BoxTransform)(weights=(10, 10, 5, 5)),
             num_classes="${..num_classes}",
             test_topk_per_image = 2000,
-            use_focal = False  
+            use_focal_ce = False  
         ),
         mask_in_features=["p2", "p3", "p4", "p5"],
         mask_pooler=L(ROIPooler)(

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -223,6 +223,8 @@ class FastRCNNOutputLayers(nn.Module):
                 classes to calculate the loss
             use_sigmoid_ce (bool): whether to calculate the loss using weighted average of binary
                 cross entropy with logits. This could be used together with federated loss
+            use_focal_ce (bool): whether or not to calculate the loss using focal_loss as detailed in RetinaNet, 
+                https://arxiv.org/pdf/1708.02002v2
             get_fed_loss_cls_weights (Callable): a callable which takes dataset name and frequency
                 weight power, and returns the probabilities to sample negative classes for
                 federated loss. The implementation can be found in


### PR DESCRIPTION
Hello FAIR team, 

I am submitting a small pull-request, which adds focal loss (as detailed in https://arxiv.org/pdf/1708.02002v2) as a possible loss function in the Fast RCNN output layer (box predictor). The new commit simply adds an attribute to the class FastRCNNOutputLayers and makes the attribute accessible from within the LazyConfig workflow. Once a LazyConfig has been instantiated using cfg = LazyConfig.load('...') the attribute can be accessed by calling cfg.model.roi_heads.box_predictor.use_focal_ce = True. The attribute's value is 'False' by default. 

Using focal loss for the ROI class prediction greatly improves network validation accuracy when training on datasets with a large deal of class imbalance. Datasets with large class imbalance are extremely common for researchers working with natural data such as time lapse movies of cells, where possible classes may be "mitotic" and "non-mitotic". The typical ratio of mitotic to non-mitotic cells on a frame is 1:9, and if training a RCNN to detect cells, whole frames must be used thus excluding the possibility of balancing the dataset by training on mitotic cells only for a select number of frames. For this reason loss functions such as focal loss are highly useful. 
