### PR TITLE
Add 'with EventStorage()' context

### DIFF
--- a/detectron2/modeling/proposal_generator/rpn.py
+++ b/detectron2/modeling/proposal_generator/rpn.py
@@ -7,7 +7,7 @@ from torch import nn
 from detectron2.config import configurable
 from detectron2.layers import Conv2d, ShapeSpec, cat
 from detectron2.structures import Boxes, ImageList, Instances, pairwise_iou
-from detectron2.utils.events import get_event_storage
+from detectron2.utils.events import EventStorage
 from detectron2.utils.memory import retry_if_cuda_oom
 from detectron2.utils.registry import Registry
 
@@ -398,9 +398,9 @@ class RPN(nn.Module):
         pos_mask = gt_labels == 1
         num_pos_anchors = pos_mask.sum().item()
         num_neg_anchors = (gt_labels == 0).sum().item()
-        storage = get_event_storage()
-        storage.put_scalar("rpn/num_pos_anchors", num_pos_anchors / num_images)
-        storage.put_scalar("rpn/num_neg_anchors", num_neg_anchors / num_images)
+        with EventStorage() as storage:
+            storage.put_scalar("rpn/num_pos_anchors", num_pos_anchors / num_images)
+            storage.put_scalar("rpn/num_neg_anchors", num_neg_anchors / num_images)
 
         localization_loss = _dense_box_regression_loss(
             anchors,

--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -10,7 +10,7 @@ from detectron2.data.detection_utils import get_fed_loss_cls_weights
 from detectron2.layers import ShapeSpec, batched_nms, cat, cross_entropy, nonzero_tuple
 from detectron2.modeling.box_regression import Box2BoxTransform, _dense_box_regression_loss
 from detectron2.structures import Boxes, Instances
-from detectron2.utils.events import get_event_storage
+from detectron2.utils.events import EventStorage
 
 __all__ = ["fast_rcnn_inference", "FastRCNNOutputLayers"]
 
@@ -108,11 +108,11 @@ def _log_classification_stats(pred_logits, gt_classes, prefix="fast_rcnn"):
     num_accurate = (pred_classes == gt_classes).nonzero().numel()
     fg_num_accurate = (fg_pred_classes == fg_gt_classes).nonzero().numel()
 
-    storage = get_event_storage()
-    storage.put_scalar(f"{prefix}/cls_accuracy", num_accurate / num_instances)
-    if num_fg > 0:
-        storage.put_scalar(f"{prefix}/fg_cls_accuracy", fg_num_accurate / num_fg)
-        storage.put_scalar(f"{prefix}/false_negative", num_false_negative / num_fg)
+    with EventStorage() as storage:
+        storage.put_scalar(f"{prefix}/cls_accuracy", num_accurate / num_instances)
+        if num_fg > 0:
+            storage.put_scalar(f"{prefix}/fg_cls_accuracy", fg_num_accurate / num_fg)
+            storage.put_scalar(f"{prefix}/false_negative", num_false_negative / num_fg)
 
 
 def fast_rcnn_inference_single_image(

--- a/detectron2/modeling/roi_heads/roi_heads.py
+++ b/detectron2/modeling/roi_heads/roi_heads.py
@@ -9,7 +9,7 @@ from torch import nn
 from detectron2.config import configurable
 from detectron2.layers import ShapeSpec, nonzero_tuple
 from detectron2.structures import Boxes, ImageList, Instances, pairwise_iou
-from detectron2.utils.events import get_event_storage
+from detectron2.utils.events import EventStorage
 from detectron2.utils.registry import Registry
 
 from ..backbone.resnet import BottleneckBlock, ResNet
@@ -115,8 +115,8 @@ def select_proposals_with_visible_keypoints(proposals: List[Instances]) -> List[
         all_num_fg.append(selection_idxs.numel())
         ret.append(proposals_per_image[selection_idxs])
 
-    storage = get_event_storage()
-    storage.put_scalar("keypoint_head/num_fg_samples", np.mean(all_num_fg))
+    with EventStorage() as storage:
+        storage.put_scalar("keypoint_head/num_fg_samples", np.mean(all_num_fg))
     return ret
 
 
@@ -295,9 +295,9 @@ class ROIHeads(torch.nn.Module):
             proposals_with_gt.append(proposals_per_image)
 
         # Log the number of fg/bg samples that are selected for training ROI heads
-        storage = get_event_storage()
-        storage.put_scalar("roi_head/num_fg_samples", np.mean(num_fg_samples))
-        storage.put_scalar("roi_head/num_bg_samples", np.mean(num_bg_samples))
+        with EventStorage() as storage:
+            storage.put_scalar("roi_head/num_fg_samples", np.mean(num_fg_samples))
+            storage.put_scalar("roi_head/num_bg_samples", np.mean(num_bg_samples))
 
         return proposals_with_gt
 


### PR DESCRIPTION
Currently I'm using pytorch to test some models benchmarks with compile mode - https://github.com/pytorch/pytorch/tree/main/benchmarks/dynamo
When I run detectron2-* models following error appears:

```bash
storage = get_event_storage()
  File "/usr/local/lib/python3.10/dist-packages/detectron2/utils/events.py", line 34, in get_event_storage
    assert len(
AssertionError: get_event_storage() has to be called inside a 'with EventStorage(...)' context!
```

It seems that the code doesn't get the storage in a proper way. I added a context to each required place and it works for me.
I also noticed that this usage is present in other different places in repo but I left it as it is.
Could you take a look?