### PR TITLE
Fix AMP autocast deprecation warning for PyTorch>=2.5

### DIFF
--- a/detectron2/engine/train_loop.py
+++ b/detectron2/engine/train_loop.py
@@ -479,7 +479,7 @@ class AMPTrainer(SimpleTrainer):
         """
         assert self.model.training, "[AMPTrainer] model was changed to eval mode!"
         assert torch.cuda.is_available(), "[AMPTrainer] CUDA is required for AMP training!"
-        from torch.cuda.amp import autocast
+        from detectron2.utils.torch_amp import autocast
 
         start = time.perf_counter()
         data = next(self._data_loader_iter)

--- a/detectron2/utils/torch_amp.py
+++ b/detectron2/utils/torch_amp.py
@@ -1,0 +1,8 @@
+try:
+    from torch.amp import autocast as _autocast
+
+    def autocast(dtype=None):
+        return _autocast("cuda", dtype=dtype)
+
+except ImportError:
+    from torch.cuda.amp import autocast  # torch < 2.0


### PR DESCRIPTION
## Summary
Fixes FutureWarning raised by PyTorch>=2.5 when using torch.cuda.amp.autocast,
while preserving backward compatibility with older PyTorch versions.

## Changes
- Adds a backward-compatible autocast helper
- Replaces direct imports of torch.cuda.amp.autocast
- No behavior change intended

## Compatibility
- No API changes
- No new dependencies

## Motivation
PyTorch deprecated torch.cuda.amp.autocast in favor of torch.amp.autocast("cuda").
This PR removes warning spam without breaking older installations.