### PR TITLE
Add torch._check hints for torch.export

### DIFF
--- a/detectron2/structures/image_list.py
+++ b/detectron2/structures/image_list.py
@@ -111,7 +111,12 @@ class ImageList:
             # This seems slightly (2%) faster.
             # TODO: check whether it's faster for multiple images as well
             image_size = image_sizes[0]
-            padding_size = [0, max_size[-1] - image_size[1], 0, max_size[-2] - image_size[0]]
+            u0 = (max_size[-1] - image_size[1]).item()
+            u1 = (max_size[-2] - image_size[0]).item()
+            padding_size = [0, u0, 0, u1]
+            if torch.compiler.is_compiling():
+                torch._check(u0 >= 0)
+                torch._check(u1 >= 0)
             batched_imgs = F.pad(tensors[0], padding_size, value=pad_value).unsqueeze_(0)
         else:
             # max_size can be a tensor in tracing mode, therefore convert to list


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/detectron2/issues/5347

This allows for torch.export.export `ImageList.from_tensors`. 

cc @angelayi @pianpwk

