### PR TITLE
Allow iopath 0.1.10 for compatibility with sam2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup(
         # NOTE: when updating fvcore/iopath version, make sure fvcore depends
         # on compatible version of iopath.
         "fvcore>=0.1.5,<0.1.6",  # required like this to make it pip installable
-        "iopath>=0.1.7,<0.1.10",
+        "iopath>=0.1.7,<0.1.11",
         "dataclasses; python_version<'3.7'",
         "omegaconf>=2.1,<2.4",
         "hydra-core>=1.1",


### PR DESCRIPTION
Update dependencies to allow iopath 0.1.10, to be able to install detectron2 and sam2 in the same env.

Based on this comparison https://github.com/facebookresearch/iopath/compare/v0.1.9...b3ea6da153ab61b3b8687544c0708a4234a8fb58 I don't see breaking changes.

