### PR TITLE
Initialize event storage when loading checkpoint in lightning module

### DIFF
--- a/tools/lightning_train_net.py
+++ b/tools/lightning_train_net.py
@@ -56,6 +56,9 @@ class TrainingModule(LightningModule):
 
     def on_load_checkpoint(self, checkpointed_state: Dict[str, Any]) -> None:
         self.start_iter = checkpointed_state["iteration"]
+        if self.storage is None:
+            self.storage = EventStorage(0)
+            self.storage.__enter__()
         self.storage.iter = self.start_iter
 
     def setup(self, stage: str):
@@ -83,6 +86,7 @@ class TrainingModule(LightningModule):
             self.storage.__enter__()
             self.iteration_timer.trainer = weakref.proxy(self)
             self.iteration_timer.before_step()
+        if self.writers is None:
             self.writers = (
                 default_writers(self.cfg.OUTPUT_DIR, self.max_iter)
                 if comm.is_main_process()


### PR DESCRIPTION
If you construct the Lightning training module and then immediately load a checkpoint, it crashes because `self.storage` is None until the first training_step call. This creates the event storage in on_load_checkpoint too. I'm not sure if this is the best solution or if it should actually go in init. The comment in training_step indicates it should not go there.

In training_step several things are being set up if self.storage is None. I split out the self.writers setup, but possibly something should be done with iteration_timer as well. My current use case is not resuming training from a checkpoint, so I haven't tried that.