### PR TITLE
support dataset more than 255 classes

### DIFF
--- a/detectron2/data/dataset_mapper.py
+++ b/detectron2/data/dataset_mapper.py
@@ -156,7 +156,7 @@ class DatasetMapper:
 
         # USER: Remove if you don't do semantic/panoptic segmentation.
         if "sem_seg_file_name" in dataset_dict:
-            sem_seg_gt = utils.read_image(dataset_dict.pop("sem_seg_file_name"), "L").squeeze(2)
+            sem_seg_gt = utils.read_image(dataset_dict.pop("sem_seg_file_name")).astype("double")
         else:
             sem_seg_gt = None
 


### PR DESCRIPTION
The previous method used uint8, which caused overflow when loading datasets with more than 255 categories. Now many datasets, such as ADE20K-847, have far more than 255 categories.
