### PR TITLE
Small fix about refcycle

### DIFF
--- a/detectron2/config/lazy.py
+++ b/detectron2/config/lazy.py
@@ -429,7 +429,10 @@ class LazyConfig:
             else:
                 return repr(obj)
 
-        py_str = _to_str(cfg, prefix=[prefix])
+        try:
+            py_str = _to_str(cfg, prefix=[prefix])
+        finally:
+            _to_str = None  # Avoid ref cycle
         try:
             return black.format_str(py_str, mode=black.Mode())
         except black.InvalidInput:

--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -130,9 +130,6 @@ class TrainerBase:
         for h in hooks:
             assert isinstance(h, HookBase)
             # To avoid circular reference, hooks and trainer cannot own each other.
-            # This normally does not matter, but will cause memory leak if the
-            # involved objects contain __del__:
-            # See http://engineering.hearsaysocial.com/2013/06/16/circular-references-in-python/
             h.trainer = weakref.proxy(self)
         self._hooks.extend(hooks)
 


### PR DESCRIPTION
The comment about `__del__` applies to Python 2 and is no longer relevant.