### PR TITLE
fix: add pyproject.toml to declare torch as build dependency for `uv` build isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This resolves a build failure when installing `detectron2` with PEP 517-compliant tools such as [`uv`](https://github.com/astral-sh/uv) or modern versions of `pip`.

When using build isolation (the default for these tools), installation fails with the following error:

    ModuleNotFoundError: No module named 'torch'


This is because `setup.py` imports `torch`, but `torch` is not declared as a build requirement. As a result, it is not available in the isolated build environment.

This MR adds a `pyproject.toml` declaring `torch` under `[build-system].requires`, ensuring it is installed prior to running `setup.py`.

While installing `torch` manually before installing `detectron2` is a workaround, that approach breaks standard installation flows (e.g., `uv pip install detectron2` or `uv pip install -e .`) — especially in CI or production packaging pipelines.

Related upstream issue: https://github.com/facebookresearch/detectron2/issues/5117
