### PR TITLE
docs(resnet): fix 'compatibiltiy' -> 'compatibility' in backward-compat docstrings

### DIFF
--- a/detectron2/modeling/backbone/resnet.py
+++ b/detectron2/modeling/backbone/resnet.py
@@ -599,13 +599,13 @@ class ResNet(Backbone):
 
 ResNetBlockBase = CNNBlockBase
 """
-Alias for backward compatibiltiy.
+Alias for backward compatibility.
 """
 
 
 def make_stage(*args, **kwargs):
     """
-    Deprecated alias for backward compatibiltiy.
+    Deprecated alias for backward compatibility.
     """
     return ResNet.make_stage(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

Two occurrences of \`compatibiltiy\` -> \`compatibility\` in \`detectron2/modeling/backbone/resnet.py\`:

\`\`\`python
# line 602
Alias for backward compatibility.

# line 608
Deprecated alias for backward compatibility.
\`\`\`

## Testing

Docstring-only change; no runtime code touched.