### PR TITLE
Fix typo in SimpleFeaturePyramid.padding_constraints

### DIFF
--- a/detectron2/modeling/backbone/vit.py
+++ b/detectron2/modeling/backbone/vit.py
@@ -470,7 +470,7 @@ class SimpleFeaturePyramid(Backbone):
     @property
     def padding_constraints(self):
         return {
-            "size_divisiblity": self._size_divisibility,
+            "size_divisibility": self._size_divisibility,
             "square_size": self._square_pad,
         }
 


### PR DESCRIPTION
The "size_divisibility" key of the padding_constraints dictionary exposed by SimpleFeaturePyramid has a missing i (size_divisiblity). This PR fixes this issue.