### PR TITLE
fix: cuda imports

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -469,7 +469,7 @@ class AMPTrainer(SimpleTrainer):
         )
 
         if grad_scaler is None:
-            from torch.cuda.amp import GradScaler
+            from torch.amp import GradScaler
 
             grad_scaler = GradScaler()
         self.grad_scaler = grad_scaler
@@ -482,7 +482,7 @@ class AMPTrainer(SimpleTrainer):
         """
         assert self.model.training, "[AMPTrainer] model was changed to eval mode!"
         assert torch.cuda.is_available(), "[AMPTrainer] CUDA is required for AMP training!"
-        from torch.cuda.amp import autocast
+        from torch.amp import autocast
 
         start = time.perf_counter()
         data = next(self._data_loader_iter)

--- a/tests/layers/test_blocks.py
+++ b/tests/layers/test_blocks.py
@@ -24,7 +24,7 @@ class TestBlocks(unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_frozen_batchnorm_fp16(self):
-        from torch.cuda.amp import autocast
+        from torch.amp import autocast
 
         C = 10
         input = torch.rand(1, C, 10, 10).cuda()

--- a/tests/modeling/test_model_e2e.py
+++ b/tests/modeling/test_model_e2e.py
@@ -155,7 +155,7 @@ class MaskRCNNE2ETest(InstanceModelE2ETest, unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_autocast(self):
-        from torch.cuda.amp import autocast
+        from torch.amp import autocast
 
         inputs = [{"image": torch.rand(3, 100, 100)}]
         self.model.eval()
@@ -195,7 +195,7 @@ class RetinaNetE2ETest(InstanceModelE2ETest, unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_autocast(self):
-        from torch.cuda.amp import autocast
+        from torch.amp import autocast
 
         inputs = [{"image": torch.rand(3, 100, 100)}]
         self.model.eval()


### PR DESCRIPTION
Misc: fix deprecated cuda import

Using ` torch.cuda.amp` is deprecated, which results in multiple warnings being logged to screen, cluttering the view. This MR updates the code to use the new correct import.


