### PR TITLE
Cast `boxes` to double when `scores.dtype == torch.float64`

### DIFF
--- a/detectron2/layers/nms.py
+++ b/detectron2/layers/nms.py
@@ -19,7 +19,11 @@ def batched_nms(
     # to decide whether to use coordinate trick or for loop to implement batched_nms. So we
     # just call it directly.
     # Fp16 does not have enough range for batched NMS, so adding float().
-    return box_ops.batched_nms(boxes.float(), scores, idxs, iou_threshold)
+    if scores.dtype == torch.float64:
+        res = box_ops.batched_nms(boxes.double(), scores, idxs, iou_threshold)
+    else:
+        res = box_ops.batched_nms(boxes.float(), scores, idxs, iou_threshold)
+    return res
 
 
 # Note: this function (nms_rotated) might be moved into


### PR DESCRIPTION
To avoid: `RuntimeError: dets should have the same type as scores`.

<details>
<summary> Stacktrace: </summary>

```bash
 File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/benchmarks/dynamo/common.py", line 2126, in check_accuracy
    breakpoint()
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/benchmarks/dynamo/common.py", line 1942, in run_n_iterations
    model_iter_fn(mod, inputs, collect_outputs=False)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/benchmarks/dynamo/torchbench.py", line 460, in forward_pass
    return mod(*inputs)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/nn/modules/module.py", line 1785, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/modeling/meta_arch/rcnn.py", line 150, in forward
    return self.inference(batched_inputs)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/modeling/meta_arch/rcnn.py", line 209, in inference
    proposals, _ = self.proposal_generator(images, features, None)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/nn/modules/module.py", line 1785, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/modeling/proposal_generator/rpn.py", line 477, in forward
    proposals = self.predict_proposals(
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/modeling/proposal_generator/rpn.py", line 503, in predict_proposals
    return find_top_rpn_proposals(
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/modeling/proposal_generator/proposal_utils.py", line 121, in find_top_rpn_proposals
    keep = batched_nms(boxes.tensor, scores_per_img, lvl, nms_thresh)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/detectron2/layers/nms.py", line 22, in batched_nms
    return box_ops.batched_nms(boxes.float(), scores, idxs, iou_threshold)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/torchvision/ops/boxes.py", line 81, in batched_nms
    return _batched_nms_vanilla(boxes, scores, idxs, iou_threshold)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/jit/_trace.py", line 1347, in wrapper
    return fn(*args, **kwargs)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/torchvision/ops/boxes.py", line 117, in _batched_nms_vanilla
    curr_keep_indices = nms(boxes[curr_indices], scores[curr_indices], iou_threshold)
  File "/home/jovyan/.conda/envs/xpu/lib/python3.10/site-packages/torchvision/ops/boxes.py", line 48, in nms
    return torch.ops.torchvision.nms(boxes, scores, iou_threshold)
  File "/home/jovyan/intel-xpu-backend-for-triton/.scripts_cache/pytorch/torch/_ops.py", line 1244, in __call__
    return self._op(*args, **kwargs)
RuntimeError: dets should have the same type as scores
```

</details>

Before submitting a PR, please run `dev/linter.sh` to lint the code.

