### PR TITLE
Replace deprecated logger.warn() with logger.warning()

### DIFF
--- a/detectron2/data/datasets/coco.py
+++ b/detectron2/data/datasets/coco.py
@@ -280,7 +280,7 @@ def load_sem_seg(gt_root, image_root, gt_ext="png", image_ext="jpg"):
 
     # Use the intersection, so that val2017_100 annotations can run smoothly with val2017 images
     if len(input_files) != len(gt_files):
-        logger.warn(
+        logger.warning(
             "Directory {} and {} has {} and {} files, respectively.".format(
                 image_root, gt_root, len(input_files), len(gt_files)
             )
@@ -290,7 +290,7 @@ def load_sem_seg(gt_root, image_root, gt_ext="png", image_ext="jpg"):
         intersect = list(set(input_basenames) & set(gt_basenames))
         # sort, otherwise each worker may obtain a list[dict] in different order
         intersect = sorted(intersect)
-        logger.warn("Will use their intersection of {} files.".format(len(intersect)))
+        logger.warning("Will use their intersection of {} files.".format(len(intersect)))
         input_files = [os.path.join(image_root, f + image_ext) for f in intersect]
         gt_files = [os.path.join(gt_root, f + gt_ext) for f in intersect]
 

--- a/detectron2/engine/defaults.py
+++ b/detectron2/engine/defaults.py
@@ -644,7 +644,7 @@ Alternatively, you can call evaluation functions yourself (see Colab balloon tut
                 try:
                     evaluator = cls.build_evaluator(cfg, dataset_name)
                 except NotImplementedError:
-                    logger.warn(
+                    logger.warning(
                         "No evaluator found. Use `DefaultTrainer.test(evaluators=)`, "
                         "or implement its `build_evaluator` method."
                     )

--- a/detectron2/evaluation/coco_evaluation.py
+++ b/detectron2/evaluation/coco_evaluation.py
@@ -118,7 +118,7 @@ class COCOEvaluator(DatasetEvaluator):
             kpt_oks_sigmas = (
                 tasks.TEST.KEYPOINT_OKS_SIGMAS if not kpt_oks_sigmas else kpt_oks_sigmas
             )
-            self._logger.warn(
+            self._logger.warning(
                 "COCO Evaluator instantiated using config, this is deprecated behavior."
                 " Please pass in explicit arguments instead."
             )
@@ -341,7 +341,7 @@ class COCOEvaluator(DatasetEvaluator):
         }[iou_type]
 
         if coco_eval is None:
-            self._logger.warn("No predictions from the model!")
+            self._logger.warning("No predictions from the model!")
             return {metric: float("nan") for metric in metrics}
 
         # the standard metrics

--- a/detectron2/evaluation/lvis_evaluation.py
+++ b/detectron2/evaluation/lvis_evaluation.py
@@ -53,7 +53,7 @@ class LVISEvaluator(DatasetEvaluator):
         self._logger = logging.getLogger(__name__)
 
         if tasks is not None and isinstance(tasks, CfgNode):
-            self._logger.warn(
+            self._logger.warning(
                 "COCO Evaluator instantiated using config, this is deprecated behavior."
                 " Please pass in explicit arguments instead."
             )
@@ -350,7 +350,7 @@ def _evaluate_predictions_on_lvis(
     logger = logging.getLogger(__name__)
 
     if len(lvis_results) == 0:  # TODO: check if needed
-        logger.warn("No predictions from the model!")
+        logger.warning("No predictions from the model!")
         return {metric: float("nan") for metric in metrics}
 
     if iou_type == "segm":

--- a/detectron2/evaluation/sem_seg_evaluation.py
+++ b/detectron2/evaluation/sem_seg_evaluation.py
@@ -60,11 +60,11 @@ class SemSegEvaluator(DatasetEvaluator):
         """
         self._logger = logging.getLogger(__name__)
         if num_classes is not None:
-            self._logger.warn(
+            self._logger.warning(
                 "SemSegEvaluator(num_classes) is deprecated! It should be obtained from metadata."
             )
         if ignore_label is not None:
-            self._logger.warn(
+            self._logger.warning(
                 "SemSegEvaluator(ignore_label) is deprecated! It should be obtained from metadata."
             )
         self._dataset_name = dataset_name
@@ -96,13 +96,13 @@ class SemSegEvaluator(DatasetEvaluator):
         self._compute_boundary_iou = True
         if not _CV2_IMPORTED:
             self._compute_boundary_iou = False
-            self._logger.warn(
+            self._logger.warning(
                 """Boundary IoU calculation requires OpenCV. B-IoU metrics are
                 not going to be computed because OpenCV is not available to import."""
             )
         if self._num_classes >= np.iinfo(np.uint8).max:
             self._compute_boundary_iou = False
-            self._logger.warn(
+            self._logger.warning(
                 f"""SemSegEvaluator(num_classes) is more than supported value for Boundary IoU
                 calculation! B-IoU metrics are not going to be computed. Max allowed value
                 (exclusive) for num_classes for calculating Boundary IoU is.


### PR DESCRIPTION
## Summary

- Replace all 11 occurrences of the deprecated `logging.Logger.warn()` method with `logging.Logger.warning()` across 5 files in the detectron2 package.
- `Logger.warn()` has been deprecated since Python 3.2 and is pending removal. It currently emits `DeprecationWarning` in recent Python versions.
- `warnings.warn()` calls (from the `warnings` module) are intentionally left unchanged, as they are not deprecated.

### Files changed

| File | Occurrences fixed |
|------|:-:|
| `detectron2/evaluation/sem_seg_evaluation.py` | 4 |
| `detectron2/evaluation/coco_evaluation.py` | 2 |
| `detectron2/evaluation/lvis_evaluation.py` | 2 |
| `detectron2/data/datasets/coco.py` | 2 |
| `detectron2/engine/defaults.py` | 1 |

## Test plan

- [x] Verified no remaining `logger.warn()` calls in the codebase
- [x] Confirmed `warnings.warn()` (stdlib) calls are unaffected
- [ ] All existing tests should pass as `warning()` is the standard method with identical behavior