### PR TITLE
Fix Windows crash: panoptic_fpn.py passing int32 instead of long

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/detectron2/modeling/meta_arch/panoptic_fpn.py
+++ b/detectron2/modeling/meta_arch/panoptic_fpn.py
@@ -123,7 +123,7 @@ class PanopticFPN(GeneralizedRCNN):
             self.backbone.size_divisibility,
             self.sem_seg_head.ignore_value,
             self.backbone.padding_constraints,
-        ).tensor
+        ).tensor.long()
         sem_seg_results, sem_seg_losses = self.sem_seg_head(features, gt_sem_seg)
 
         gt_instances = [x["instances"].to(self.device) for x in batched_inputs]


### PR DESCRIPTION
Stack trace:

```log
[04/02 13:07:05 d2.data.build]: Distribution of instances among all 4 categories:
|  category  | #instances   |  category  | #instances   |  category  | #instances   |
|:----------:|:-------------|:----------:|:-------------|:----------:|:-------------|
|     G      | 25           |     SG     | 8            |     T      | 746          |
|     A      | 58           |            |              |            |              |
|   total    | 837          |            |              |            |              |
[04/02 13:07:05 d2.data.common]: Serializing the dataset using: <class 'detectron2.data.common._TorchSerializedList'>
[04/02 13:07:05 d2.data.common]: Serializing 40 elements to byte tensors and concatenating them all ...
[04/02 13:07:05 d2.data.common]: Serialized dataset takes 8.95 MiB
check and see
[04/02 13:07:05 d2.checkpoint.detection_checkpoint]: [DetectionCheckpointer] Loading from M:/Histo/Work/model_0214999.pth ...
[04/02 13:07:05 d2.engine.train_loop]: Starting training from iteration 0
ERROR [04/02 13:07:42 d2.engine.train_loop]: Exception during training:
Traceback (most recent call last):
  File "M:\Histo\.venv38\lib\site-packages\detectron2\engine\train_loop.py", line 155, in train
    self.run_step()
  File "M:\Histo\.venv38\lib\site-packages\detectron2\engine\defaults.py", line 530, in run_step
    self._trainer.run_step()
  File "M:\Histo\.venv38\lib\site-packages\detectron2\engine\train_loop.py", line 310, in run_step
    loss_dict = self.model(data)
  File "M:\Histo\.venv38\lib\site-packages\torch\nn\modules\module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "M:\Histo\.venv38\lib\site-packages\detectron2\modeling\meta_arch\panoptic_fpn.py", line 127, in forward
    sem_seg_results, sem_seg_losses = self.sem_seg_head(features, gt_sem_seg)
  File "M:\Histo\.venv38\lib\site-packages\torch\nn\modules\module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "M:\Histo\.venv38\lib\site-packages\detectron2\modeling\meta_arch\semantic_seg.py", line 239, in forward
    return None, self.losses(x, targets)
  File "M:\Histo\.venv38\lib\site-packages\detectron2\modeling\meta_arch\semantic_seg.py", line 263, in losses
    loss = F.cross_entropy(
  File "M:\Histo\.venv38\lib\site-packages\torch\nn\functional.py", line 2846, in cross_entropy
    return torch._C._nn.cross_entropy_loss(input, target, weight, _Reduction.get_enum(reduction), ignore_index, label_smoothing)
RuntimeError: expected scalar type Long but found Int
```

 `dev/linter.sh` only makes unrelated changes.