### PR TITLE
Fix mask visualization to exclude holes from polygon drawing

### DIFF
--- a/detectron2/utils/visualizer.py
+++ b/detectron2/utils/visualizer.py
@@ -126,9 +126,12 @@ class GenericMask:
         hierarchy = res[-1]
         if hierarchy is None:  # empty mask
             return [], False
-        has_holes = (hierarchy.reshape(-1, 4)[:, 3] >= 0).sum() > 0
-        res = res[-2]
-        res = [x.flatten() for x in res]
+        hierarchy = hierarchy.reshape(-1, 4)
+        has_holes = (hierarchy[:, 3] >= 0).sum() > 0
+        contours = res[-2]
+        # Filter out hole contours (those with a parent, i.e., hierarchy[i][3] >= 0)
+        # Only keep external contours (hierarchy[i][3] == -1)
+        res = [contours[i].flatten() for i in range(len(contours)) if hierarchy[i][3] < 0]
         # These coordinates from OpenCV are integers in range [0, W-1 or H-1].
         # We add 0.5 to turn them into real-value coordinate space. A better solution
         # would be to first +0.5 and then dilate the returned polygon by 0.5.


### PR DESCRIPTION
## Summary

Fixes #1771

When drawing segmentation masks with holes, the `GenericMask.mask_to_polygons()` method was returning all contours including internal hole contours. When these polygons were drawn, the holes were incorrectly filled in.

## Problem

As reported in #1771:
1. Model predicts segmentation masks with holes (donut shapes, etc.)
2. `Visualizer.draw_instance_predictions()` creates `GenericMask` and calls `overlay_instances`
3. `mask_to_polygons` uses `cv2.findContours` with `cv2.RETR_CCOMP` which returns both external and internal (hole) contours
4. All contours are returned as polygons without filtering
5. When drawing, hole contours are drawn as filled polygons, incorrectly filling in the holes

**Before fix:**
![Holes incorrectly filled](https://user-images.githubusercontent.com/39639112/87484757-08067b00-c605-11ea-96f7-47413a7dd845.png)

## Solution

Filter out hole contours by checking the hierarchy returned from `cv2.findContours`. With `cv2.RETR_CCOMP`:
- External contours have `hierarchy[i][3] == -1` (no parent)
- Hole contours have `hierarchy[i][3] >= 0` (have a parent)

Now only external contours (boundaries) are returned as polygons, while holes are correctly left empty.

## Changes

Modified `GenericMask.mask_to_polygons()` to filter contours based on hierarchy:
```python
# Filter out hole contours (those with a parent, i.e., hierarchy[i][3] >= 0)
# Only keep external contours (hierarchy[i][3] == -1)
res = [contours[i].flatten() for i in range(len(contours)) if hierarchy[i][3] < 0]
```

## Test plan

```python
import numpy as np
from detectron2.utils.visualizer import GenericMask

# Create a mask with a hole (donut shape)
mask = np.zeros((100, 100), dtype=np.uint8)
mask[20:80, 20:80] = 1  # outer square
mask[35:65, 35:65] = 0  # inner hole

gm = GenericMask(mask, 100, 100)
print(f"Has holes: {gm.has_holes}")  # Should be True
print(f"Number of polygons: {len(gm.polygons)}")  # Should be 1 (only outer boundary)
```