### PR TITLE
Fix torch export issue

### DIFF
--- a/detectron2/export/c10.py
+++ b/detectron2/export/c10.py
@@ -84,6 +84,11 @@ class InstancesList:
         else:
             data_len = len(value)
         if len(self.batch_extra_fields):
+            # If we are tracing with Dynamo, the check here is needed since len(self)
+            # represents the number of bounding boxes detected in the image and thus is
+            # an unbounded SymInt.
+            if torch._utils.is_compiling():
+                torch._check(len(self) == data_len)
             assert (
                 len(self) == data_len
             ), "Adding a field of length {} to a Instances of length {}".format(data_len, len(self))


### PR DESCRIPTION
Summary: Add a check to deal with dynamic shapes so that the model can be exported with `torch.export`. This check prevents the graph break caused by the SymInt by delaying the assertion to runtime.

Reviewed By: wat3rBro

Differential Revision: D60126415
