### PR TITLE
visualizer's sem_seg function dtype uint8 cannot handle classes more than 256!

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -600,7 +600,9 @@ class Visualizer:
         if sem_seg is None and "sem_seg_file_name" in dic:
             with PathManager.open(dic["sem_seg_file_name"], "rb") as f:
                 sem_seg = Image.open(f)
-                sem_seg = np.asarray(sem_seg, dtype="uint8")
+                # sem_seg = np.asarray(sem_seg, dtype="uint8")
+                # The dtype uint8 is 0-255 which is not suitable for GT visualization of Pascal Context 459 whose class num is more than 256 and make the visualization text wrong!
+                sem_seg = np.asarray(sem_seg, dtype=np.int16)
         if sem_seg is not None:
             self.draw_sem_seg(sem_seg, area_threshold=0, alpha=0.5)
 


### PR DESCRIPTION
…than 256

Update visualizer.py

Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

