### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,35 +1,30 @@
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
-# use an older system (18.04) to avoid opencv incompatibility (issue#3524)
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
-	python3-opencv ca-certificates python3-dev git wget sudo ninja-build
-RUN ln -sv /usr/bin/python3 /usr/bin/python
+    python3-opencv ca-certificates python3.8 python3.8-dev git wget sudo ninja-build && \
+    ln -sv /usr/bin/python3.8 /usr/bin/python3
 
 # create a non-root user
 ARG USER_ID=1000
-RUN useradd -m --no-log-init --system  --uid ${USER_ID} appuser -g sudo
+RUN useradd -m --no-log-init --system --uid ${USER_ID} appuser -g sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER appuser
 WORKDIR /home/appuser
 
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
-	python3 get-pip.py --user && \
-	rm get-pip.py
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py --user && \
+    rm get-pip.py
 
 # install dependencies
-# See https://pytorch.org/ for other options if you use a different version of CUDA
-RUN pip install --user tensorboard cmake onnx   # cmake from apt-get is too old
+RUN pip install --user tensorboard cmake onnx
 RUN pip install --user torch==1.10 torchvision==0.11.1 -f https://download.pytorch.org/whl/cu111/torch_stable.html
 
 RUN pip install --user 'git+https://github.com/facebookresearch/fvcore'
 # install detectron2
 RUN git clone https://github.com/facebookresearch/detectron2 detectron2_repo
-# set FORCE_CUDA because during `docker build` cuda is not accessible
 ENV FORCE_CUDA="1"
-# This will by default build detectron2 for all common cuda architectures and take a lot more time,
-# because inside `docker build`, there is no way to tell which architecture will be used.
 ARG TORCH_CUDA_ARCH_LIST="Kepler;Kepler+Tesla;Maxwell;Maxwell+Tegra;Pascal;Volta;Turing"
 ENV TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}"
 


### PR DESCRIPTION
This commit updates the Dockerfile to ensure compatibility with Detectron2 by upgrading the Python version from 3.6 to 3.8. The changes include: Base Image Change: Switched from nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04 to nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04 to provide a more recent environment with better package support. Python Installation: Removed the installation of Python 3.6 and replaced it with Python 3.8, ensuring that the python3 command points to the newly installed version.

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

