### PR TITLE
Remove deprecated <THC/THCAtomics.cuh> inclusion

### DIFF
--- a/detectron2/layers/csrc/deformable/deform_conv_cuda_kernel.cu
+++ b/detectron2/layers/csrc/deformable/deform_conv_cuda_kernel.cu
@@ -73,7 +73,6 @@
 #include <float.h>
 #include <math.h>
 #include <stdio.h>
-#include <THC/THCAtomics.cuh>
 
 using namespace at;
 


### PR DESCRIPTION
Thanks for your contribution!

If you're sending a large PR (e.g., >100 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.

We do not always accept features.
See https://detectron2.readthedocs.io/notes/contributing.html#pull-requests about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.

