### PR TITLE
Update AMP imports for PyTorch version compatibility

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -469,7 +469,12 @@ class AMPTrainer(SimpleTrainer):
         )
 
         if grad_scaler is None:
-            from torch.cuda.amp import GradScaler
+            if torch.__version__ < "2.4.0":
+                from torch.cuda.amp import GradScaler
+            else:
+                from torch.amp import GradScaler
+                from functools import partial
+                GradScaler = partial(GradScaler, device="cuda")
 
             grad_scaler = GradScaler()
         self.grad_scaler = grad_scaler
@@ -482,7 +487,12 @@ class AMPTrainer(SimpleTrainer):
         """
         assert self.model.training, "[AMPTrainer] model was changed to eval mode!"
         assert torch.cuda.is_available(), "[AMPTrainer] CUDA is required for AMP training!"
-        from torch.cuda.amp import autocast
+        if torch.__version__ < "2.4.0":
+            from torch.cuda.amp import autocast
+        else:
+            from torch.amp import autocast
+            from functools import partial
+            autocast = partial(autocast, device_type="cuda")
 
         start = time.perf_counter()
         data = next(self._data_loader_iter)

--- a/tests/layers/test_blocks.py
+++ b/tests/layers/test_blocks.py
@@ -24,7 +24,12 @@ class TestBlocks(unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_frozen_batchnorm_fp16(self):
-        from torch.cuda.amp import autocast
+        if torch.__version__ < "2.4.0":
+            from torch.cuda.amp import autocast
+        else:
+            from torch.amp import autocast
+            from functools import partial
+            autocast = partial(autocast, device_type="cuda")
 
         C = 10
         input = torch.rand(1, C, 10, 10).cuda()

--- a/tests/modeling/test_model_e2e.py
+++ b/tests/modeling/test_model_e2e.py
@@ -155,7 +155,12 @@ class MaskRCNNE2ETest(InstanceModelE2ETest, unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_autocast(self):
-        from torch.cuda.amp import autocast
+        if torch.__version__ < "2.4.0":
+            from torch.cuda.amp import autocast
+        else:
+            from torch.amp import autocast
+            from functools import partial
+            autocast = partial(autocast, device_type="cuda")
 
         inputs = [{"image": torch.rand(3, 100, 100)}]
         self.model.eval()
@@ -195,7 +200,12 @@ class RetinaNetE2ETest(InstanceModelE2ETest, unittest.TestCase):
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_autocast(self):
-        from torch.cuda.amp import autocast
+        if torch.__version__ < "2.4.0":
+            from torch.cuda.amp import autocast
+        else:
+            from torch.amp import autocast
+            from functools import partial
+            autocast = partial(autocast, device_type="cuda")
 
         inputs = [{"image": torch.rand(3, 100, 100)}]
         self.model.eval()


### PR DESCRIPTION
Replace `torch.cuda.amp` imports with `torch.amp` for PyTorch versions greater than 2.4.0, ensuring compatibility and using `partial` for device specification. Improvment over PR #5371 due to backward compatibility. Resolves: 
```
FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with autocast(dtype=self.precision):
```